### PR TITLE
Modified Formatter That Formats Multiple Staves

### DIFF
--- a/src/accidental.js
+++ b/src/accidental.js
@@ -33,12 +33,15 @@ Vex.Flow.Accidental.prototype.init = function(type) {
 }
 
 Vex.Flow.Accidental.prototype.getCategory = function() { return "accidentals"; }
+
+/* Redundant functions defined in modifier.js
 Vex.Flow.Accidental.prototype.getNote = function() { return this.note; }
 Vex.Flow.Accidental.prototype.setNote = function(note)
   { this.note = note; return this; }
 Vex.Flow.Accidental.prototype.getIndex = function() { return this.index; }
 Vex.Flow.Accidental.prototype.setIndex = function(index) {
   this.index = index; return this; }
+*/
 
 Vex.Flow.Accidental.prototype.draw = function() {
   if (!this.context) throw new Vex.RERR("NoContext",

--- a/src/articulation.js
+++ b/src/articulation.js
@@ -1,0 +1,70 @@
+// VexFlow - Music Engraving for HTML5
+// Copyright Mohit Muthanna 2010
+// Author Larry Kuhns 2011
+// This class implements Accents.
+
+/**
+ * @constructor
+ */
+Vex.Flow.Articulation = function(type) {
+  if (arguments.length > 0) this.init(type);
+}
+Vex.Flow.Articulation.prototype = new Vex.Flow.Modifier();
+Vex.Flow.Articulation.prototype.constructor = Vex.Flow.Articulation;
+Vex.Flow.Articulation.superclass = Vex.Flow.Modifier.prototype;
+
+Vex.Flow.Articulation.prototype.init = function(type) {
+  var superclass = Vex.Flow.Articulation.superclass;
+  superclass.init.call(this);
+
+  this.note = null;
+  this.index = null;
+  this.type = type;
+  this.position = Vex.Flow.Modifier.Position.BELOW;
+
+  this.render_options = {
+    font_scale: 38,
+    stroke_px: 3,
+    stroke_spacing: 10
+  };
+
+  this.articulation = Vex.Flow.articulationCodes(this.type);
+  this.setWidth(this.articulation.width);
+}
+
+Vex.Flow.Articulation.prototype.getCategory = function() { return "articulations"; }
+Vex.Flow.Articulation.prototype.getPosition = function() {return this.position; }
+Vex.Flow.Articulation.prototype.setPosition = function(position) {
+  if (position == Vex.Flow.Modifier.Position.ABOVE ||
+      position == Vex.Flow.Modifier.Position.BELOW)
+    this.position = position;
+  return this;
+}
+
+Vex.Flow.Articulation.prototype.draw = function() {
+  if (!this.context) throw new Vex.RERR("NoContext",
+    "Can't draw Articulation without a context.");
+  if (!(this.note && (this.index != null))) throw new Vex.RERR("NoAttachedNote",
+    "Can't draw Articulation without a note and index.");
+  // Articulations are centered over/under the note head
+
+  var stave = this.note.stave;
+  var start = this.note.getModifierStartXY(this.position, this.index);
+  var glyph_y = start.y;
+  var stem_ext = this.note.getStemExtents();
+  if (this.position == Vex.Flow.Modifier.Position.ABOVE) {
+    var shiftY = this.articulation.shift_up - 10;
+    glyph_y = Vex.Min(glyph_y, stem_ext.topY);
+    glyph_y = Vex.Min(glyph_y, this.note.stave.getYForLine(1) - 10);
+  } else {
+    var shiftY = this.articulation.shift_down + 10;
+    glyph_y = Vex.Max(glyph_y, stem_ext.topY);
+    glyph_y = Vex.Max(glyph_y,
+                      stave.getYForLine(stave.options.num_lines - 1));
+  }
+  var glyph_x = (start.x) + this.articulation.shift_right;
+  glyph_y += shiftY + this.y_shift;
+
+ Vex.Flow.renderGlyph(this.context, glyph_x, glyph_y,
+                       this.render_options.font_scale, this.articulation.code);
+}

--- a/src/beam.js
+++ b/src/beam.js
@@ -146,6 +146,12 @@ Vex.Flow.Beam.prototype.draw = function(notes) {
     var y_extents = note.getStemExtents();
     var base_y_px = y_extents.baseY;
 
+    // For harmonic note heads, shorten stem length by 3 pixels
+    if (note.glyph.code_head == "v92" ||
+        note.glyph.code_head == "v95" ||
+        note.glyph.code_head == "v3e")
+      base_y_px -= this.stem_direction * 3;
+
     // Draw the stem
     this.context.fillRect(x_px, base_y_px, 1,
         ((Math.abs(base_y_px - (getSlopeY(x_px) + y_shift)))) *

--- a/src/bend.js
+++ b/src/bend.js
@@ -34,10 +34,16 @@ Vex.Flow.Bend.prototype.init = function(text, release) {
 Vex.Flow.Bend.prototype.getCategory = function() { return "bends"; }
 Vex.Flow.Bend.prototype.getText = function() { return this.text; }
 Vex.Flow.Bend.prototype.updateWidth = function() {
+  var text_width = Vex.Flow.textWidth(this.text);
+  if (this.context) {
+    text_width = this.context.measureText(this.text).width;
+  }
+
+  var text_width
   this.setWidth(
       this.bend_width +
       this.release_width +
-      (Vex.Flow.textWidth(this.text) / 2));
+      text_width / 2);
 }
 Vex.Flow.Bend.prototype.setBendWidth = function(width) {
   this.bend_width = width; this.updateWidth();
@@ -57,7 +63,7 @@ Vex.Flow.Bend.prototype.draw = function() {
 
   var start = this.note.getModifierStartXY(Vex.Flow.Modifier.Position.RIGHT,
       this.index);
-  start.x += 1;
+  start.x += 3;
 
   var ctx = this.context;
   var that = this;

--- a/src/dot.js
+++ b/src/dot.js
@@ -26,12 +26,14 @@ Vex.Flow.Dot.prototype.init = function() {
 }
 
 Vex.Flow.Dot.prototype.getCategory = function() { return "dots"; }
+/*  Redundant functions defined in modifier.js
 Vex.Flow.Dot.prototype.getNote = function() { return this.note; }
 Vex.Flow.Dot.prototype.setNote = function(note)
   { this.note = note; return this; }
 Vex.Flow.Dot.prototype.getIndex = function() { return this.index; }
 Vex.Flow.Dot.prototype.setIndex = function(index) {
   this.index = index; return this; }
+*/
 
 Vex.Flow.Dot.prototype.draw = function() {
   if (!this.context) throw new Vex.RERR("NoContext",

--- a/src/modifier.js
+++ b/src/modifier.js
@@ -1,7 +1,7 @@
 // VexFlow - Music Engraving for HTML5
 // Copyright Mohit Muthanna 2010
 //
-// This class implements varies types of modifiers to notes (e.g. bends, 
+// This class implements varies types of modifiers to notes (e.g. bends,
 // fingering positions etc.) Accidentals should also be implemented as
 // modifiers, eventually.
 
@@ -51,6 +51,9 @@ Vex.Flow.Modifier.prototype.setModifierContext = function(c) {
   this.modifier_context = c; return this; }
 Vex.Flow.Modifier.prototype.setTextLine = function(line)
   { this.text_line = line; return this; }
+// Shift y pixels in vertical direction
+Vex.Flow.Modifier.prototype.setYShift = function(y)
+  { this.y_shift = y; return this; }
 
 // Shift x pixels in the direction of the modifier
 Vex.Flow.Modifier.prototype.setXShift = function(x) {

--- a/src/stave.js
+++ b/src/stave.js
@@ -13,7 +13,7 @@ Vex.Flow.Stave.prototype.init = function(x, y, width, options) {
   this.y = y;
   this.width = width;
   this.glyph_start_x = x + 5;
-  this.start_x = this.glyph_start_x + 5;
+  this.start_x = this.glyph_start_x;
   this.context = null;
   this.glyphs = [];
   this.modifiers = [];  // non-glyph stave items (barlines, coda, segno, etc.)
@@ -42,13 +42,19 @@ Vex.Flow.Stave.prototype.init = function(x, y, width, options) {
       new Vex.Flow.Barline(Vex.Flow.Barline.type.SINGLE, this.x)); // beg bar
   this.modifiers.push(
       new Vex.Flow.Barline(Vex.Flow.Barline.type.SINGLE,
-                           this.x + this.width)); // end bar
+      this.x + this.width)); // end bar
 }
 
 Vex.Flow.Stave.prototype.setNoteStartX = function(x) {
   this.start_x = x; return this; }
 Vex.Flow.Stave.prototype.getNoteStartX = function() {
-  return this.start_x; }
+  var start_x = this.start_x;
+
+  // Add additional space if left barline is REPEAT_BEGIN
+  if (this.modifiers[0].barline == Vex.Flow.Barline.type.REPEAT_BEGIN)
+    start_x += 10;
+  return start_x;
+}
 Vex.Flow.Stave.prototype.getNoteEndX = function() {
   return this.x + this.width; }
 Vex.Flow.Stave.prototype.getTieStartX = function() {
@@ -76,11 +82,12 @@ Vex.Flow.Stave.prototype.setMeasure = function(measure) {
   this.measure = measure; return this;
 }
 
-// Bar Line functions
+  // Bar Line functions
 Vex.Flow.Stave.prototype.setBegBarType = function(type) {
-  // Only valid bar types at beginning of stave is single or begin repeat
+  // Only valid bar types at beginning of stave is none, single or begin repeat
   if (type == Vex.Flow.Barline.type.SINGLE ||
-      type == Vex.Flow.Barline.type.REPEAT_BEGIN) {
+      type == Vex.Flow.Barline.type.REPEAT_BEGIN ||
+      type == Vex.Flow.Barline.type.NONE) {
       this.modifiers[0] = new Vex.Flow.Barline(type, this.x);
   }
   return this;
@@ -202,7 +209,6 @@ Vex.Flow.Stave.prototype.draw = function(context) {
   var width = this.width;
   var x = this.x;
 
-  this.drawVertical(0, false);
   for (var line=0; line < num_lines; line++) {
 
     var y = this.getYForLine(line);

--- a/src/stavebarline.js
+++ b/src/stavebarline.js
@@ -16,7 +16,8 @@ Vex.Flow.Barline.type = {
   DOUBLE: 2,
   END: 3,
   REPEAT_BEGIN: 4,
-  REPEAT_END: 5
+  REPEAT_END: 5,
+  NONE: 6
 };
 
 Vex.Flow.Barline.prototype = new Vex.Flow.StaveModifier();
@@ -48,12 +49,16 @@ Vex.Flow.Barline.prototype.draw = function(stave, x) {
       this.drawVerticalEndBar(stave, this.x);
       break;
     case Vex.Flow.Barline.type.REPEAT_BEGIN:
+      // If repeat begin is not at start of stave, draw single barline
+      if (x > 0)
+        this.drawVerticalBar(stave, this.x, false);
       this.drawRepeatBar(stave, this.x + x, true);
       break;
     case Vex.Flow.Barline.type.REPEAT_END:
       this.drawRepeatBar(stave, this.x, false);
       break;
     default:
+      // Default is NONE, so nothing to draw
       break;
   }
 }

--- a/src/staveconnector.js
+++ b/src/staveconnector.js
@@ -8,11 +8,17 @@
 /** @constructor */
 Vex.Flow.StaveConnector = function(top_stave, bottom_stave) {
   this.init(top_stave, bottom_stave); }
-
+  Vex.Flow.StaveConnector.type = {
+  SINGLE: 1,
+  DOUBLE: 2,
+  BRACE: 3,
+  BRACKET: 4
+};
 Vex.Flow.StaveConnector.prototype.init = function(top_stave, bottom_stave) {
   this.width = 3;
   this.top_stave = top_stave;
   this.bottom_stave = bottom_stave;
+  this.type = Vex.Flow.StaveConnector.type.DOUBLE;
 }
 
 Vex.Flow.StaveConnector.prototype.setContext = function(ctx) {
@@ -20,13 +26,73 @@ Vex.Flow.StaveConnector.prototype.setContext = function(ctx) {
   return this;
 }
 
+Vex.Flow.StaveConnector.prototype.setType = function(type) {
+  if (type >= Vex.Flow.StaveConnector.type.SINGLE &&
+      type <= Vex.Flow.StaveConnector.type.BRACKET)
+    this.type = type;
+  return this;
+}
+
 Vex.Flow.StaveConnector.prototype.draw = function() {
   if (!this.ctx) throw new Vex.RERR(
       "NoContext", "Can't draw without a context.");
-  var attachment_height =
-    (this.bottom_stave.getYForLine(this.bottom_stave.getNumLines() - 1) -
-    this.top_stave.getYForLine(0)) + 1;
-  this.ctx.fillRect(
-    this.top_stave.getX() - (this.width + 2), this.top_stave.getYForLine(0),
-    this.width, attachment_height);
+  var topY = this.top_stave.getYForLine(0);
+  var botY = this.bottom_stave.getYForLine(this.bottom_stave.getNumLines() - 1);
+  var width = this.width;
+  var topX = this.top_stave.getX();
+  var attachment_height = botY - topY;
+  switch (this.type) {
+    case Vex.Flow.StaveConnector.type.SINGLE:
+      width = 1;
+      break;
+    case Vex.Flow.StaveConnector.type.DOUBLE:
+      topX -= (this.width + 2);
+      break;
+    case Vex.Flow.StaveConnector.type.BRACE:
+      width = 12;
+      // May need additional code to draw brace
+      var x1 = this.top_stave.getX() - 2;
+      var y1 = topY;
+      var x3 = x1;
+      var y3 = botY;
+      var x2 = x1 - width;
+      var y2 = y1 + attachment_height/2.0;
+      var cpx1 = x2 - (0.90 * width);
+      var cpy1 = y1 + (0.2 * attachment_height);
+      var cpx2 = x1 + (1.10 * width);
+      var cpy2 = y2 - (0.135 * attachment_height);
+      var cpx3 = cpx2;
+      var cpy3 = y2 + (0.135 * attachment_height);
+      var cpx4 = cpx1;
+      var cpy4 = y3 - (0.2 * attachment_height);
+      var cpx5 = x2 - width;
+      var cpy5 = cpy4;
+      var cpx6 = x1 + (0.40 * width);
+      var cpy6 = y2 + (0.135 * attachment_height);
+      var cpx7 = cpx6;
+      var cpy7 = y2 - (0.135 * attachment_height);
+      var cpx8 = cpx5;
+      var cpy8 = cpy1;
+      this.ctx.beginPath();
+      this.ctx.moveTo(x1, y1);
+      this.ctx.bezierCurveTo(cpx1, cpy1, cpx2, cpy2, x2, y2);
+      this.ctx.bezierCurveTo(cpx3, cpy3, cpx4, cpy4, x3, y3);
+      this.ctx.bezierCurveTo(cpx5, cpy5, cpx6, cpy6, x2, y2);
+      this.ctx.bezierCurveTo(cpx7, cpy7, cpx8, cpy8, x1, y1);
+      this.ctx.fill();
+      this.ctx.stroke();
+      break;
+    case Vex.Flow.StaveConnector.type.BRACKET:
+      topY -= 4;
+      botY += 4;
+      attachment_height = botY - topY;
+      Vex.Flow.renderGlyph(this.ctx, topX - 5, topY - 3, 40, "v1b", true);
+      Vex.Flow.renderGlyph(this.ctx, topX - 5, botY + 3, 40, "v10", true);
+      topX -= (this.width + 2);
+      break;
+  }
+  
+  if (this.type != Vex.Flow.StaveConnector.type.BRACE) {
+    this.ctx.fillRect(topX , topY, width, attachment_height);
+  }
 }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -72,6 +72,9 @@ Vex.Flow.StaveNote.prototype.init = function(note_struct) {
     this.keyProps.push(props);
   }
 
+  // Sort the notes from lowest line to highest line
+  this.keyProps.sort(function(a, b) {return a.line - b.line});
+
   // Drawing
   this.modifiers = [];
 
@@ -166,7 +169,6 @@ Vex.Flow.StaveNote.prototype.getTieRightX = function() {
 Vex.Flow.StaveNote.prototype.getTieLeftX = function() {
   var tieEndX = this.getAbsoluteX();
   tieEndX += this.x_shift - this.extraLeftPx;
-  // if (this.modifierContext) tieEndX -= this.modifierContext.getExtraLeftPx();
   return tieEndX;
 }
 
@@ -218,7 +220,7 @@ Vex.Flow.StaveNote.prototype.addToModifierContext = function(mc) {
   this.setPreFormatted(false);
 }
 
-// Generic functions to add modifiers to a note
+// Generic function to add modifiers to a note
 Vex.Flow.StaveNote.prototype.addModifier = function(index, modifier) {
   modifier.setNote(this);
   modifier.setIndex(index);
@@ -235,14 +237,14 @@ Vex.Flow.StaveNote.prototype.addAccidental = function(index, accidental) {
   return this;
 }
 
-Vex.Flow.StaveNote.prototype.addStroke = function(index, stroke) {
-  stroke.setNote(this);
-  stroke.setIndex(index);
-  this.modifiers.push(stroke);
-  this.setPreFormatted(false);
-  return this;
-}
-
+//Vex.Flow.StaveNote.prototype.addStroke = function(index, stroke) {
+//  stroke.setNote(this);
+//  stroke.setIndex(index);
+//  this.modifiers.push(stroke);
+//  this.setPreFormatted(false);
+//  return this;
+//}
+//
 Vex.Flow.StaveNote.prototype.addArticulation = function(index, articulation) {
   articulation.setNote(this);
   articulation.setIndex(index);
@@ -305,7 +307,14 @@ Vex.Flow.StaveNote.prototype.preFormat = function() {
   if (this.preFormatted) return;
   if (this.modifierContext) this.modifierContext.preFormat();
 
-  this.setWidth(this.glyph.head_width + this.extraLeftPx + this.extraRightPx);
+  var width = this.glyph.head_width + this.extraLeftPx + this.extraRightPx;
+
+  // For upward flagged notes, the width of the flag needs to be added
+  if (this.glyph.flag && this.beam == null && this.stem_direction == 1) {
+    width += this.glyph.head_width;
+  }
+
+  this.setWidth(width);
 
   this.setPreFormatted(true);
 }
@@ -426,7 +435,7 @@ Vex.Flow.StaveNote.prototype.draw = function() {
   // applicable to non-rests.
   if (!glyph.rest) {
     var that = this;
-    
+
     function stroke(y) {
       if (default_head_x != null) head_x = default_head_x;
       ctx.fillRect(

--- a/src/tabslide.js
+++ b/src/tabslide.js
@@ -86,8 +86,8 @@ Vex.Flow.TabSlide.prototype.renderTie = function(params) {
       throw new Vex.RERR("BadArguments", "Bad indices for slide rendering.");
 
     ctx.beginPath();
-    ctx.moveTo(first_x_px + 5, slide_y + (3 * direction));
-    ctx.lineTo(last_x_px - 5, slide_y - (3 * direction));
+    ctx.moveTo(first_x_px, slide_y + (3 * direction));
+    ctx.lineTo(last_x_px, slide_y - (3 * direction));
     ctx.closePath();
     ctx.stroke();
   }

--- a/src/tickable.js
+++ b/src/tickable.js
@@ -26,7 +26,7 @@ Vex.Flow.Tickable.prototype.init = function() {
 
 /** optional, if tickable has modifiers **/
 Vex.Flow.Tickable.prototype.addToModifierContext = function(mc) {
-  this.modifierContext = modifierContext;
+  this.modifierContext = mc;
   // Add modifiers to modifier context (if any)
   this.preFormatted = false;
 }

--- a/src/timesignature.js
+++ b/src/timesignature.js
@@ -4,11 +4,11 @@
 // representation
 //
 
-/** 
- * @constructor 
+/**
+ * @constructor
  */
-Vex.Flow.TimeSignature = function(timeSpec) { 
-  if (arguments.length > 0) this.init(timeSpec); 
+Vex.Flow.TimeSignature = function(timeSpec) {
+  if (arguments.length > 0) this.init(timeSpec);
 }
 
 
@@ -16,7 +16,7 @@ Vex.Flow.TimeSignature.glyphs = {
   "C": {
     code: "v41",
     point: 40,
-    line: 2 
+    line: 2
   },
   "C|": {
     code: "vb6",
@@ -25,7 +25,7 @@ Vex.Flow.TimeSignature.glyphs = {
   }
 }
 Vex.Flow.TimeSignature.prototype = new Vex.Flow.StaveModifier();
-Vex.Flow.TimeSignature.prototype.constructor = Vex.Flow.KeySignature;
+Vex.Flow.TimeSignature.prototype.constructor = Vex.Flow.TimeSignature;
 Vex.Flow.TimeSignature.superclass = Vex.Flow.StaveModifier.prototype;
 
 Vex.Flow.TimeSignature.prototype.init = function(timeSpec) {
@@ -41,7 +41,7 @@ Vex.Flow.TimeSignature.prototype.init = function(timeSpec) {
 Vex.Flow.TimeSignature.prototype.parseTimeSpec = function(timeSpec) {
   if (timeSpec == "C" || timeSpec == "C|") {
     var glyphInfo = Vex.Flow.TimeSignature.glyphs[timeSpec];
-    return {num: false, line: glyphInfo.line, 
+    return {num: false, line: glyphInfo.line,
       glyph: new Vex.Flow.Glyph(glyphInfo.code, glyphInfo.point)};
   }
 
@@ -51,18 +51,18 @@ Vex.Flow.TimeSignature.prototype.parseTimeSpec = function(timeSpec) {
     var c = timeSpec.charAt(i);
     if (c == "/") {
       break;
-    } 
+    }
     else if (/[0-9]/.test(c)) {
       topNums.push(c);
     }
     else {
-      throw new Vex.RERR("BadTimeSignature", 
+      throw new Vex.RERR("BadTimeSignature",
           "Invalid time spec: " + timeSpec);
     }
   }
-  
+
   if (i == 0) {
-    throw new Vex.RERR("BadTimeSignature", 
+    throw new Vex.RERR("BadTimeSignature",
           "Invalid time spec: " + timeSpec);
   }
 
@@ -70,7 +70,7 @@ Vex.Flow.TimeSignature.prototype.parseTimeSpec = function(timeSpec) {
   ++i;
 
   if (i == timeSpec.length) {
-    throw new Vex.RERR("BadTimeSignature", 
+    throw new Vex.RERR("BadTimeSignature",
           "Invalid time spec: " + timeSpec);
   }
 
@@ -82,7 +82,7 @@ Vex.Flow.TimeSignature.prototype.parseTimeSpec = function(timeSpec) {
       botNums.push(c);
     }
     else {
-      throw new Vex.RERR("BadTimeSignature", 
+      throw new Vex.RERR("BadTimeSignature",
           "Invalid time spec: " + timeSpec);
     }
   }
@@ -104,7 +104,7 @@ Vex.Flow.TimeSignature.prototype.makeTimeSignatureGlyph = function(topNums, botN
     glyph.topGlyphs.push(topGlyph);
     topWidth += topGlyph.getMetrics().width;
   }
- 
+
   var botWidth = 0;
   for (var i = 0; i < botNums.length; ++i) {
     var num = botNums[i];
@@ -117,7 +117,7 @@ Vex.Flow.TimeSignature.prototype.makeTimeSignatureGlyph = function(topNums, botN
   var width = (topWidth > botWidth ? topWidth : botWidth);
   var xMin = glyph.getMetrics().x_min;
 
-  glyph.getMetrics = function() { 
+  glyph.getMetrics = function() {
     return {
       x_min: xMin,
       x_max: xMin + width,
@@ -147,7 +147,7 @@ Vex.Flow.TimeSignature.prototype.makeTimeSignatureGlyph = function(topNums, botN
       start_x += g.getMetrics().width;
     }
   }
- 
+
   return glyph;
 }
 

--- a/tabdiv/tutorial.html
+++ b/tabdiv/tutorial.html
@@ -46,7 +46,7 @@
   <script src="../src/renderer.js"></script>
   <script src="../src/raphaelcontext.js"></script>
   <script src="../src/stavevolta.js"></script>
-  <script src="../src/staverepetition.js"></script>
+  <script src="../src/staverepetiion.js"></script>
   <script src="../src/stavebarline.js"></script>
   <script src="../src/stavesection.js"></script>
 
@@ -182,10 +182,10 @@ notes 4-5/6</div>
       required before and after the <code>|</code> character.
     </div>
 
-    <div style="width:420; margin-left: auto; margin-right: auto;">
+    <div style="width:450; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=400 scale=1.0 editor="true"
-      editor_width=420 editor_height=110>tabstave
+      width=500 scale=1.0 editor="true"
+      editor_width=500 editor_height=110>tabstave
 notes 4-5-6/3 10/4 | 5-4-2/3 2/2
 
 tabstave
@@ -204,8 +204,8 @@ notes 6-7-8-9/3 | 9-8-7-6/2</div>
 
     <div style="width:420; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=400 scale=1.0 editor="true"
-      editor_width=420 editor_height=110>tabstave
+      width=500 scale=1.0 editor="true"
+      editor_width=500 editor_height=110>tabstave
 notes 4-5-6b7/3 10/4 | 5-4-2/3 2/2
 
 tabstave
@@ -221,8 +221,8 @@ notes 6-7b9b7/3 7/4 | 9-8-7-6/2</div>
 
     <div style="width:420; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=400 scale=1.0 editor="true"
-      editor_width=420 editor_height=110>tabstave
+      width=500 scale=1.0 editor="true"
+      editor_width=500 editor_height=110>tabstave
 notes 4-5-6b7v/3 10/1 | 5-4-2/3 2v/2
 
 tabstave
@@ -240,8 +240,8 @@ notes 6-7b9b7/3 7/4 | 9-8-7-6V/2</div>
 
     <div style="width:420; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=400 scale=1.0 editor="true"
-      editor_width=420 editor_height=130>tabstave
+      width=500 scale=1.0 editor="true"
+      editor_width=500 editor_height=130>tabstave
 notes (5/2.6/3.7/4) 5v/1 | 5-4-3/3 2v/4
 
 tabstave
@@ -261,8 +261,8 @@ notes (5/2.6/3.7/4)</div>
 
     <div style="width:490; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=470 scale=1.0 editor="true"
-      editor_width=490 editor_height=230>tabstave
+      width=500 scale=1.0 editor="true"
+      editor_width=500 editor_height=230>tabstave
 notes (5/2.5/3.7/4) 5h6/3 7/4 |
 notes t12p7p5h7/4 7/5 5s3/5
 
@@ -292,8 +292,8 @@ notes t(12/5.12/4)s(5/5.5/4) 3b4/5 5V/6</div>
 
     <div style="width:540; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=520 scale=1.0 editor="true"
-      editor_width=540 editor_height=100>tabstave notation=true time=4/4 key=Ab tuning=eb
+      width=550 scale=1.0 editor="true"
+      editor_width=550 editor_height=100>tabstave notation=true time=4/4 key=Ab tuning=eb
 notes :8 [ 5s7/5 ] :q (5/2.6/3)h(7/3) [ :8 5/4 :16 7p5/5 ]</div>
     </div>
 
@@ -307,8 +307,8 @@ notes :8 [ 5s7/5 ] :q (5/2.6/3)h(7/3) [ :8 5/4 :16 7p5/5 ]</div>
 
     <div style="width:540; margin-left: auto; margin-right: auto;">
     <div class="vex-tabdiv"
-      width=520 scale=1.0 editor="true"
-      editor_width=540 editor_height=230>tabstave notation=true key=A
+      width=650 scale=1.0 editor="true"
+      editor_width=650 editor_height=230>tabstave notation=true key=A
 notes :q (5/2.5/3.7/4) 5h6/3 7/4 |
 notes :8 [ t12p7p5h7/4 ] :q 7/5 :8 [ 3s5/5 ]
 

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -1,0 +1,170 @@
+/**
+ * VexFlow - Basic Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ *
+ */
+
+Vex.Flow.Test.Articulation = {}
+
+Vex.Flow.Test.Articulation.Start = function() {
+  module("Stave");
+  Vex.Flow.Test.Articulation.runTest("Articulation - Staccato/Staccatissimo (Canvas)",
+    "a.","av", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Staccato/Staccatissimo (Raphael)",
+    "a.","av", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Accent/Tenuto (Canvas)",
+    "a>","a-", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Accent/Tenuto (Raphael)",
+    "a>","a-", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Marcato/L.H. Pizzicato (Canvas)",
+    "a^","a+", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Marcato/L.H. Pizzicato (Raphael)",
+    "a^","a+", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Snap Pizzicato/Fermata (Canvas)",
+    "ao","ao", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Snap Pizzicato/Fermata (Raphael)",
+    "ao","ao", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Up-stroke/Down-Stroke (Canvas)",
+    "a|","am", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Up-stroke/Down-Stroke (Raphael)",
+    "a|","am", Vex.Flow.Test.Articulation.drawArticulations);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Fermata Above/Below (Canvas)",
+    "a@a","a@u",Vex.Flow.Test.Articulation.drawFermata);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Fermata Above/Below (Raphael)",
+    "a@a","a@u",Vex.Flow.Test.Articulation.drawFermata);
+}
+
+Vex.Flow.Test.Articulation.runTest = function(name, sym1, sym2, func, params) {
+  test(name, function() {
+      test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
+      test_canvas = Vex.Flow.Test.createTestCanvas(test_canvas_sel, name);
+      func({ canvas_sel: test_canvas_sel, params: params },
+        Vex.Flow.Renderer.getCanvasContext, sym1, sym2);
+    });
+}
+Vex.Flow.Test.Articulation.runRaphaelTest = function(name, sym1, sym2, func, params) {
+  test(name, function() {
+      test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
+      test_canvas = Vex.Flow.Test.createTestRaphael(test_canvas_sel, name);
+      func({ canvas_sel: test_canvas_sel, params: params },
+        Vex.Flow.Renderer.getRaphaelContext, sym1, sym2);
+    });
+}
+
+Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder, sym1, sym2) {
+  // Get the rendering context
+  var ctx = contextBuilder(options.canvas_sel, 625, 175);
+
+  // bar 1
+  var staveBar1 = new Vex.Flow.Stave(10, 30, 125);
+  staveBar1.setContext(ctx).draw();
+  var notesBar1 = [
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+  ];
+  notesBar1[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
+  notesBar1[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
+  notesBar1[2].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar1[3].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+
+  // bar 2 - juxtaposing second bar next to first bar
+  var staveBar2 = new Vex.Flow.Stave(staveBar1.width + staveBar1.x, staveBar1.y, 125);
+  staveBar2.setEndBarType(Vex.Flow.Barline.type.DOUBLE);
+  staveBar2.setContext(ctx).draw();
+
+  var notesBar2 = [
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+  ];
+  notesBar2[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar2[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar2[2].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
+  notesBar2[3].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
+
+  // bar 3 - juxtaposing second bar next to first bar
+    var staveBar3 = new Vex.Flow.Stave(staveBar2.width + staveBar2.x, staveBar2.y, 125);
+  staveBar3.setContext(ctx).draw();
+
+  var notesBar3 = [
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+  ];
+  notesBar3[0].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+  notesBar3[1].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+  notesBar3[2].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
+  notesBar3[3].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar3, notesBar3);
+  // bar 4 - juxtaposing second bar next to first bar
+  var staveBar4 = new Vex.Flow.Stave(staveBar3.width + staveBar3.x, staveBar3.y, 125);
+  staveBar4.setEndBarType(Vex.Flow.Barline.type.END);
+  staveBar4.setContext(ctx).draw();
+
+  var notesBar4 = [
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+  ];
+  notesBar4[0].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
+  notesBar4[1].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
+  notesBar4[2].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+  notesBar4[3].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar4, notesBar4);
+}
+
+Vex.Flow.Test.Articulation.drawFermata = function(options, contextBuilder, sym1, sym2) {
+  // Get the rendering context
+  var ctx = contextBuilder(options.canvas_sel, 400, 200);
+
+  // bar 1
+  var staveBar1 = new Vex.Flow.Stave(50, 30, 150);
+  staveBar1.setContext(ctx).draw();
+  var notesBar1 = [
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: -1 }),
+  ];
+  notesBar1[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar1[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar1[2].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+  notesBar1[3].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+
+  // bar 2 - juxtaposing second bar next to first bar
+  var staveBar2 = new Vex.Flow.Stave(staveBar1.width + staveBar1.x, staveBar1.y, 150);
+  staveBar2.setEndBarType(Vex.Flow.Barline.type.DOUBLE);
+  staveBar2.setContext(ctx).draw();
+
+  var notesBar2 = [
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+  ];
+  notesBar2[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar2[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
+  notesBar2[2].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+  notesBar2[3].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
+}

--- a/tests/beam_tests.js
+++ b/tests/beam_tests.js
@@ -32,11 +32,11 @@ Vex.Flow.Test.Beam.beamNotes = function(notes, stave, ctx) {
 }
 
 Vex.Flow.Test.Beam.setupContext = function(options, x, y) {
-  Vex.Flow.Test.resizeCanvas(options.canvas_sel, x || 350, y || 140);
+  Vex.Flow.Test.resizeCanvas(options.canvas_sel, x || 450, y || 140);
   var ctx = Vex.getCanvasContext(options.canvas_sel);
   ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
   ctx.font = " 10pt Arial";
-  var stave = new Vex.Flow.Stave(10, 10, x || 350).addTrebleGlyph().
+  var stave = new Vex.Flow.Stave(10, 10, x || 450).addTrebleGlyph().
     setContext(ctx).draw();
 
   return {context: ctx, stave: stave};
@@ -248,7 +248,7 @@ Vex.Flow.Test.Beam.mixed = function(options) {
   voice2.addTickables(notes2);
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice, voice2]).
-    format([voice, voice2], 300);
+    format([voice, voice2], 450);
   var beam1_1 = new Vex.Flow.Beam(notes.slice(0, 4));
   var beam1_2 = new Vex.Flow.Beam(notes.slice(4, 8));
 
@@ -295,7 +295,7 @@ Vex.Flow.Test.Beam.dotted = function(options) {
   voice.addTickables(notes);
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
-    format([voice], 300);
+    format([voice], 450);
   var beam1_1 = new Vex.Flow.Beam(notes.slice(0, 4));
   var beam1_2 = new Vex.Flow.Beam(notes.slice(4, 8));
   var beam1_3 = new Vex.Flow.Beam(notes.slice(8, 12));

--- a/tests/bend_tests.js
+++ b/tests/bend_tests.js
@@ -112,7 +112,7 @@ Vex.Flow.Test.Bend.reverseBends = function(options) {
     note.addToModifierContext(mc);
 
     var tickContext = new Vex.Flow.TickContext();
-    tickContext.addTickable(note).preFormat().setX(50 * i).setPixelsUsed(95);
+    tickContext.addTickable(note).preFormat().setX(75 * i).setPixelsUsed(95);
 
     note.setStave(stave).setContext(ctx).draw();
     ok(true, "Bend " + i);

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -99,6 +99,7 @@
   <script src="../src/stavevolta.js"></script>
   <script src="../src/staverepetition.js"></script>
   <script src="../src/stavesection.js"></script>
+  <script src="../src/articulation.js"></script>
   <script src="../src/raphaelcontext.js"></script>
 
   <!-- Compiled Source -->
@@ -138,6 +139,8 @@
   <script src="clef_tests.js"></script>
   <script src="music_tests.js"></script>
   <script src="keymanager_tests.js"></script>
+  <script src="articulation_tests.js"></script>
+  <script src="staveconnector_tests.js"></script>
   <script src="../vextab/vextab_tests.js"></script>
 
   <script>
@@ -166,6 +169,8 @@
       Vex.Flow.Test.Tuning.Start();
       Vex.Flow.Test.Music.Start();
       Vex.Flow.Test.KeyManager.Start();
+      Vex.Flow.Test.Articulation.Start();
+      Vex.Flow.Test.StaveConnector.Start();
     });
   </script>
 </head>

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -14,6 +14,10 @@ Vex.Flow.Test.Formatter.Start = function() {
       Vex.Flow.Test.Formatter.justifyStaveNotes);
   Vex.Flow.Test.runTest("Notes with Tab",
       Vex.Flow.Test.Formatter.notesWithTab);
+  Vex.Flow.Test.runTest("Format Multiple Staves - No Justification",
+      Vex.Flow.Test.Formatter.multiStaves, {justify: 0});
+  Vex.Flow.Test.runTest("Format Multiple Staves - Justified",
+      Vex.Flow.Test.Formatter.multiStaves, {justify: 188});
 }
 
 Vex.Flow.Test.Formatter.buildTickContexts = function(options) {
@@ -235,3 +239,150 @@ Vex.Flow.Test.Formatter.notesWithTab = function(options) {
       { notes: stave2, tabs: tabstave2 }, 300);
   ok(true);
 }
+
+Vex.Flow.Test.Formatter.multiStaves = function(options) {
+  Vex.Flow.Test.resizeCanvas(options.canvas_sel, 500, 300);
+  var ctx = Vex.getCanvasContext(options.canvas_sel);
+  ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = "10pt Arial";
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+  var stave11 = new Vex.Flow.Stave(20, 10, 255).
+    addTrebleGlyph().
+    addTimeSignature("6/8").
+    setContext(ctx).draw();
+  var stave21 = new Vex.Flow.Stave(20, 100, 255).
+    addTrebleGlyph().
+    addTimeSignature("6/8").
+    setContext(ctx).draw();
+  var stave31 = new Vex.Flow.Stave(20, 200, 255).
+    addClef("bass").
+    addTimeSignature("6/8").
+    setContext(ctx).draw();
+  var connector = new Vex.Flow.StaveConnector(stave21, stave31).
+    setType(Vex.Flow.StaveConnector.type.BRACE).
+    setContext(ctx).draw();
+
+  var notes11 = [
+    newNote({ keys: ["f/4"], duration: "q"}).setStave(stave11),
+    newNote({ keys: ["d/4"], duration: "8"}).setStave(stave11),
+    newNote({ keys: ["g/4"], duration: "q"}).setStave(stave11),
+    newNote({ keys: ["e/4"], duration: "8"}).setStave(stave11).
+      addAccidental(0, newAcc("b")),
+  ];
+  var notes21 = [
+    newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}).setStave(stave21),
+    newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}).setStave(stave21),
+    newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}).setStave(stave21),
+    newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}).setStave(stave21),
+    newNote({ keys: ["e/4"], stem_direction: 1, duration: "8"}).setStave(stave21).
+      addAccidental(0, newAcc("b")),
+    newNote({ keys: ["e/4"], stem_direction: 1, duration: "8"}).setStave(stave21).
+      addAccidental(0, newAcc("b")),
+  ];
+  var notes31 = [
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+  ];
+
+  var voice11 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  var voice21 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  var voice31 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  voice11.addTickables(notes11);
+  voice21.addTickables(notes21);
+  voice31.addTickables(notes31);
+
+  var beam21a = new Vex.Flow.Beam(notes21.slice(0, 3));
+  var beam21b = new Vex.Flow.Beam(notes21.slice(3, 6));
+  var beam31a = new Vex.Flow.Beam(notes31.slice(0, 3));
+  var beam31b = new Vex.Flow.Beam(notes31.slice(3, 6));
+
+  if (options.params.justify > 0) {
+    var formatter = new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
+      format([voice11, voice21, voice31], options.params.justify);
+  } else {
+    var formatter = new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
+      format([voice11, voice21, voice31]);
+  }
+
+  voice11.draw(ctx, stave11);
+  voice21.draw(ctx, stave21);
+  voice31.draw(ctx, stave31);
+  beam21a.setContext(ctx).draw();
+  beam21b.setContext(ctx).draw();
+  beam31a.setContext(ctx).draw();
+  beam31b.setContext(ctx).draw();
+
+  var stave12 = new Vex.Flow.Stave(stave11.width + stave11.x, stave11.y, 250).
+    setContext(ctx).draw();
+  var stave22 = new Vex.Flow.Stave(stave21.width + stave21.x, stave21.y, 250).
+    setContext(ctx).draw();
+  var stave32 = new Vex.Flow.Stave(stave31.width + stave31.x, stave31.y, 250).
+    setContext(ctx).draw();
+
+  var notes12 = [
+    newNote({ keys: ["a/4"], duration: "q"}).setStave(stave12).
+     addAccidental(0, newAcc("b")),
+    newNote({ keys: ["b/4"], duration: "8"}).setStave(stave12).
+      addAccidental(0, newAcc("b")),
+    newNote({ keys: ["c/5", "e/5"], stem_direction: -1, duration: "q"}).setStave(stave12). //,
+      addAccidental(0, newAcc("b")).
+      addAccidental(1, newAcc("b")),
+
+    newNote({ keys: ["d/5"], stem_direction: -1, duration: "8"}).setStave(stave12)
+  ];
+  var notes22 = [
+    newNote({ keys: ["a/4", "e/4"], stem_direction: 1, duration: "qd"}).setStave(stave22).
+      addAccidental(0, newAcc("b")).
+      addAccidental(1, newAcc("b")).
+      addDotToAll(),
+    newNote({ keys: ["c/5", "a/4", "e/4"], stem_direction: 1, duration: "q"}).setStave(stave22).
+      addAccidental(0, newAcc("b")).
+      addAccidental(1, newAcc("b")),
+    newNote({ keys: ["d/5"], stem_direction: 1, duration: "8"}).setStave(stave22).
+      addAccidental(0, newAcc("b")),
+  ];
+  var notes32 = [
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32)
+  ];
+  var voice12 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  var voice22 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  var voice32 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
+  voice12.addTickables(notes12);
+  voice22.addTickables(notes22);
+  voice32.addTickables(notes32);
+
+  if (options.params.justify > 0) {
+    var formatter = new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
+      format([voice12, voice22, voice32], 188);
+  } else {
+    var formatter = new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
+      format([voice12, voice22, voice32]);
+  }
+  var beam32a = new Vex.Flow.Beam(notes32.slice(0, 3));
+  var beam32b = new Vex.Flow.Beam(notes32.slice(3, 6));
+
+  voice12.draw(ctx, stave12);
+  voice22.draw(ctx, stave22);
+  voice32.draw(ctx, stave32);
+  beam32a.setContext(ctx).draw();
+  beam32b.setContext(ctx).draw();
+
+  ok(true);
+}
+
+Vex.Flow.Test.Formatter.TIME6_8 = {
+  num_beats: 6,
+  beat_value: 8,
+  resolution: Vex.Flow.RESOLUTION
+};

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -17,6 +17,12 @@ Vex.Flow.Test.MockTickable.prototype.getX = function() {
 Vex.Flow.Test.MockTickable.prototype.getTicks = function() {return this.ticks;}
 Vex.Flow.Test.MockTickable.prototype.setTicks = function(t) {
   this.ticks = t; return this; };
+Vex.Flow.Test.MockTickable.prototype.getMetrics = function() {
+  return { noteWidth: this.width,
+           left_shift: 0,
+           modLeftPx: 0, modRightPx: 0,
+           extraLeftPx: 0, extraRightPx: 0 };
+}
 Vex.Flow.Test.MockTickable.prototype.getWidth = function() {return this.width;}
 Vex.Flow.Test.MockTickable.prototype.setWidth = function(w) {
   this.width = w; return this; }

--- a/tests/staveconnector_tests.js
+++ b/tests/staveconnector_tests.js
@@ -1,0 +1,177 @@
+/**
+ * VexFlow - Basic Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ */
+
+Vex.Flow.Test.StaveConnector = {}
+
+Vex.Flow.Test.StaveConnector.Start = function() {
+  module("StaveConnector");
+  Vex.Flow.Test.runTest("StaveConnector Single Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawSingle);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Single Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawSingle);
+  Vex.Flow.Test.runTest("StaveConnector Double Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawDouble);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Double Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawDouble);
+  Vex.Flow.Test.runTest("StaveConnector Brace Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawBrace);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Brace Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawBrace);
+  Vex.Flow.Test.runTest("StaveConnector Brace Wide Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawBraceWide);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Wide Brace Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawBraceWide);
+  Vex.Flow.Test.runTest("StaveConnector Bracket Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawBracket);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Bracket Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawBracket);
+  Vex.Flow.Test.runTest("StaveConnector Combined Draw Test (Canvas)", 
+    Vex.Flow.Test.StaveConnector.drawCombined);  
+  Vex.Flow.Test.runRaphaelTest("StaveConnector Combined Draw Test (Raphael)",
+    Vex.Flow.Test.StaveConnector.drawCombined);
+}
+
+Vex.Flow.Test.StaveConnector.drawSingle = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+  var stave = new Vex.Flow.Stave(25, 10, 300);
+  var stave2 = new Vex.Flow.Stave(25, 120, 300);  
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  var connector = new Vex.Flow.StaveConnector(stave, stave2);
+  connector.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  connector.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  connector.draw();  
+
+  ok(true, "all pass");
+}
+
+Vex.Flow.Test.StaveConnector.drawDouble = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+  var stave = new Vex.Flow.Stave(25, 10, 300);
+  var stave2 = new Vex.Flow.Stave(25, 120, 300);  
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  var connector = new Vex.Flow.StaveConnector(stave, stave2);
+  var line = new Vex.Flow.StaveConnector(stave, stave2);
+  connector.setType(Vex.Flow.StaveConnector.type.DOUBLE);
+  connector.setContext(ctx);
+  line.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  connector.setContext(ctx);
+  line.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  connector.draw(); 
+  line.draw();
+
+  ok(true, "all pass");
+}
+
+Vex.Flow.Test.StaveConnector.drawBrace = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+  var stave = new Vex.Flow.Stave(25, 10, 300);
+  var stave2 = new Vex.Flow.Stave(25, 120, 300);  
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  var connector = new Vex.Flow.StaveConnector(stave, stave2);
+  var line = new Vex.Flow.StaveConnector(stave, stave2);
+  connector.setType(Vex.Flow.StaveConnector.type.BRACE);
+  connector.setContext(ctx);
+  line.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  connector.setContext(ctx);
+  line.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  connector.draw(); 
+  line.draw();
+
+  ok(true, "all pass");
+}
+
+Vex.Flow.Test.StaveConnector.drawBraceWide = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+  var stave = new Vex.Flow.Stave(25, -20, 300);
+  var stave2 = new Vex.Flow.Stave(25, 200, 300);
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  var connector = new Vex.Flow.StaveConnector(stave, stave2);
+  var line = new Vex.Flow.StaveConnector(stave, stave2);
+  connector.setType(Vex.Flow.StaveConnector.type.BRACE);
+  connector.setContext(ctx);
+  line.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  connector.setContext(ctx);
+  line.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  connector.draw(); 
+  line.draw();
+
+  ok(true, "all pass");
+}
+
+Vex.Flow.Test.StaveConnector.drawBracket = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+  var stave = new Vex.Flow.Stave(25, 10, 300);
+  var stave2 = new Vex.Flow.Stave(25, 120, 300);  
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  var connector = new Vex.Flow.StaveConnector(stave, stave2);
+  var line = new Vex.Flow.StaveConnector(stave, stave2);
+  connector.setType(Vex.Flow.StaveConnector.type.BRACKET);
+  connector.setContext(ctx);
+  line.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  connector.setContext(ctx);
+  line.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  connector.draw(); 
+  line.draw();
+
+  ok(true, "all pass");
+}
+
+Vex.Flow.Test.StaveConnector.drawCombined = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 400, 700);
+  var stave = new Vex.Flow.Stave(25, 10, 300);
+  var stave2 = new Vex.Flow.Stave(25, 100, 300);
+  var stave3 = new Vex.Flow.Stave(25, 190, 300);
+  var stave4 = new Vex.Flow.Stave(25, 280, 300);
+  var stave5 = new Vex.Flow.Stave(25, 370, 300);
+  var stave6 = new Vex.Flow.Stave(25, 460, 300);
+  var stave7 = new Vex.Flow.Stave(25, 560, 300);
+  stave.setContext(ctx);
+  stave2.setContext(ctx);
+  stave3.setContext(ctx);
+  stave4.setContext(ctx);
+  stave5.setContext(ctx);
+  stave6.setContext(ctx);
+  stave7.setContext(ctx);
+  var conn_single = new Vex.Flow.StaveConnector(stave, stave7);
+  var conn_double = new Vex.Flow.StaveConnector(stave2, stave3);
+  var conn_bracket = new Vex.Flow.StaveConnector(stave4, stave5);
+  var conn_brace = new Vex.Flow.StaveConnector(stave6, stave7);
+  conn_single.setType(Vex.Flow.StaveConnector.type.SINGLE);
+  conn_double.setType(Vex.Flow.StaveConnector.type.DOUBLE);
+  conn_bracket.setType(Vex.Flow.StaveConnector.type.BRACKET);
+  conn_brace.setType(Vex.Flow.StaveConnector.type.BRACE);
+  conn_single.setContext(ctx);
+  conn_double.setContext(ctx);  
+  conn_bracket.setContext(ctx);
+  conn_brace.setContext(ctx);
+  stave.draw();
+  stave2.draw();
+  stave3.draw();
+  stave4.draw();
+  stave5.draw();
+  stave6.draw();
+  stave7.draw();
+  conn_single.draw();
+  conn_double.draw();
+  conn_bracket.draw();
+  conn_brace.draw();
+
+  ok(true, "all pass");
+}


### PR DESCRIPTION
Modifications to the formatter and supporting classes to align tablature
with the notation and enable formatting voices from multiple staves. Below
is a summary of the modified classes, tests and web pages included in this
commit.
# Classes (src/)

accidental.js      :: Removed redundant functions defined in modifier.js
beam.js            :: Shorten stems by 3 picels when note head is a harmonic
bend.js            :: Changed text width calculation from textWidth() to
                      measureText()
dot.js             :: Removed redundant functions defined in modifier.js
formatter.js       :: FormatAndDrawTab() - reversed order of noteVoices and
                      tabVoices so stave notes formatted first
                   :: preFormat() - completely recoded to layout notes with
                      left justification
modifier.js        :: added setYShift() function
modifiercontext.js :: new functions formatNotesByY() and formatAccidentalsByY()
                      to enable formatting of more than two voices (multiple
                      staves)
                   :: Fixed accidentals drawing over note heads for displaced
                      notes with downward stems
note.js            :: Added getMetrics() to get note onfo needed for formatting
stave.js           :: Added option for no vertical barline
stavebarline.js    :: Added "NONE" as a barline option
staveconnector.js  :: Added single line, brace and brackets stave connectors
stavenote.js       :: Sorted notes during init to ensure they are in correct
                      sequence by line plus minor changes for new formatter
tabnote.js         :: Various changes to support new formatter
tabslide.js        :: draw() mod to draw consistent slide lines in tablature
tickable.js        :: addToModifierContext() did not use correct variable name
tickcontext.js     :: Added variable to support getting tickcontext metrics for
                      new formatter
timesignature.js   :: Corrected constructor definition from KeySignature to
                      TimeSignature
# New Class (src/)

articulation.js    :: Class to draw articulations in notation
# TabDiv (tabdiv/)

tutorial.html      :: Increased width Steps 5 & 6 so notation would display
# Tests (tests/)

flow.html               :: Added articulation & staveconnector tests
articulation_tests.js   :: New test for articulations
beam_tests.js           :: Made stave width larger
bend_tests.js           :: fixed spacing of reverse bends
formatter_tests.js      :: Added multiple system format test
mocks.js                :: added tickable.getMetrics() function
staveconnector_tests.js :: Tests for the various stave connectors
