### PR TITLE
Voice tick counting bug

### DIFF
--- a/src/voice.js
+++ b/src/voice.js
@@ -72,19 +72,22 @@ Vex.Flow.Voice.prototype.getTickables = function() {
 
 Vex.Flow.Voice.prototype.addTickable = function(tickable) {
   var time = this.time;
-  var numTicks = tickable.getTicks();
 
-  // Update the total ticks for this line
-  this.ticksUsed += numTicks;
+  if (!tickable.shouldIgnoreTicks()) {
+    var numTicks = tickable.getTicks();
 
-  if (this.strict && this.ticksUsed > this.totalTicks) {
-    this.totalTicks -= numTicks;
-    throw new Vex.RERR("BadArgument", "Too many ticks.");
+    // Update the total ticks for this line
+    this.ticksUsed += numTicks;
+
+    if (this.strict && this.ticksUsed > this.totalTicks) {
+      this.totalTicks -= numTicks;
+      throw new Vex.RERR("BadArgument", "Too many ticks.");
+    }
+
+    // Track the smallest tickable for formatting
+    if (numTicks < this.smallestTickCount)
+      this.smallestTickCount = numTicks;
   }
-
-  // Track the smallest tickable for formatting
-  if (numTicks < this.smallestTickCount)
-    this.smallestTickCount = numTicks;
 
   /* Can't do this without formatting modifier context
 

--- a/tests/voice_tests.js
+++ b/tests/voice_tests.js
@@ -8,6 +8,7 @@ Vex.Flow.Test.Voice = {}
 Vex.Flow.Test.Voice.Start = function() {
   module("Voice");
   test("Basic Test", Vex.Flow.Test.Voice.basic);
+  test("Ignore Test", Vex.Flow.Test.Voice.ignore);
 }
 
 Vex.Flow.Test.Voice.basic = function(options) {
@@ -41,4 +42,26 @@ Vex.Flow.Test.Voice.basic = function(options) {
   }
 
   equals(voice.getSmallestTickCount(), BEAT, "Smallest tick count is BEAT");
+}
+
+Vex.Flow.Test.Voice.ignore = function(options) {
+  function createTickable() {
+    return new Vex.Flow.Test.MockTickable(Vex.Flow.Test.TIME4_4);
+  }
+
+  var R = Vex.Flow.RESOLUTION;
+  var BEAT = 1 * R / 4;
+
+  var tickables = [
+    createTickable().setTicks(BEAT),
+    createTickable().setTicks(BEAT),
+    createTickable().setTicks(BEAT).setIgnoreTicks(true),
+    createTickable().setTicks(BEAT),
+    createTickable().setTicks(BEAT).setIgnoreTicks(true),
+    createTickable().setTicks(BEAT)
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4);
+  voice.addTickables(tickables);
+  ok(true, "all pass");
 }


### PR DESCRIPTION
I noticed a bug in how the voice class was counting ticks (it kept counting my barlines and threw off the time signatures).  Here's the quick fix, and a test as well.
