### PR TITLE
Add in line configuration for Stave

### DIFF
--- a/src/stave.js
+++ b/src/stave.js
@@ -228,7 +228,7 @@ Vex.Flow.Stave.prototype.draw = function(context) {
 
     var y = this.getYForLine(line);
 
-    if (this.options.line_config && this.options.line_config[line].visible) {
+    if (this.options.line_config[line].visible) {
       this.context.fillRect(x, y, width, 1);
     }
   }
@@ -294,7 +294,7 @@ Vex.Flow.Stave.prototype.drawVerticalBarFixed = function(x) {
  * Get the current configuration for the Stave.
  * @return {Array} An array of configuration objects.
  */
-Vex.Flow.Stave.prototype.getLinesConfiguration = function() {
+Vex.Flow.Stave.prototype.getConfigForLines = function() {
   return this.options.line_config;
 }
 
@@ -305,10 +305,18 @@ Vex.Flow.Stave.prototype.getLinesConfiguration = function() {
  * @throws Vex.RERR "StaveConfigError" When the specified line number is out of
  *   range of the number of lines specified in the constructor.
  */
-Vex.Flow.Stave.prototype.setLineConfiguration = function(line_number, line_config) {
+Vex.Flow.Stave.prototype.setConfigForLine = function(line_number, line_config) {
   if (line_number >= this.options.num_lines || line_number < 0) {
     throw new Vex.RERR("StaveConfigError",
       "The line number must be within the range of the number of lines in the Stave.");
+  }
+  if (!line_config.hasOwnProperty('visible')) {
+    throw new Vex.RERR("StaveConfigError",
+      "The line configuration object is missing the 'visible' property.");
+  }
+  if (typeof(line_config.visible) !== 'boolean') {
+    throw new Vex.RERR("StaveConfigError",
+      "The line configuration objects 'visible' property must be true or false.");
   }
 
   this.options.line_config[line_number] = line_config;
@@ -325,7 +333,7 @@ Vex.Flow.Stave.prototype.setLineConfiguration = function(line_number, line_confi
  *   exactly the same number of elements as the num_lines configuration object set in
  *   the constructor.
  */
-Vex.Flow.Stave.prototype.setLinesConfiguration = function(lines_configuration) {
+Vex.Flow.Stave.prototype.setConfigForLines = function(lines_configuration) {
   if (lines_configuration.length !== this.options.num_lines) {
     throw new Vex.RERR("StaveConfigError",
       "The length of the lines configuration array must match the number of lines in the Stave");

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -351,14 +351,14 @@ Vex.Flow.Test.Stave.drawTempo = function(options, contextBuilder) {
 Vex.Flow.Test.Stave.configureSingleLine = function(options, contextBuilder) {
   var ctx = new contextBuilder(options.canvas_sel, 400, 120);
   var stave = new Vex.Flow.Stave(10, 10, 300);
-  stave.setLineConfiguration(0, { visible: true })
-    .setLineConfiguration(1, { visible: false })
-    .setLineConfiguration(2, { visible: true })
-    .setLineConfiguration(3, { visible: false })
-    .setLineConfiguration(4, { visible: true });
+  stave.setConfigForLine(0, { visible: true })
+    .setConfigForLine(1, { visible: false })
+    .setConfigForLine(2, { visible: true })
+    .setConfigForLine(3, { visible: false })
+    .setConfigForLine(4, { visible: true });
   stave.setContext(ctx).draw();
 
-  var config = stave.getLinesConfiguration();
+  var config = stave.getConfigForLines();
   equals(config[0].visible, true, "getLinesConfiguration() - Line 0");
   equals(config[1].visible, false, "getLinesConfiguration() - Line 1");
   equals(config[2].visible, true, "getLinesConfiguration() - Line 2");
@@ -371,7 +371,7 @@ Vex.Flow.Test.Stave.configureSingleLine = function(options, contextBuilder) {
 Vex.Flow.Test.Stave.configureAllLines = function(options, contextBuilder) {
   var ctx = new contextBuilder(options.canvas_sel, 400, 120);
   var stave = new Vex.Flow.Stave(10, 10, 300);
-  stave.setLinesConfiguration([
+  stave.setConfigForLines([
     { visible: false },
     null,
     { visible: false },
@@ -379,7 +379,7 @@ Vex.Flow.Test.Stave.configureAllLines = function(options, contextBuilder) {
     { visible: false }
   ]).setContext(ctx).draw();
 
-  var config = stave.getLinesConfiguration();
+  var config = stave.getConfigForLines();
   equals(config[0].visible, false, "getLinesConfiguration() - Line 0");
   equals(config[1].visible, true, "getLinesConfiguration() - Line 1");
   equals(config[2].visible, false, "getLinesConfiguration() - Line 2");


### PR DESCRIPTION
Added in a line configuration data structure the Stave instance options.

This is an array of objects, one per Stave line that can be used to granularly control how each line is drawn in Stave.draw().  Currently, the only configuration parameter is line visibility, but it was designed so that other parameters can be added with minimal effort.

3 new instance functions were added to Vex.Flow.Stave:
- getConfigForLines(): Returns the current line configuration array.
- setConfigForLine(int, object): Sets the line configuration for a single line.  All other lines are unaffected.
- setConfigForLines(array): Sets the configuration for all lines.  The length of the input array must match the existing num_lines option that is set in the Stave constructor.  If the defaults are desired for a particular line index, null may be passed in at that array index.
