### PR TITLE
Tab glyph scaling for 4/5 lined tabs

### DIFF
--- a/src/tabstave.js
+++ b/src/tabstave.js
@@ -33,6 +33,25 @@ Vex.Flow.TabStave.prototype.getYForGlyphs = function() {
 }
 
 Vex.Flow.TabStave.prototype.addTabGlyph = function() {
-  this.addGlyph(new Vex.Flow.Glyph("v2f", 40));
+	var glyphScale;
+	var glyphOffset;
+
+	switch(this.options.num_lines) {
+		case 6:
+			glyphScale = 40;
+			glyphOffset = 0;
+			break;
+		case 5:
+			glyphScale = 30;
+			glyphOffset = -6;
+			break;
+		case 4:
+			glyphScale = 23;
+			glyphOffset = -12;
+			break;
+	}
+	var tabGlyph = new Vex.Flow.Glyph("v2f", glyphScale);
+	tabGlyph.y_shift = glyphOffset;
+  this.addGlyph(tabGlyph);
   return this;
 }


### PR DESCRIPTION
The tablature glyph now scales and is positioned correctly when passing {num_lines: 5} and {num_lines: 4} to the TabStave constructor. This improves the rendering of the tablature glyph for 4 and 5 stringed instruments (banjos, mandolins etc).
