### PR TITLE
Bugfix in Vex.Flow.keyProperties function

### DIFF
--- a/src/tables.js
+++ b/src/tables.js
@@ -32,8 +32,7 @@ Vex.Flow.keyProperties = function(key) {
   if (line >= 6 && (((line * 2) % 2) == 0)) stroke = -1; // stroke down
 
   // Integer value for note arithmetic.
-  var int_value = null;
-  if (value.int_val) int_value = (o * 12) + value.int_val;
+  var int_value = (typeof(value.int_val)!='undefined') ? (o * 12) + value.int_val : null;
 
   return {
     line: line,


### PR DESCRIPTION
C note has a int_value of 0, the conditional was getting FALSE since zero==false, resulting in null value for the C note/
