### PR TITLE
Upgrade to latest version of QUnit and updated tests to be compatible.

### DIFF
--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -36,22 +36,24 @@ Vex.Flow.Test.Articulation.Start = function() {
 
 Vex.Flow.Test.Articulation.runTest = function(name, sym1, sym2, func, params) {
   test(name, function() {
-      test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
-      test_canvas = Vex.Flow.Test.createTestCanvas(test_canvas_sel, name);
+      var test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
+      Vex.Flow.Test.createTestCanvas(test_canvas_sel, name);
       func({ canvas_sel: test_canvas_sel, params: params },
         Vex.Flow.Renderer.getCanvasContext, sym1, sym2);
     });
 }
 Vex.Flow.Test.Articulation.runRaphaelTest = function(name, sym1, sym2, func, params) {
   test(name, function() {
-      test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
-      test_canvas = Vex.Flow.Test.createTestRaphael(test_canvas_sel, name);
+      var test_canvas_sel = "canvas_" + Vex.Flow.Test.genID();
+      Vex.Flow.Test.createTestRaphael(test_canvas_sel, name);
       func({ canvas_sel: test_canvas_sel, params: params },
         Vex.Flow.Renderer.getRaphaelContext, sym1, sym2);
     });
 }
 
 Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder, sym1, sym2) {
+  expect(0);
+
   // Get the rendering context
   var ctx = contextBuilder(options.canvas_sel, 625, 175);
 
@@ -62,7 +64,7 @@ Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder,
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 })
   ];
   notesBar1[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
   notesBar1[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(4));
@@ -81,7 +83,7 @@ Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder,
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
     new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 })
   ];
   notesBar2[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
   notesBar2[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
@@ -99,7 +101,7 @@ Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder,
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 })
   ];
   notesBar3[0].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
   notesBar3[1].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(4));
@@ -117,7 +119,7 @@ Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder,
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
     new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 })
   ];
   notesBar4[0].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
   notesBar4[1].addArticulation(0, new Vex.Flow.Articulation(sym2).setPosition(3));
@@ -129,6 +131,8 @@ Vex.Flow.Test.Articulation.drawArticulations = function(options, contextBuilder,
 }
 
 Vex.Flow.Test.Articulation.drawFermata = function(options, contextBuilder, sym1, sym2) {
+  expect(0);
+
   // Get the rendering context
   var ctx = contextBuilder(options.canvas_sel, 400, 200);
 
@@ -139,7 +143,7 @@ Vex.Flow.Test.Articulation.drawFermata = function(options, contextBuilder, sym1,
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "q", stem_direction: -1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "q", stem_direction: -1 })
   ];
   notesBar1[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
   notesBar1[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
@@ -158,7 +162,7 @@ Vex.Flow.Test.Articulation.drawFermata = function(options, contextBuilder, sym1,
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: 1 }),
     new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
-    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 })
   ];
   notesBar2[0].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));
   notesBar2[1].addArticulation(0, new Vex.Flow.Articulation(sym1).setPosition(3));

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -20,7 +20,7 @@ Vex.Flow.Test.Formatter.Start = function() {
       Vex.Flow.Test.Formatter.multiStaves, {justify: 188});
 }
 
-Vex.Flow.Test.Formatter.buildTickContexts = function(options) {
+Vex.Flow.Test.Formatter.buildTickContexts = function() {
   function createTickable() {
     return new Vex.Flow.Test.MockTickable();
   }
@@ -49,14 +49,14 @@ Vex.Flow.Test.Formatter.buildTickContexts = function(options) {
   var formatter = new Vex.Flow.Formatter();
   var tContexts = formatter.createTickContexts([voice1, voice2]);
 
-  equals(tContexts.list.length, 4, "Voices should have four tick contexts");
+  equal(tContexts.list.length, 4, "Voices should have four tick contexts");
 
   formatter.preFormat();
-  equals(formatter.getMinTotalWidth(), 104, "Minimum total width");
+  equal(formatter.getMinTotalWidth(), 104, "Minimum total width");
 
-  equals(tickables1[0].getX(), tickables2[0].getX(),
+  equal(tickables1[0].getX(), tickables2[0].getX(),
       "First notes of both voices have the same X");
-  equals(tickables1[2].getX(), tickables2[2].getX(),
+  equal(tickables1[2].getX(), tickables2[2].getX(),
       "Last notes of both voices have the same X");
   ok(tickables1[1].getX() < tickables2[1].getX(),
       "Second note of voice 2 is to the right of the second note of voice 1");
@@ -70,7 +70,7 @@ Vex.Flow.Test.Formatter.renderNotes = function(
   voice1.addTickables(notes1);
   voice2.addTickables(notes2);
 
-  var formatter = new Vex.Flow.Formatter().joinVoices([voice1, voice2]).
+  new Vex.Flow.Formatter().joinVoices([voice1, voice2]).
     format([voice1, voice2], justify);
 
   voice1.draw(ctx, stave);
@@ -95,7 +95,7 @@ Vex.Flow.Test.Formatter.formatStaveNotes = function(options) {
     newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "q"}),
     newNote({ keys: ["f/4", "a/4", "c/4"], stem_direction: -1, duration: "q"}).
       addAccidental(0, newAcc("n")).
-      addAccidental(1, newAcc("#")),
+      addAccidental(1, newAcc("#"))
   ];
 
   var notes2 = [
@@ -105,7 +105,7 @@ Vex.Flow.Test.Formatter.formatStaveNotes = function(options) {
     newNote({ keys: ["d/5", "e/5", "f/5"], stem_direction: 1, duration: "q"}),
     newNote({ keys: ["f/5", "a/5", "c/5"], stem_direction: 1, duration: "q"}).
       addAccidental(0, newAcc("n")).
-      addAccidental(1, newAcc("#")),
+      addAccidental(1, newAcc("#"))
   ];
 
   Vex.Flow.Test.Formatter.renderNotes(notes1, notes2, ctx, stave);
@@ -113,7 +113,7 @@ Vex.Flow.Test.Formatter.formatStaveNotes = function(options) {
   ok(true);
 }
 
-Vex.Flow.Test.Formatter.getNotes = function(options) {
+Vex.Flow.Test.Formatter.getNotes = function() {
   function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
   function newAcc(type) { return new Vex.Flow.Accidental(type); }
 
@@ -125,7 +125,7 @@ Vex.Flow.Test.Formatter.getNotes = function(options) {
     newNote({ keys: ["d/4", "f/4", "a/4"], stem_direction: -1, duration: "8"}),
     newNote({ keys: ["f/4", "a/4", "c/4"], stem_direction: -1, duration: "q"}).
       addAccidental(0, newAcc("n")).
-      addAccidental(1, newAcc("#")),
+      addAccidental(1, newAcc("#"))
   ];
 
   var notes2 = [
@@ -135,7 +135,7 @@ Vex.Flow.Test.Formatter.getNotes = function(options) {
     newNote({ keys: ["d/5", "e/5", "f/5"], stem_direction: 1, duration: "h"}),
     newNote({ keys: ["f/5", "a/5", "c/5"], stem_direction: 1, duration: "q"}).
       addAccidental(0, newAcc("##")).
-      addAccidental(1, newAcc("b")),
+      addAccidental(1, newAcc("b"))
   ];
 
   return [notes1, notes2];
@@ -167,7 +167,7 @@ Vex.Flow.Test.Formatter.justifyStaveNotes = function(options) {
   ok(true);
 }
 
-Vex.Flow.Test.Formatter.getTabNotes = function(options) {
+Vex.Flow.Test.Formatter.getTabNotes = function() {
   function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
   function newTabNote(tab_struct) { return new Vex.Flow.TabNote(tab_struct); }
   function newAcc(type) { return new Vex.Flow.Accidental(type); }
@@ -178,7 +178,7 @@ Vex.Flow.Test.Formatter.getTabNotes = function(options) {
     newNote({ keys: ["c/4", "d/4"], stem_direction: 1, duration: "8"}),
     newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}),
     newNote({ keys: ["c/4", "a/4", "e/4"], stem_direction: 1, duration: "q"}).
-      addAccidental(0, newAcc("#")),
+      addAccidental(0, newAcc("#"))
   ];
 
   var tabs1 = [
@@ -190,7 +190,7 @@ Vex.Flow.Test.Formatter.getTabNotes = function(options) {
     newTabNote({ positions: [{str: 3, fret: 7}], duration: "8"}),
     newTabNote({ positions: [{str: 3, fret: 6},
                              {str: 4, fret: 7},
-                             {str: 2, fret: 5}], duration: "q"}),
+                             {str: 2, fret: 5}], duration: "q"})
 
   ];
 
@@ -205,7 +205,7 @@ Vex.Flow.Test.Formatter.renderNotesWithTab =
   voice.addTickables(notes.notes);
   tabVoice.addTickables(notes.tabs);
 
-  var formatter = new Vex.Flow.Formatter().
+  new Vex.Flow.Formatter().
     joinVoices([voice]).joinVoices([tabVoice]).
     format([voice, tabVoice], justify);
 
@@ -260,7 +260,7 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
     addClef("bass").
     addTimeSignature("6/8").
     setContext(ctx).draw();
-  var connector = new Vex.Flow.StaveConnector(stave21, stave31).
+  new Vex.Flow.StaveConnector(stave21, stave31).
     setType(Vex.Flow.StaveConnector.type.BRACE).
     setContext(ctx).draw();
 
@@ -269,7 +269,7 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
     newNote({ keys: ["d/4"], duration: "8"}).setStave(stave11),
     newNote({ keys: ["g/4"], duration: "q"}).setStave(stave11),
     newNote({ keys: ["e/4"], duration: "8"}).setStave(stave11).
-      addAccidental(0, newAcc("b")),
+      addAccidental(0, newAcc("b"))
   ];
   var notes21 = [
     newNote({ keys: ["d/4"], stem_direction: 1, duration: "8"}).setStave(stave21),
@@ -279,7 +279,7 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
     newNote({ keys: ["e/4"], stem_direction: 1, duration: "8"}).setStave(stave21).
       addAccidental(0, newAcc("b")),
     newNote({ keys: ["e/4"], stem_direction: 1, duration: "8"}).setStave(stave21).
-      addAccidental(0, newAcc("b")),
+      addAccidental(0, newAcc("b"))
   ];
   var notes31 = [
     newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
@@ -287,7 +287,7 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
     newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
     newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
     newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
-    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31),
+    newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave31)
   ];
 
   var voice11 = new Vex.Flow.Voice(Vex.Flow.Test.Formatter.TIME6_8);
@@ -303,10 +303,10 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
   var beam31b = new Vex.Flow.Beam(notes31.slice(3, 6));
 
   if (options.params.justify > 0) {
-    var formatter = new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
+    new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
       format([voice11, voice21, voice31], options.params.justify);
   } else {
-    var formatter = new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
+    new Vex.Flow.Formatter().joinVoices( [voice11, voice21, voice31] ).
       format([voice11, voice21, voice31]);
   }
 
@@ -345,7 +345,7 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
       addAccidental(0, newAcc("b")).
       addAccidental(1, newAcc("b")),
     newNote({ keys: ["d/5"], stem_direction: 1, duration: "8"}).setStave(stave22).
-      addAccidental(0, newAcc("b")),
+      addAccidental(0, newAcc("b"))
   ];
   var notes32 = [
     newNote({ keys: ["a/5"], stem_direction: -1, duration: "8"}).setStave(stave32),
@@ -363,10 +363,10 @@ Vex.Flow.Test.Formatter.multiStaves = function(options) {
   voice32.addTickables(notes32);
 
   if (options.params.justify > 0) {
-    var formatter = new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
+    new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
       format([voice12, voice22, voice32], 188);
   } else {
-    var formatter = new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
+    new Vex.Flow.Formatter().joinVoices([voice12, voice22, voice32]).
       format([voice12, voice22, voice32]);
   }
   var beam32a = new Vex.Flow.Beam(notes32.slice(0, 3));

--- a/tests/key_clef_tests.js
+++ b/tests/key_clef_tests.js
@@ -57,11 +57,11 @@ Vex.Flow.Test.ClefKeySignature.catchError = function(spec) {
   try {
     Vex.Flow.keySignature(spec);
   } catch (e) {
-    equals(e.code, "BadKeySignature", e.message);
+    equal(e.code, "BadKeySignature", e.message);
   }
 }
 
-Vex.Flow.Test.ClefKeySignature.parser = function(options) {
+Vex.Flow.Test.ClefKeySignature.parser = function() {
   expect(11);
   Vex.Flow.Test.ClefKeySignature.catchError("asdf");
   Vex.Flow.Test.ClefKeySignature.catchError("D!");
@@ -98,9 +98,9 @@ Vex.Flow.Test.ClefKeySignature.majorKeys = function(options, contextBuilder) {
   stave4.addClef("tenor");
   var keys = Vex.Flow.Test.ClefKeySignature.MAJOR_KEYS;
 
-  for (var i = 0; i < 8; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
-    var keySig2 = new Vex.Flow.KeySignature(keys[i]);
+  for (var n = 0; n < 8; ++n) {
+    var keySig = new Vex.Flow.KeySignature(keys[n]);
+    var keySig2 = new Vex.Flow.KeySignature(keys[n]);
     keySig.addToStave(stave);
     keySig2.addToStave(stave2);
   }
@@ -137,9 +137,9 @@ Vex.Flow.Test.ClefKeySignature.minorKeys = function(options, contextBuilder) {
   stave4.addClef("tenor");
   var keys = Vex.Flow.Test.ClefKeySignature.MINOR_KEYS;
 
-  for (var i = 0; i < 8; ++i) {
-    var keySig3 = new Vex.Flow.KeySignature(keys[i]);
-    var keySig4 = new Vex.Flow.KeySignature(keys[i]);
+  for (var n = 0; n < 8; ++n) {
+    var keySig3 = new Vex.Flow.KeySignature(keys[n]);
+    var keySig4 = new Vex.Flow.KeySignature(keys[n]);
     keySig3.addToStave(stave3);
     keySig4.addToStave(stave4);
   }
@@ -177,9 +177,9 @@ Vex.Flow.Test.ClefKeySignature.staveHelper = function(options, contextBuilder) {
   stave3.addClef("alto");
   stave4.addClef("tenor");
 
-  for (var i = 0; i < 8; ++i) {
-    stave.addKeySignature(keys[i]);
-    stave2.addKeySignature(keys[i]);
+  for (var n = 0; n < 8; ++n) {
+    stave.addKeySignature(keys[n]);
+    stave2.addKeySignature(keys[n]);
   }
 
   for (var i = 8; i < keys.length; ++i) {

--- a/tests/keymanager_tests.js
+++ b/tests/keymanager_tests.js
@@ -11,70 +11,70 @@ Vex.Flow.Test.KeyManager.Start = function() {
   test("Select Notes", Vex.Flow.Test.KeyManager.selectNotes);
 }
 
-Vex.Flow.Test.KeyManager.works = function(options) {
+Vex.Flow.Test.KeyManager.works = function() {
   // expect(1);
 
-  manager = new Vex.Flow.KeyManager("g");
-  equals(manager.getAccidental("f").accidental, "#");
+  var manager = new Vex.Flow.KeyManager("g");
+  equal(manager.getAccidental("f").accidental, "#");
 
   manager.setKey("a");
-  equals(manager.getAccidental("c").accidental, "#");
-  equals(manager.getAccidental("a").accidental, null);
-  equals(manager.getAccidental("f").accidental, "#");
+  equal(manager.getAccidental("c").accidental, "#");
+  equal(manager.getAccidental("a").accidental, null);
+  equal(manager.getAccidental("f").accidental, "#");
 
   manager.setKey("A");
-  equals(manager.getAccidental("c").accidental, "#");
-  equals(manager.getAccidental("a").accidental, null);
-  equals(manager.getAccidental("f").accidental, "#");
+  equal(manager.getAccidental("c").accidental, "#");
+  equal(manager.getAccidental("a").accidental, null);
+  equal(manager.getAccidental("f").accidental, "#");
 }
 
 Vex.Flow.Test.KeyManager.selectNotes = function(options) {
-  manager = new Vex.Flow.KeyManager("f");
-  equals(manager.selectNote("bb").note, "bb");
-  equals(manager.selectNote("bb").accidental, "b");
-  equals(manager.selectNote("g").note, "g");
-  equals(manager.selectNote("g").accidental, null);
-  equals(manager.selectNote("b").note, "b");
-  equals(manager.selectNote("b").accidental, null);
-  equals(manager.selectNote("a#").note, "bb");
-  equals(manager.selectNote("g#").note, "g#");
+  var manager = new Vex.Flow.KeyManager("f");
+  equal(manager.selectNote("bb").note, "bb");
+  equal(manager.selectNote("bb").accidental, "b");
+  equal(manager.selectNote("g").note, "g");
+  equal(manager.selectNote("g").accidental, null);
+  equal(manager.selectNote("b").note, "b");
+  equal(manager.selectNote("b").accidental, null);
+  equal(manager.selectNote("a#").note, "bb");
+  equal(manager.selectNote("g#").note, "g#");
 
   // Changes have no effect?
-  equals(manager.selectNote("g#").note, "g#");
-  equals(manager.selectNote("bb").note, "bb");
-  equals(manager.selectNote("bb").accidental, "b");
-  equals(manager.selectNote("g").note, "g");
-  equals(manager.selectNote("g").accidental, null);
-  equals(manager.selectNote("b").note, "b");
-  equals(manager.selectNote("b").accidental, null);
-  equals(manager.selectNote("a#").note, "bb");
-  equals(manager.selectNote("g#").note, "g#");
+  equal(manager.selectNote("g#").note, "g#");
+  equal(manager.selectNote("bb").note, "bb");
+  equal(manager.selectNote("bb").accidental, "b");
+  equal(manager.selectNote("g").note, "g");
+  equal(manager.selectNote("g").accidental, null);
+  equal(manager.selectNote("b").note, "b");
+  equal(manager.selectNote("b").accidental, null);
+  equal(manager.selectNote("a#").note, "bb");
+  equal(manager.selectNote("g#").note, "g#");
 
   // Changes should propagate
   manager.reset();
-  equals(manager.selectNote("g#").change, true);
-  equals(manager.selectNote("g#").change, false);
-  equals(manager.selectNote("g").change, true);
-  equals(manager.selectNote("g").change, false);
-  equals(manager.selectNote("g#").change, true);
+  equal(manager.selectNote("g#").change, true);
+  equal(manager.selectNote("g#").change, false);
+  equal(manager.selectNote("g").change, true);
+  equal(manager.selectNote("g").change, false);
+  equal(manager.selectNote("g#").change, true);
 
   manager.reset();
-  note = manager.selectNote("bb");
-  equals(note.change, false);
-  equals(note.accidental, "b");
+  var note = manager.selectNote("bb");
+  equal(note.change, false);
+  equal(note.accidental, "b");
   note = manager.selectNote("g");
-  equals(note.change, false);
-  equals(note.accidental, null);
+  equal(note.change, false);
+  equal(note.accidental, null);
   note = manager.selectNote("g#");
-  equals(note.change, true);
-  equals(note.accidental, "#");
+  equal(note.change, true);
+  equal(note.accidental, "#");
   note = manager.selectNote("g");
-  equals(note.change, true);
-  equals(note.accidental, null);
+  equal(note.change, true);
+  equal(note.accidental, null);
   note = manager.selectNote("g");
-  equals(note.change, false);
-  equals(note.accidental, null);
+  equal(note.change, false);
+  equal(note.accidental, null);
   note = manager.selectNote("g#");
-  equals(note.change, true);
-  equals(note.accidental, "#");
+  equal(note.change, true);
+  equal(note.accidental, "#");
 }

--- a/tests/keysignature_tests.js
+++ b/tests/keysignature_tests.js
@@ -54,11 +54,11 @@ Vex.Flow.Test.KeySignature.catchError = function(spec) {
   try {
     Vex.Flow.keySignature(spec);
   } catch (e) {  
-    equals(e.code, "BadKeySignature", e.message); 
+    equal(e.code, "BadKeySignature", e.message);
   }
 }
 
-Vex.Flow.Test.KeySignature.parser = function(options) {
+Vex.Flow.Test.KeySignature.parser = function() {
   expect(11);
   Vex.Flow.Test.KeySignature.catchError("asdf");
   Vex.Flow.Test.KeySignature.catchError("D!");
@@ -89,13 +89,14 @@ Vex.Flow.Test.KeySignature.majorKeys = function(options, contextBuilder) {
   var stave2 = new Vex.Flow.Stave(10, 90, 350);
   var keys = Vex.Flow.Test.KeySignature.MAJOR_KEYS;
 
+  var keySig = null;
   for (var i = 0; i < 8; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
+    keySig = new Vex.Flow.KeySignature(keys[i]);
     keySig.addToStave(stave);
   }
 
-  for (var i = 8; i < keys.length; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
+  for (var n = 8; n < keys.length; ++n) {
+    keySig = new Vex.Flow.KeySignature(keys[n]);
     keySig.addToStave(stave2);
   }
 
@@ -114,13 +115,14 @@ Vex.Flow.Test.KeySignature.minorKeys = function(options, contextBuilder) {
   var stave2 = new Vex.Flow.Stave(10, 90, 350);
   var keys = Vex.Flow.Test.KeySignature.MINOR_KEYS;
 
+  var keySig = null;
   for (var i = 0; i < 8; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
+    keySig = new Vex.Flow.KeySignature(keys[i]);
     keySig.addToStave(stave);
   }
 
-  for (var i = 8; i < keys.length; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
+  for (var n = 8; n < keys.length; ++n) {
+    keySig = new Vex.Flow.KeySignature(keys[n]);
     keySig.addToStave(stave2);
   }
 
@@ -143,8 +145,8 @@ Vex.Flow.Test.KeySignature.staveHelper = function(options, contextBuilder) {
     stave.addKeySignature(keys[i]);
   }
 
-  for (var i = 8; i < keys.length; ++i) {
-    stave2.addKeySignature(keys[i]);
+  for (var n = 8; n < keys.length; ++n) {
+    stave2.addKeySignature(keys[n]);
   }
 
   stave.setContext(ctx);

--- a/tests/modifier_tests.js
+++ b/tests/modifier_tests.js
@@ -13,10 +13,10 @@ Vex.Flow.Test.ModifierContext.Start = function() {
 
 Vex.Flow.Test.ModifierContext.width = function() {
   var mc = new Vex.Flow.ModifierContext();
-  equals(mc.getWidth(), 0, "New modifier context has no width");
+  equal(mc.getWidth(), 0, "New modifier context has no width");
 }
 
-Vex.Flow.Test.ModifierContext.management = function(options) {
+Vex.Flow.Test.ModifierContext.management = function() {
   var mc = new Vex.Flow.ModifierContext();
   var modifier1 = new Vex.Flow.Test.MockModifier;
   var modifier2 = new Vex.Flow.Test.MockModifier;
@@ -26,5 +26,5 @@ Vex.Flow.Test.ModifierContext.management = function(options) {
 
   var accidentals = mc.getModifiers("none");
 
-  equals(accidentals.length, 2, "Added two modifiers");
+  equal(accidentals.length, 2, "Added two modifiers");
 }

--- a/tests/music_tests.js
+++ b/tests/music_tests.js
@@ -19,201 +19,201 @@ Vex.Flow.Test.Music.Start = function() {
   test("Scale Intervals", Vex.Flow.Test.Music.scaleIntervals);
 }
 
-Vex.Flow.Test.Music.validNotes = function(options) {
+Vex.Flow.Test.Music.validNotes = function() {
   expect(10);
 
   var music = new Vex.Flow.Music();
 
   var parts = music.getNoteParts("c");
-  equals(parts.root, "c");
-  equals(parts.accidental, null);
+  equal(parts.root, "c");
+  equal(parts.accidental, null);
 
-  var parts = music.getNoteParts("C");
-  equals(parts.root, "c");
-  equals(parts.accidental, null);
+  parts = music.getNoteParts("C");
+  equal(parts.root, "c");
+  equal(parts.accidental, null);
 
-  var parts = music.getNoteParts("c#");
-  equals(parts.root, "c");
-  equals(parts.accidental, "#");
+  parts = music.getNoteParts("c#");
+  equal(parts.root, "c");
+  equal(parts.accidental, "#");
 
-  var parts = music.getNoteParts("c##");
-  equals(parts.root, "c");
-  equals(parts.accidental, "##");
+  parts = music.getNoteParts("c##");
+  equal(parts.root, "c");
+  equal(parts.accidental, "##");
 
   try {
     music.getNoteParts("r");
   } catch (e) {
-    equals(e.code, "BadArguments", "Invalid note: r");
+    equal(e.code, "BadArguments", "Invalid note: r");
   }
 
   try {
     music.getNoteParts("");
   } catch (e) {
-    equals(e.code, "BadArguments", "Invalid note: ''");
+    equal(e.code, "BadArguments", "Invalid note: ''");
   }
 }
 
-Vex.Flow.Test.Music.validKeys = function(options) {
+Vex.Flow.Test.Music.validKeys = function() {
   expect(18);
 
   var music = new Vex.Flow.Music();
 
   var parts = music.getKeyParts("c");
-  equals(parts.root, "c");
-  equals(parts.accidental, null);
-  equals(parts.type, "M");
+  equal(parts.root, "c");
+  equal(parts.accidental, null);
+  equal(parts.type, "M");
 
-  var parts = music.getKeyParts("d#");
-  equals(parts.root, "d");
-  equals(parts.accidental, "#");
-  equals(parts.type, "M");
+  parts = music.getKeyParts("d#");
+  equal(parts.root, "d");
+  equal(parts.accidental, "#");
+  equal(parts.type, "M");
 
-  var parts = music.getKeyParts("fbm");
-  equals(parts.root, "f");
-  equals(parts.accidental, "b");
-  equals(parts.type, "m");
+  parts = music.getKeyParts("fbm");
+  equal(parts.root, "f");
+  equal(parts.accidental, "b");
+  equal(parts.type, "m");
 
-  var parts = music.getKeyParts("c#mel");
-  equals(parts.root, "c");
-  equals(parts.accidental, "#");
-  equals(parts.type, "mel");
+  parts = music.getKeyParts("c#mel");
+  equal(parts.root, "c");
+  equal(parts.accidental, "#");
+  equal(parts.type, "mel");
 
-  var parts = music.getKeyParts("g#harm");
-  equals(parts.root, "g");
-  equals(parts.accidental, "#");
-  equals(parts.type, "harm");
+  parts = music.getKeyParts("g#harm");
+  equal(parts.root, "g");
+  equal(parts.accidental, "#");
+  equal(parts.type, "harm");
 
   try {
     music.getKeyParts("r");
   } catch (e) {
-    equals(e.code, "BadArguments", "Invalid key: r");
+    equal(e.code, "BadArguments", "Invalid key: r");
   }
 
   try {
     music.getKeyParts("");
   } catch (e) {
-    equals(e.code, "BadArguments", "Invalid key: ''");
+    equal(e.code, "BadArguments", "Invalid key: ''");
   }
 
   try {
     music.getKeyParts("#m");
   } catch (e) {
-    equals(e.code, "BadArguments", "Invalid key: #m");
+    equal(e.code, "BadArguments", "Invalid key: #m");
   }
 }
 
-Vex.Flow.Test.Music.noteValue = function(options) {
+Vex.Flow.Test.Music.noteValue = function() {
   expect(3);
 
   var music = new Vex.Flow.Music();
 
   var note = music.getNoteValue("c");
-  equals(note, 0);
+  equal(note, 0);
 
   try {
-    var note = music.getNoteValue("r");
+    music.getNoteValue("r");
   } catch(e) {
     ok(true, "Invalid note");
   }
 
-  var note = music.getNoteValue("f#");
-  equals(note, 6);
+  note = music.getNoteValue("f#");
+  equal(note, 6);
 }
 
-Vex.Flow.Test.Music.intervalValue = function(options) {
+Vex.Flow.Test.Music.intervalValue = function() {
   expect(2);
 
   var music = new Vex.Flow.Music();
 
   var value = music.getIntervalValue("b2");
-  equals(value, 1);
+  equal(value, 1);
 
   try {
-    value = music.getIntervalValue("7");
+    music.getIntervalValue("7");
   } catch(e) {
     ok(true, "Invalid note");
   }
 }
 
-Vex.Flow.Test.Music.relativeNotes = function(options) {
+Vex.Flow.Test.Music.relativeNotes = function() {
   expect(8);
 
   var music = new Vex.Flow.Music();
 
   var value = music.getRelativeNoteValue(music.getNoteValue("c"),
       music.getIntervalValue("b5"));
-  equals(value, 6);
+  equal(value, 6);
 
   try {
-    value = music.getRelativeNoteValue(music.getNoteValue("bc"),
+    music.getRelativeNoteValue(music.getNoteValue("bc"),
         music.getIntervalValue("b2"));
   } catch(e) {
     ok(true, "Invalid note");
   }
 
   try {
-    value = music.getRelativeNoteValue(music.getNoteValue("b"),
+    music.getRelativeNoteValue(music.getNoteValue("b"),
         music.getIntervalValue("p3"));
   } catch(e) {
     ok(true, "Invalid interval");
   }
 
   // Direction
-  var value = music.getRelativeNoteValue(music.getNoteValue("d"),
+  value = music.getRelativeNoteValue(music.getNoteValue("d"),
       music.getIntervalValue("2"), -1);
-  equals(value, 0);
+  equal(value, 0);
 
   try {
-    value = music.getRelativeNoteValue(music.getNoteValue("b"),
+    music.getRelativeNoteValue(music.getNoteValue("b"),
         music.getIntervalValue("p4"), 0);
   } catch(e) {
     ok(true, "Invalid direction");
   }
 
   // Rollover
-  var value = music.getRelativeNoteValue(music.getNoteValue("b"),
+  value = music.getRelativeNoteValue(music.getNoteValue("b"),
       music.getIntervalValue("b5"));
-  equals(value, 5);
+  equal(value, 5);
 
   // Reverse rollover
-  var value = music.getRelativeNoteValue(music.getNoteValue("c"),
+  value = music.getRelativeNoteValue(music.getNoteValue("c"),
       music.getIntervalValue("b2"), -1);
-  equals(value, 11);
+  equal(value, 11);
 
   // Practical tests
-  var value = music.getRelativeNoteValue(music.getNoteValue("g"),
+  value = music.getRelativeNoteValue(music.getNoteValue("g"),
       music.getIntervalValue("p5"));
-  equals(value, 2);
+  equal(value, 2);
 }
 
-Vex.Flow.Test.Music.relativeNoteNames = function(options) {
+Vex.Flow.Test.Music.relativeNoteNames = function() {
   expect(9);
 
   var music = new Vex.Flow.Music();
-  equals(music.getRelativeNoteName("c", music.getNoteValue("c")), "c");
-  equals(music.getRelativeNoteName("c", music.getNoteValue("db")), "c#");
-  equals(music.getRelativeNoteName("c#", music.getNoteValue("db")), "c#");
-  equals(music.getRelativeNoteName("e", music.getNoteValue("f#")), "e##");
-  equals(music.getRelativeNoteName("e", music.getNoteValue("d#")), "eb");
-  equals(music.getRelativeNoteName("e", music.getNoteValue("fb")), "e");
+  equal(music.getRelativeNoteName("c", music.getNoteValue("c")), "c");
+  equal(music.getRelativeNoteName("c", music.getNoteValue("db")), "c#");
+  equal(music.getRelativeNoteName("c#", music.getNoteValue("db")), "c#");
+  equal(music.getRelativeNoteName("e", music.getNoteValue("f#")), "e##");
+  equal(music.getRelativeNoteName("e", music.getNoteValue("d#")), "eb");
+  equal(music.getRelativeNoteName("e", music.getNoteValue("fb")), "e");
 
   try {
-    v = music.getRelativeNoteName("e", music.getNoteValue("g#"));
+    music.getRelativeNoteName("e", music.getNoteValue("g#"));
   } catch(e) {
     ok(true, "Too far");
   }
 
-  equals(music.getRelativeNoteName("b", music.getNoteValue("c#")), "b##");
-  equals(music.getRelativeNoteName("c", music.getNoteValue("b")), "cb");
+  equal(music.getRelativeNoteName("b", music.getNoteValue("c#")), "b##");
+  equal(music.getRelativeNoteName("c", music.getNoteValue("b")), "cb");
 }
 
-Vex.Flow.Test.Music.canonicalNotes = function(options) {
+Vex.Flow.Test.Music.canonicalNotes = function() {
   expect(3);
 
   var music = new Vex.Flow.Music();
 
-  equals(music.getCanonicalNoteName(0), "c");
-  equals(music.getCanonicalNoteName(2), "d");
+  equal(music.getCanonicalNoteName(0), "c");
+  equal(music.getCanonicalNoteName(2), "d");
 
   try {
     music.getCanonicalNoteName(-1);
@@ -222,13 +222,13 @@ Vex.Flow.Test.Music.canonicalNotes = function(options) {
   }
 }
 
-Vex.Flow.Test.Music.canonicalIntervals = function(options) {
+Vex.Flow.Test.Music.canonicalIntervals = function() {
   expect(3);
 
   var music = new Vex.Flow.Music();
 
-  equals(music.getCanonicalIntervalName(0), "unison");
-  equals(music.getCanonicalIntervalName(2), "M2");
+  equal(music.getCanonicalIntervalName(0), "unison");
+  equal(music.getCanonicalIntervalName(2), "M2");
 
   try {
     music.getCanonicalIntervalName(-1);
@@ -237,7 +237,7 @@ Vex.Flow.Test.Music.canonicalIntervals = function(options) {
   }
 }
 
-Vex.Flow.Test.Music.scaleTones = function(options) {
+Vex.Flow.Test.Music.scaleTones = function() {
   expect(24);
 
   // C Major
@@ -248,53 +248,54 @@ Vex.Flow.Test.Music.scaleTones = function(options) {
       music.getNoteValue("c"), Vex.Flow.Music.scales.major);
   var values = ["c", "d", "e", "f", "g", "a", "b"];
 
-  equals(c_major.length, 7);
+  equal(c_major.length, 7);
 
-  for (var i = 0; i < c_major.length; ++i) {
-    equals(music.getCanonicalNoteName(c_major[i]), values[i]);
+  for (var cm = 0; cm < c_major.length; ++cm) {
+    equal(music.getCanonicalNoteName(c_major[cm]), values[cm]);
   }
 
   // Dorian
   var c_dorian = music.getScaleTones(
       music.getNoteValue("c"), Vex.Flow.Music.scales.dorian);
-  var values = ["c", "d", "eb", "f", "g", "a", "bb"];
+  values = ["c", "d", "eb", "f", "g", "a", "bb"];
 
-  equals(c_dorian.length,  7);
-  for (var i = 0; i < c_dorian.length; ++i) {
-      var note = music.getCanonicalNoteName(c_dorian[i]);
-      equals(manager.selectNote(note).note, values[i]);
+  var note = null;
+  equal(c_dorian.length,  7);
+  for (var cd = 0; cd < c_dorian.length; ++cd) {
+      note = music.getCanonicalNoteName(c_dorian[cd]);
+      equal(manager.selectNote(note).note, values[cd]);
   }
 
   // Mixolydian
   var c_mixolydian = music.getScaleTones(
       music.getNoteValue("c"), Vex.Flow.Music.scales.mixolydian);
-  var values = ["c", "d", "e", "f", "g", "a", "bb"];
+  values = ["c", "d", "e", "f", "g", "a", "bb"];
 
-  equals(c_mixolydian.length,  7);
+  equal(c_mixolydian.length,  7);
 
   for (var i = 0; i < c_mixolydian.length; ++i) {
-      var note = music.getCanonicalNoteName(c_mixolydian[i]);
-      equals(manager.selectNote(note).note, values[i]);
+      note = music.getCanonicalNoteName(c_mixolydian[i]);
+      equal(manager.selectNote(note).note, values[i]);
   }
 }
 
-Vex.Flow.Test.Music.scaleIntervals = function(options) {
+Vex.Flow.Test.Music.scaleIntervals = function() {
   expect(6);
 
   var music = new Vex.Flow.Music();
 
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("c"), music.getNoteValue("d"))), "M2");
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("g"), music.getNoteValue("c"))), "p4");
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("c"), music.getNoteValue("c"))), "unison");
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("f"), music.getNoteValue("cb"))), "dim5");
 
   // Forwards and backwards
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("d"), music.getNoteValue("c"), 1)), "b7");
-  equals(music.getCanonicalIntervalName(music.getIntervalBetween(
+  equal(music.getCanonicalIntervalName(music.getIntervalBetween(
          music.getNoteValue("d"), music.getNoteValue("c"), -1)), "M2");
 }

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -38,10 +38,10 @@ Vex.Flow.Test.Stave.draw = function(options, contextBuilder) {
   stave.setContext(ctx);
   stave.draw();
 
-  equals(stave.getYForNote(0), 100, "getYForNote(0)");
-  equals(stave.getYForLine(5), 100, "getYForLine(5)");
-  equals(stave.getYForLine(0), 50, "getYForLine(0) - Top Line");
-  equals(stave.getYForLine(4), 90, "getYForLine(4) - Bottom Line");
+  equal(stave.getYForNote(0), 100, "getYForNote(0)");
+  equal(stave.getYForLine(5), 100, "getYForLine(5)");
+  equal(stave.getYForLine(0), 50, "getYForLine(0) - Top Line");
+  equal(stave.getYForLine(4), 90, "getYForLine(4) - Bottom Line");
 
   ok(true, "all pass");
 }
@@ -60,6 +60,8 @@ Vex.Flow.Test.Stave.drawVerticalBar = function(options, contextBuilder) {
 }
 
 Vex.Flow.Test.Stave.drawMultipleMeasures = function(options, contextBuilder) {
+  expect(0);
+
   // Get the rendering context
   var ctx = contextBuilder(options.canvas_sel, 550, 200);
 
@@ -114,6 +116,8 @@ Vex.Flow.Test.Stave.drawMultipleMeasures = function(options, contextBuilder) {
 }
 
 Vex.Flow.Test.Stave.drawRepeats = function(options, contextBuilder) {
+  expect(0);
+
   // Get the rendering context
   var ctx = contextBuilder(options.canvas_sel, 550, 120);
 
@@ -172,6 +176,8 @@ Vex.Flow.Test.Stave.drawRepeats = function(options, contextBuilder) {
 }
 
 Vex.Flow.Test.Stave.drawVoltaTest = function(options, contextBuilder) {
+  expect(0);
+
   // Get the rendering context
   var ctx = contextBuilder(options.canvas_sel, 725, 200);
 
@@ -185,7 +191,7 @@ Vex.Flow.Test.Stave.drawVoltaTest = function(options, contextBuilder) {
   mm1.setSection("A", 0);
   mm1.setContext(ctx).draw();
   var notesmm1 = [
-    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "w" }),
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "w" })
   ];
   // Helper function to justify and draw a 4/4 voice
   Vex.Flow.Formatter.FormatAndDraw(ctx, mm1, notesmm1);
@@ -287,6 +293,8 @@ Vex.Flow.Test.Stave.drawVoltaTest = function(options, contextBuilder) {
 }
 
 Vex.Flow.Test.Stave.drawTempo = function(options, contextBuilder) {
+  expect(0);
+
   var ctx = contextBuilder(options.canvas_sel, 725, 350);
   var padding = 10, x = 0, y = 50;
 

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -52,80 +52,80 @@ Vex.Flow.Test.StaveNote.ticks = function(options) {
 
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "w"});
-  equals(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "q"});
-  equals(note.getTicks(), BEAT, "Quarter note has 1 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT, "Quarter note has 1 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hd"});
-  equals(note.getTicks(), BEAT * 3, "Dotted half note has 3 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3, "Dotted half note has 3 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hdd"});
-  equals(note.getTicks(), BEAT * 3.5, "Double-dotted half note has 3.5 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3.5, "Double-dotted half note has 3.5 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hddd"});
-  equals(note.getTicks(), BEAT * 3.75, "Triple-dotted half note has 3.75 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3.75, "Triple-dotted half note has 3.75 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hdr"});
-  equals(note.getTicks(), BEAT * 3, "Dotted half rest has 3 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3, "Dotted half rest has 3 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hddr"});
-  equals(note.getTicks(), BEAT * 3.5, "Double-dotted half rest has 3.5 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3.5, "Double-dotted half rest has 3.5 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "hdddr"});
-  equals(note.getTicks(), BEAT * 3.75, "Triple-dotted half rest has 3.75 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3.75, "Triple-dotted half rest has 3.75 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "qdh"});
-  equals(note.getTicks(), BEAT * 1.5, "Dotted harmonic quarter note has 1.5 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.5, "Dotted harmonic quarter note has 1.5 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "qddh"});
-  equals(note.getTicks(), BEAT * 1.75, "Double-dotted harmonic quarter note has 1.75 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.75, "Double-dotted harmonic quarter note has 1.75 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "qdddh"});
-  equals(note.getTicks(), BEAT * 1.875, "Triple-dotted harmonic quarter note has 1.875 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.875, "Triple-dotted harmonic quarter note has 1.875 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8dm"});
-  equals(note.getTicks(), BEAT * 0.75, "Dotted muted 8th note has 0.75 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.75, "Dotted muted 8th note has 0.75 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8ddm"});
-  equals(note.getTicks(), BEAT * 0.875, "Double-dotted muted 8th note has 0.875 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.875, "Double-dotted muted 8th note has 0.875 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8dddm"});
-  equals(note.getTicks(), BEAT * 0.9375, "Triple-dotted muted 8th note has 0.9375 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.9375, "Triple-dotted muted 8th note has 0.9375 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
   try {
     new Vex.Flow.StaveNote(
         { keys: ["c/4", "e/4", "g/4"], duration: "8.7dddm"});
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid note duration '8.7' throws BadArguments exception");
   }
 
@@ -134,7 +134,7 @@ Vex.Flow.Test.StaveNote.ticks = function(options) {
         { keys: ["c/4", "e/4", "g/4"], duration: "2Z"});
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid note type 'Z' throws BadArguments exception");
   }
 
@@ -143,90 +143,90 @@ Vex.Flow.Test.StaveNote.ticks = function(options) {
         { keys: ["c/4", "e/4", "g/4"], duration: "2dddZ"});
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid note type 'Z' for dotted note throws BadArguments exception");
   }
 }
 
-Vex.Flow.Test.StaveNote.ticksNewApi = function(options) {
+Vex.Flow.Test.StaveNote.ticksNewApi = function() {
   var BEAT = 1 * Vex.Flow.RESOLUTION / 4;
 
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "1"});
-  equals(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "4"});
-  equals(note.getTicks(), BEAT, "Quarter note has 1 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT, "Quarter note has 1 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 1});
-  equals(note.getTicks(), BEAT * 3, "Dotted half note has 3 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3, "Dotted half note has 3 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 2});
-  equals(note.getTicks(), BEAT * 3.5, "Double-dotted half note has 3.5 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3.5, "Double-dotted half note has 3.5 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 3});
-  equals(note.getTicks(), BEAT * 3.75, "Triple-dotted half note has 3.75 beats");
-  equals(note.getNoteType(), "n", "Note type is 'n' for normal note");
+  equal(note.getTicks(), BEAT * 3.75, "Triple-dotted half note has 3.75 beats");
+  equal(note.getNoteType(), "n", "Note type is 'n' for normal note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 1, type: "r"});
-  equals(note.getTicks(), BEAT * 3, "Dotted half rest has 3 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3, "Dotted half rest has 3 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 2, type: "r"});
-  equals(note.getTicks(), BEAT * 3.5, "Double-dotted half rest has 3.5 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3.5, "Double-dotted half rest has 3.5 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "2", dots: 3, type: "r"});
-  equals(note.getTicks(), BEAT * 3.75, "Triple-dotted half rest has 3.75 beats");
-  equals(note.getNoteType(), "r", "Note type is 'r' for rest");
+  equal(note.getTicks(), BEAT * 3.75, "Triple-dotted half rest has 3.75 beats");
+  equal(note.getNoteType(), "r", "Note type is 'r' for rest");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "4", dots: 1, type: "h"});
-  equals(note.getTicks(), BEAT * 1.5, "Dotted harmonic quarter note has 1.5 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.5, "Dotted harmonic quarter note has 1.5 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "4", dots: 2, type: "h"});
-  equals(note.getTicks(), BEAT * 1.75, "Double-dotted harmonic quarter note has 1.75 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.75, "Double-dotted harmonic quarter note has 1.75 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "4", dots: 3, type: "h"});
-  equals(note.getTicks(), BEAT * 1.875, "Triple-dotted harmonic quarter note has 1.875 beats");
-  equals(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
+  equal(note.getTicks(), BEAT * 1.875, "Triple-dotted harmonic quarter note has 1.875 beats");
+  equal(note.getNoteType(), "h", "Note type is 'h' for harmonic note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8", dots: 1, type: "m"});
-  equals(note.getTicks(), BEAT * 0.75, "Dotted muted 8th note has 0.75 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.75, "Dotted muted 8th note has 0.75 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8", dots: 2, type: "m"});
-  equals(note.getTicks(), BEAT * 0.875, "Double-dotted muted 8th note has 0.875 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.875, "Double-dotted muted 8th note has 0.875 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
-  var note = new Vex.Flow.StaveNote(
+  note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "8", dots: 3, type: "m"});
-  equals(note.getTicks(), BEAT * 0.9375, "Triple-dotted muted 8th note has 0.9375 beats");
-  equals(note.getNoteType(), "m", "Note type is 'm' for muted note");
+  equal(note.getTicks(), BEAT * 0.9375, "Triple-dotted muted 8th note has 0.9375 beats");
+  equal(note.getNoteType(), "m", "Note type is 'm' for muted note");
 
   try {
     new Vex.Flow.StaveNote(
         { keys: ["c/4", "e/4", "g/4"], duration: "8.7"});
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid note duration '8.7' throws BadArguments exception");
   }
 
@@ -235,7 +235,7 @@ Vex.Flow.Test.StaveNote.ticksNewApi = function(options) {
         { keys: ["c/4", "e/4", "g/4"], duration: "8", dots: "three" });
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid number of dots 'three' (as string) throws BadArguments exception");
   }
 
@@ -244,38 +244,38 @@ Vex.Flow.Test.StaveNote.ticksNewApi = function(options) {
         { keys: ["c/4", "e/4", "g/4"], duration: "2", type: "Z"});
     throw new Error();
   } catch (e) {
-    equals(e.code, "BadArguments",
+    equal(e.code, "BadArguments",
         "Invalid note type 'Z' throws BadArguments exception");
   }
 }
 
 
-Vex.Flow.Test.StaveNote.stem = function(options) {
+Vex.Flow.Test.StaveNote.stem = function() {
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "g/4"], duration: "w"});
-  equals(note.getStemDirection(), Vex.Flow.StaveNote.STEM_UP,
+  equal(note.getStemDirection(), Vex.Flow.StaveNote.STEM_UP,
       "Default note has UP stem");
 }
 
-Vex.Flow.Test.StaveNote.staveLine = function(options) {
+Vex.Flow.Test.StaveNote.staveLine = function() {
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "a/4"], duration: "w"});
   var props = note.getKeyProps();
-  equals(props[0].line, 0, "C/4 on line 0");
-  equals(props[1].line, 1, "E/4 on line 1");
-  equals(props[2].line, 2.5, "A/4 on line 2.5");
+  equal(props[0].line, 0, "C/4 on line 0");
+  equal(props[1].line, 1, "E/4 on line 1");
+  equal(props[2].line, 2.5, "A/4 on line 2.5");
 
   var stave = new Vex.Flow.Stave(10, 10, 300);
   note.setStave(stave);
 
   var ys = note.getYs();
-  equals(ys.length, 3, "Chord should be rendered on three lines");
-  equals(ys[0], 100, "Line for C/4");
-  equals(ys[1], 90, "Line for E/4");
-  equals(ys[2], 75, "Line for A/4");
+  equal(ys.length, 3, "Chord should be rendered on three lines");
+  equal(ys[0], 100, "Line for C/4");
+  equal(ys[1], 90, "Line for E/4");
+  equal(ys[2], 75, "Line for A/4");
 }
 
-Vex.Flow.Test.StaveNote.width = function(options) {
+Vex.Flow.Test.StaveNote.width = function() {
   expect(1);
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "a/4"], duration: "w"});
@@ -283,12 +283,12 @@ Vex.Flow.Test.StaveNote.width = function(options) {
   try {
     var width = note.getWidth();
   } catch (e) {
-    equals(e.code, "UnformattedNote",
+    equal(e.code, "UnformattedNote",
         "Unformatted note should have no width");
   }
 }
 
-Vex.Flow.Test.StaveNote.tickContext = function(options) {
+Vex.Flow.Test.StaveNote.tickContext = function() {
   var note = new Vex.Flow.StaveNote(
       { keys: ["c/4", "e/4", "a/4"], duration: "w"});
   var tickContext = new Vex.Flow.TickContext();
@@ -297,7 +297,7 @@ Vex.Flow.Test.StaveNote.tickContext = function(options) {
   tickContext.setX(10);
   tickContext.setPadding(0);
 
-  equals(tickContext.getWidth(), 16.5);
+  equal(tickContext.getWidth(), 16.5);
 }
 
 Vex.Flow.Test.StaveNote.showNote = function(note_struct, stave, ctx, x) {
@@ -323,9 +323,9 @@ Vex.Flow.Test.StaveNote.draw = function(options, contextBuilder) {
 
   var lowerKeys = ["c/", "e/", "a/"];
   var higherKeys = ["c/", "e/", "a/"];
-  for (var i = 0; i < lowerKeys.length; i++) {
-    lowerKeys[i] = lowerKeys[i] + (4 + octaveShift);
-    higherKeys[i] = higherKeys[i] + (5 + octaveShift);
+  for (var k = 0; k < lowerKeys.length; k++) {
+    lowerKeys[k] = lowerKeys[k] + (4 + octaveShift);
+    higherKeys[k] = higherKeys[k] + (5 + octaveShift);
   }
 
   var restKeys = [ restKey ];
@@ -399,7 +399,7 @@ Vex.Flow.Test.StaveNote.displacements = function(options, contextBuilder) {
     { keys: ["b/3", "c/4", "e/4", "a/4", "b/5", "c/6", "e/6"], duration: "32",
       stem_direction: -1},
     { keys: ["b/3", "c/4", "e/4", "a/4", "b/5", "c/6", "e/6", "e/6"],
-      duration: "64", stem_direction: -1},
+      duration: "64", stem_direction: -1}
   ];
   expect(notes.length * 2);
 
@@ -448,7 +448,7 @@ Vex.Flow.Test.StaveNote.drawHarmonicAndMuted = function(options, contextBuilder)
     { keys: ["c/4", "e/4", "a/4"], duration: "8m", stem_direction: -1},
     { keys: ["c/4", "e/4", "a/4"], duration: "16m", stem_direction: -1},
     { keys: ["c/4", "e/4", "a/4"], duration: "32m", stem_direction: -1},
-    { keys: ["c/4", "e/4", "a/4"], duration: "64m", stem_direction: -1},
+    { keys: ["c/4", "e/4", "a/4"], duration: "64m", stem_direction: -1}
   ];
   expect(notes.length * 2);
 

--- a/tests/support/qunit.css
+++ b/tests/support/qunit.css
@@ -1,119 +1,231 @@
+/**
+ * QUnit v1.10.0pre - A JavaScript Unit Testing Framework
+ *
+ * http://qunitjs.com
+ *
+ * Copyright 2012 jQuery Foundation and other contributors
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
+ */
 
-ol#qunit-tests {
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	margin:0;
-	padding:0;
-	list-style-position:inside;
+/** Font Family and Sizes */
 
-	font-size: smaller;
-}
-ol#qunit-tests li{
-	padding:0.4em 0.5em 0.4em 2.5em;
-	border-bottom:1px solid #fff;
-	font-size:small;
-	list-style-position:inside;
-}
-ol#qunit-tests li ol{
-	box-shadow: inset 0px 2px 13px #999;
-	-moz-box-shadow: inset 0px 2px 13px #999;
-	-webkit-box-shadow: inset 0px 2px 13px #999;
-	margin-top:0.5em;
-	margin-left:0;
-	padding:0.5em;
-	background-color:#fff;
-	border-radius:15px;
-	-moz-border-radius: 15px;
-	-webkit-border-radius: 15px;
-}
-ol#qunit-tests li li{
-	border-bottom:none;
-	margin:0.5em;
-	background-color:#fff;
-	list-style-position: inside;
-	padding:0.4em 0.5em 0.4em 0.5em;
+#qunit-tests, #qunit-header, #qunit-banner, #qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult {
+	font-family: "Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial, sans-serif;
 }
 
-ol#qunit-tests li li.pass{
-	border-left:26px solid #C6E746;
-	background-color:#fff;
-	color:#5E740B;
-	}
-ol#qunit-tests li li.fail{
-	border-left:26px solid #EE5757;
-	background-color:#fff;
-	color:#710909;
+#qunit-testrunner-toolbar, #qunit-userAgent, #qunit-testresult, #qunit-tests li { font-size: small; }
+#qunit-tests { font-size: smaller; }
+
+
+/** Resets */
+
+#qunit-tests, #qunit-tests ol, #qunit-header, #qunit-banner, #qunit-userAgent, #qunit-testresult {
+	margin: 0;
+	padding: 0;
 }
-ol#qunit-tests li.pass{
-	background-color:#D2E0E6;
-	color:#528CE0;
+
+
+/** Header */
+
+#qunit-header {
+	padding: 0.5em 0 0.5em 1em;
+
+	color: #8699a4;
+	background-color: #0d3349;
+
+	font-size: 1.5em;
+	line-height: 1em;
+	font-weight: normal;
+
+	border-radius: 5px 5px 0 0;
+	-moz-border-radius: 5px 5px 0 0;
+	-webkit-border-top-right-radius: 5px;
+	-webkit-border-top-left-radius: 5px;
 }
-ol#qunit-tests li.fail{
-	background-color:#EE5757;
-	color:#000;
+
+#qunit-header a {
+	text-decoration: none;
+	color: #c2ccd1;
 }
-ol#qunit-tests li strong {
-	cursor:pointer;
+
+#qunit-header a:hover,
+#qunit-header a:focus {
+	color: #fff;
 }
-h1#qunit-header{
-	background-color:#0d3349;
-	margin:0;
-	padding:0.5em 0 0.5em 1em;
-	color:#fff;
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	border-top-right-radius:15px;
-	border-top-left-radius:15px;
-	-moz-border-radius-topright:15px;
-	-moz-border-radius-topleft:15px;
-	-webkit-border-top-right-radius:15px;
-	-webkit-border-top-left-radius:15px;
-	text-shadow: rgba(0, 0, 0, 0.5) 4px 4px 1px;
+
+#qunit-testrunner-toolbar label {
+	display: inline-block;
+	padding: 0 .5em 0 .1em;
 }
-h2#qunit-banner{
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	height:5px;
-	margin:0;
-	padding:0;
+
+#qunit-banner {
+	height: 5px;
 }
-h2#qunit-banner.qunit-pass{
-	background-color:#C6E746;
-}
-h2#qunit-banner.qunit-fail, #qunit-testrunner-toolbar {
-	background-color:#EE5757;
-}
+
 #qunit-testrunner-toolbar {
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	padding:0;
-	/*width:80%;*/
-	padding:0em 0 0.5em 2em;
-	font-size: small;
+	padding: 0.5em 0 0.5em 2em;
+	color: #5E740B;
+	background-color: #eee;
 }
-h2#qunit-userAgent {
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	background-color:#2b81af;
-	margin:0;
-	padding:0;
-	color:#fff;
-	font-size: small;
-	padding:0.5em 0 0.5em 2.5em;
+
+#qunit-userAgent {
+	padding: 0.5em 0 0.5em 2.5em;
+	background-color: #2b81af;
+	color: #fff;
 	text-shadow: rgba(0, 0, 0, 0.5) 2px 2px 1px;
 }
-p#qunit-testresult{
-	font-family:"Helvetica Neue Light", "HelveticaNeue-Light", "Helvetica Neue", Calibri, Helvetica, Arial;
-	margin:0;
-	font-size: small;
-	color:#2b81af;
-	border-bottom-right-radius:15px;
-	border-bottom-left-radius:15px;
-	-moz-border-radius-bottomright:15px;
-	-moz-border-radius-bottomleft:15px;
-	-webkit-border-bottom-right-radius:15px;
-	-webkit-border-bottom-left-radius:15px;
-	background-color:#D2E0E6;
-	padding:0.5em 0.5em 0.5em 2.5em;
+
+
+/** Tests: Pass/Fail */
+
+#qunit-tests {
+	list-style-position: inside;
 }
-strong b.fail{
-	color:#710909;
-	}
-strong b.pass{
-	color:#5E740B;
-	}
+
+#qunit-tests li {
+	padding: 0.4em 0.5em 0.4em 2.5em;
+	border-bottom: 1px solid #fff;
+	list-style-position: inside;
+}
+
+#qunit-tests.hidepass li.pass, #qunit-tests.hidepass li.running  {
+	display: none;
+}
+
+#qunit-tests li strong {
+	cursor: pointer;
+}
+
+#qunit-tests li a {
+	padding: 0.5em;
+	color: #c2ccd1;
+	text-decoration: none;
+}
+#qunit-tests li a:hover,
+#qunit-tests li a:focus {
+	color: #000;
+}
+
+#qunit-tests ol {
+	margin-top: 0.5em;
+	padding: 0.5em;
+
+	background-color: #fff;
+
+	border-radius: 5px;
+	-moz-border-radius: 5px;
+	-webkit-border-radius: 5px;
+}
+
+#qunit-tests table {
+	border-collapse: collapse;
+	margin-top: .2em;
+}
+
+#qunit-tests th {
+	text-align: right;
+	vertical-align: top;
+	padding: 0 .5em 0 0;
+}
+
+#qunit-tests td {
+	vertical-align: top;
+}
+
+#qunit-tests pre {
+	margin: 0;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+#qunit-tests del {
+	background-color: #e0f2be;
+	color: #374e0c;
+	text-decoration: none;
+}
+
+#qunit-tests ins {
+	background-color: #ffcaca;
+	color: #500;
+	text-decoration: none;
+}
+
+/*** Test Counts */
+
+#qunit-tests b.counts                       { color: black; }
+#qunit-tests b.passed                       { color: #5E740B; }
+#qunit-tests b.failed                       { color: #710909; }
+
+#qunit-tests li li {
+	padding: 5px;
+	background-color: #fff;
+	border-bottom: none;
+	list-style-position: inside;
+}
+
+/*** Passing Styles */
+
+#qunit-tests li li.pass {
+	color: #3c510c;
+	background-color: #fff;
+	border-left: 10px solid #C6E746;
+}
+
+#qunit-tests .pass                          { color: #528CE0; background-color: #D2E0E6; }
+#qunit-tests .pass .test-name               { color: #366097; }
+
+#qunit-tests .pass .test-actual,
+#qunit-tests .pass .test-expected           { color: #999999; }
+
+#qunit-banner.qunit-pass                    { background-color: #C6E746; }
+
+/*** Failing Styles */
+
+#qunit-tests li li.fail {
+	color: #710909;
+	background-color: #fff;
+	border-left: 10px solid #EE5757;
+	white-space: pre;
+}
+
+#qunit-tests > li:last-child {
+	border-radius: 0 0 5px 5px;
+	-moz-border-radius: 0 0 5px 5px;
+	-webkit-border-bottom-right-radius: 5px;
+	-webkit-border-bottom-left-radius: 5px;
+}
+
+#qunit-tests .fail                          { color: #000000; background-color: #EE5757; }
+#qunit-tests .fail .test-name,
+#qunit-tests .fail .module-name             { color: #000000; }
+
+#qunit-tests .fail .test-actual             { color: #EE5757; }
+#qunit-tests .fail .test-expected           { color: green;   }
+
+#qunit-banner.qunit-fail                    { background-color: #EE5757; }
+
+
+/** Result */
+
+#qunit-testresult {
+	padding: 0.5em 0.5em 0.5em 2.5em;
+
+	color: #2b81af;
+	background-color: #D2E0E6;
+
+	border-bottom: 1px solid white;
+}
+#qunit-testresult .module-name {
+	font-weight: bold;
+}
+
+/** Fixture */
+
+#qunit-fixture {
+	position: absolute;
+	top: -10000px;
+	left: -10000px;
+	width: 1000px;
+	height: 1000px;
+}

--- a/tests/support/qunit.js
+++ b/tests/support/qunit.js
@@ -1,34 +1,694 @@
-/*
- * QUnit - A JavaScript Unit Testing Framework
- * 
- * http://docs.jquery.com/QUnit
+/**
+ * QUnit v1.10.0pre - A JavaScript Unit Testing Framework
  *
- * Copyright (c) 2009 John Resig, Jörn Zaefferer
- * Dual licensed under the MIT (MIT-LICENSE.txt)
- * and GPL (GPL-LICENSE.txt) licenses.
+ * http://qunitjs.com
+ *
+ * Copyright 2012 jQuery Foundation and other contributors
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
  */
 
-(function(window) {
+(function( window ) {
 
-var QUnit = {
+var QUnit,
+	config,
+	onErrorFnPrev,
+	testId = 0,
+	fileName = (sourceFromStacktrace( 0 ) || "" ).replace(/(:\d+)+\)?/, "").replace(/.+\//, ""),
+	toString = Object.prototype.toString,
+	hasOwn = Object.prototype.hasOwnProperty,
+	// Keep a local reference to Date (GH-283)
+	Date = window.Date,
+	defined = {
+	setTimeout: typeof window.setTimeout !== "undefined",
+	sessionStorage: (function() {
+		var x = "qunit-test-string";
+		try {
+			sessionStorage.setItem( x, x );
+			sessionStorage.removeItem( x );
+			return true;
+		} catch( e ) {
+			return false;
+		}
+	}())
+};
+
+function Test( settings ) {
+	extend( this, settings );
+	this.assertions = [];
+	this.testNumber = ++Test.count;
+}
+
+Test.count = 0;
+
+Test.prototype = {
+	init: function() {
+		var a, b, li,
+        tests = id( "qunit-tests" );
+
+		if ( tests ) {
+			b = document.createElement( "strong" );
+			b.innerHTML = this.name;
+
+			// `a` initialized at top of scope
+			a = document.createElement( "a" );
+			a.innerHTML = "Rerun";
+			a.href = QUnit.url({ testNumber: this.testNumber });
+
+			li = document.createElement( "li" );
+			li.appendChild( b );
+			li.appendChild( a );
+			li.className = "running";
+			li.id = this.id = "qunit-test-output" + testId++;
+
+			tests.appendChild( li );
+		}
+	},
+	setup: function() {
+		if ( this.module !== config.previousModule ) {
+			if ( config.previousModule ) {
+				runLoggingCallbacks( "moduleDone", QUnit, {
+					name: config.previousModule,
+					failed: config.moduleStats.bad,
+					passed: config.moduleStats.all - config.moduleStats.bad,
+					total: config.moduleStats.all
+				});
+			}
+			config.previousModule = this.module;
+			config.moduleStats = { all: 0, bad: 0 };
+			runLoggingCallbacks( "moduleStart", QUnit, {
+				name: this.module
+			});
+		} else if ( config.autorun ) {
+			runLoggingCallbacks( "moduleStart", QUnit, {
+				name: this.module
+			});
+		}
+
+		config.current = this;
+
+		this.testEnvironment = extend({
+			setup: function() {},
+			teardown: function() {}
+		}, this.moduleTestEnvironment );
+
+		runLoggingCallbacks( "testStart", QUnit, {
+			name: this.testName,
+			module: this.module
+		});
+
+		// allow utility functions to access the current test environment
+		// TODO why??
+		QUnit.current_testEnvironment = this.testEnvironment;
+
+		if ( !config.pollution ) {
+			saveGlobal();
+		}
+		if ( config.notrycatch ) {
+			this.testEnvironment.setup.call( this.testEnvironment );
+			return;
+		}
+		try {
+			this.testEnvironment.setup.call( this.testEnvironment );
+		} catch( e ) {
+			QUnit.pushFailure( "Setup failed on " + this.testName + ": " + e.message, extractStacktrace( e, 1 ) );
+		}
+	},
+	run: function() {
+		config.current = this;
+
+		var running = id( "qunit-testresult" );
+
+		if ( running ) {
+			running.innerHTML = "Running: <br/>" + this.name;
+		}
+
+		if ( this.async ) {
+			QUnit.stop();
+		}
+
+		if ( config.notrycatch ) {
+			this.callback.call( this.testEnvironment, QUnit.assert );
+			return;
+		}
+
+		try {
+			this.callback.call( this.testEnvironment, QUnit.assert );
+		} catch( e ) {
+			QUnit.pushFailure( "Died on test #" + (this.assertions.length + 1) + " " + this.stack + ": " + e.message, extractStacktrace( e, 0 ) );
+			// else next test will carry the responsibility
+			saveGlobal();
+
+			// Restart the tests if they're blocking
+			if ( config.blocking ) {
+				QUnit.start();
+			}
+		}
+	},
+	teardown: function() {
+		config.current = this;
+		if ( config.notrycatch ) {
+			this.testEnvironment.teardown.call( this.testEnvironment );
+			return;
+		} else {
+			try {
+				this.testEnvironment.teardown.call( this.testEnvironment );
+			} catch( e ) {
+				QUnit.pushFailure( "Teardown failed on " + this.testName + ": " + e.message, extractStacktrace( e, 1 ) );
+			}
+		}
+		checkPollution();
+	},
+	finish: function() {
+		config.current = this;
+		if ( config.requireExpects && this.expected == null ) {
+			QUnit.pushFailure( "Expected number of assertions to be defined, but expect() was not called.", this.stack );
+		} else if ( this.expected != null && this.expected != this.assertions.length ) {
+			QUnit.pushFailure( "Expected " + this.expected + " assertions, but " + this.assertions.length + " were run", this.stack );
+		} else if ( this.expected == null && !this.assertions.length ) {
+			QUnit.pushFailure( "Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.", this.stack );
+		}
+
+		var assertion, a, b, i, li, ol,
+			test = this,
+			good = 0,
+			bad = 0,
+			tests = id( "qunit-tests" );
+
+		config.stats.all += this.assertions.length;
+		config.moduleStats.all += this.assertions.length;
+
+		if ( tests ) {
+			ol = document.createElement( "ol" );
+
+			for ( i = 0; i < this.assertions.length; i++ ) {
+				assertion = this.assertions[i];
+
+				li = document.createElement( "li" );
+				li.className = assertion.result ? "pass" : "fail";
+				li.innerHTML = assertion.message || ( assertion.result ? "okay" : "failed" );
+				ol.appendChild( li );
+
+				if ( assertion.result ) {
+					good++;
+				} else {
+					bad++;
+					config.stats.bad++;
+					config.moduleStats.bad++;
+				}
+			}
+
+			// store result when possible
+			if ( QUnit.config.reorder && defined.sessionStorage ) {
+				if ( bad ) {
+					sessionStorage.setItem( "qunit-test-" + this.module + "-" + this.testName, bad );
+				} else {
+					sessionStorage.removeItem( "qunit-test-" + this.module + "-" + this.testName );
+				}
+			}
+
+			if ( bad === 0 ) {
+				ol.style.display = "none";
+			}
+
+			// `b` initialized at top of scope
+			b = document.createElement( "strong" );
+			b.innerHTML = this.name + " <b class='counts'>(<b class='failed'>" + bad + "</b>, <b class='passed'>" + good + "</b>, " + this.assertions.length + ")</b>";
+
+			addEvent(b, "click", function() {
+				var next = b.nextSibling.nextSibling,
+					display = next.style.display;
+				next.style.display = display === "none" ? "block" : "none";
+			});
+
+			addEvent(b, "dblclick", function( e ) {
+				var target = e && e.target ? e.target : window.event.srcElement;
+				if ( target.nodeName.toLowerCase() == "span" || target.nodeName.toLowerCase() == "b" ) {
+					target = target.parentNode;
+				}
+				if ( window.location && target.nodeName.toLowerCase() === "strong" ) {
+					window.location = QUnit.url({ testNumber: test.testNumber });
+				}
+			});
+
+			// `li` initialized at top of scope
+			li = id( this.id );
+			li.className = bad ? "fail" : "pass";
+			li.removeChild( li.firstChild );
+			a = li.firstChild;
+			li.appendChild( b );
+			li.appendChild ( a );
+			li.appendChild( ol );
+
+		} else {
+			for ( i = 0; i < this.assertions.length; i++ ) {
+				if ( !this.assertions[i].result ) {
+					bad++;
+					config.stats.bad++;
+					config.moduleStats.bad++;
+				}
+			}
+		}
+
+		runLoggingCallbacks( "testDone", QUnit, {
+			name: this.testName,
+			module: this.module,
+			failed: bad,
+			passed: this.assertions.length - bad,
+			total: this.assertions.length
+		});
+
+		QUnit.reset();
+
+		config.current = undefined;
+	},
+
+	queue: function() {
+		var bad,
+			test = this;
+
+		synchronize(function() {
+			test.init();
+		});
+		function run() {
+			// each of these can by async
+			synchronize(function() {
+				test.setup();
+			});
+			synchronize(function() {
+				test.run();
+			});
+			synchronize(function() {
+				test.teardown();
+			});
+			synchronize(function() {
+				test.finish();
+			});
+		}
+
+		// `bad` initialized at top of scope
+		// defer when previous test run passed, if storage is available
+		bad = QUnit.config.reorder && defined.sessionStorage &&
+						+sessionStorage.getItem( "qunit-test-" + this.module + "-" + this.testName );
+
+		if ( bad ) {
+			run();
+		} else {
+			synchronize( run, true );
+		}
+	}
+};
+
+// Root QUnit object.
+// `QUnit` initialized at top of scope
+QUnit = {
+
+	// call on start of module test to prepend name to all tests
+	module: function( name, testEnvironment ) {
+		config.currentModule = name;
+		config.currentModuleTestEnviroment = testEnvironment;
+	},
+
+	asyncTest: function( testName, expected, callback ) {
+		if ( arguments.length === 2 ) {
+			callback = expected;
+			expected = null;
+		}
+
+		QUnit.test( testName, expected, callback, true );
+	},
+
+	test: function( testName, expected, callback, async ) {
+		var test,
+			name = "<span class='test-name'>" + escapeInnerText( testName ) + "</span>";
+
+		if ( arguments.length === 2 ) {
+			callback = expected;
+			expected = null;
+		}
+
+		if ( config.currentModule ) {
+			name = "<span class='module-name'>" + config.currentModule + "</span>: " + name;
+		}
+
+		test = new Test({
+			name: name,
+			testName: testName,
+			expected: expected,
+			async: async,
+			callback: callback,
+			module: config.currentModule,
+			moduleTestEnvironment: config.currentModuleTestEnviroment,
+			stack: sourceFromStacktrace( 2 )
+		});
+
+		if ( !validTest( test ) ) {
+			return;
+		}
+
+		test.queue();
+	},
+
+	// Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
+	expect: function( asserts ) {
+		config.current.expected = asserts;
+	},
+
+	start: function( count ) {
+		config.semaphore -= count || 1;
+		// don't start until equal number of stop-calls
+		if ( config.semaphore > 0 ) {
+			return;
+		}
+		// ignore if start is called more often then stop
+		if ( config.semaphore < 0 ) {
+			config.semaphore = 0;
+		}
+		// A slight delay, to avoid any current callbacks
+		if ( defined.setTimeout ) {
+			window.setTimeout(function() {
+				if ( config.semaphore > 0 ) {
+					return;
+				}
+				if ( config.timeout ) {
+					clearTimeout( config.timeout );
+				}
+
+				config.blocking = false;
+				process( true );
+			}, 13);
+		} else {
+			config.blocking = false;
+			process( true );
+		}
+	},
+
+	stop: function( count ) {
+		config.semaphore += count || 1;
+		config.blocking = true;
+
+		if ( config.testTimeout && defined.setTimeout ) {
+			clearTimeout( config.timeout );
+			config.timeout = window.setTimeout(function() {
+				QUnit.ok( false, "Test timed out" );
+				config.semaphore = 1;
+				QUnit.start();
+			}, config.testTimeout );
+		}
+	}
+};
+
+// Asssert helpers
+// All of these must call either QUnit.push() or manually do:
+// - runLoggingCallbacks( "log", .. );
+// - config.current.assertions.push({ .. });
+QUnit.assert = {
+	/**
+	 * Asserts rough true-ish result.
+	 * @name ok
+	 * @function
+	 * @example ok( "asdfasdf".length > 5, "There must be at least 5 chars" );
+	 */
+	ok: function( result, msg ) {
+		if ( !config.current ) {
+			throw new Error( "ok() assertion outside test context, was " + sourceFromStacktrace(2) );
+		}
+		result = !!result;
+
+		var source,
+			details = {
+				result: result,
+				message: msg
+			};
+
+		msg = escapeInnerText( msg || (result ? "okay" : "failed" ) );
+		msg = "<span class='test-message'>" + msg + "</span>";
+
+		if ( !result ) {
+			source = sourceFromStacktrace( 2 );
+			if ( source ) {
+				details.source = source;
+				msg += "<table><tr class='test-source'><th>Source: </th><td><pre>" + escapeInnerText( source ) + "</pre></td></tr></table>";
+			}
+		}
+		runLoggingCallbacks( "log", QUnit, details );
+		config.current.assertions.push({
+			result: result,
+			message: msg
+		});
+	},
+
+	/**
+	 * Assert that the first two arguments are equal, with an optional message.
+	 * Prints out both actual and expected values.
+	 * @name equal
+	 * @function
+	 * @example equal( format( "Received {0} bytes.", 2), "Received 2 bytes.", "format() replaces {0} with next argument" );
+	 */
+	equal: function( actual, expected, message ) {
+		QUnit.push( expected == actual, actual, expected, message );
+	},
+
+	/**
+	 * @name notEqual
+	 * @function
+	 */
+	notEqual: function( actual, expected, message ) {
+		QUnit.push( expected != actual, actual, expected, message );
+	},
+
+	/**
+	 * @name deepEqual
+	 * @function
+	 */
+	deepEqual: function( actual, expected, message ) {
+		QUnit.push( QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name notDeepEqual
+	 * @function
+	 */
+	notDeepEqual: function( actual, expected, message ) {
+		QUnit.push( !QUnit.equiv(actual, expected), actual, expected, message );
+	},
+
+	/**
+	 * @name strictEqual
+	 * @function
+	 */
+	strictEqual: function( actual, expected, message ) {
+		QUnit.push( expected === actual, actual, expected, message );
+	},
+
+	/**
+	 * @name notStrictEqual
+	 * @function
+	 */
+	notStrictEqual: function( actual, expected, message ) {
+		QUnit.push( expected !== actual, actual, expected, message );
+	},
+
+	throws: function( block, expected, message ) {
+		var actual,
+			ok = false;
+
+		// 'expected' is optional
+		if ( typeof expected === "string" ) {
+			message = expected;
+			expected = null;
+		}
+
+		config.current.ignoreGlobalErrors = true;
+		try {
+			block.call( config.current.testEnvironment );
+		} catch (e) {
+			actual = e;
+		}
+		config.current.ignoreGlobalErrors = false;
+
+		if ( actual ) {
+			// we don't want to validate thrown error
+			if ( !expected ) {
+				ok = true;
+			// expected is a regexp
+			} else if ( QUnit.objectType( expected ) === "regexp" ) {
+				ok = expected.test( actual );
+			// expected is a constructor
+			} else if ( actual instanceof expected ) {
+				ok = true;
+			// expected is a validation function which returns true is validation passed
+			} else if ( expected.call( {}, actual ) === true ) {
+				ok = true;
+			}
+
+			QUnit.push( ok, actual, null, message );
+		} else {
+			QUnit.pushFailure( message, null, 'No exception was thrown.' );
+		}
+	}
+};
+
+/**
+ * @deprecate since 1.8.0
+ * Kept assertion helpers in root for backwards compatibility
+ */
+extend( QUnit, QUnit.assert );
+
+/**
+ * @deprecated since 1.9.0
+ * Kept global "raises()" for backwards compatibility
+ */
+QUnit.raises = QUnit.assert.throws;
+
+/**
+ * @deprecated since 1.0.0, replaced with error pushes since 1.3.0
+ * Kept to avoid TypeErrors for undefined methods.
+ */
+QUnit.equals = function() {
+	QUnit.push( false, false, false, "QUnit.equals has been deprecated since 2009 (e88049a0), use QUnit.equal instead" );
+};
+QUnit.same = function() {
+	QUnit.push( false, false, false, "QUnit.same has been deprecated since 2009 (e88049a0), use QUnit.deepEqual instead" );
+};
+
+// We want access to the constructor's prototype
+(function() {
+	function F() {}
+	F.prototype = QUnit;
+	QUnit = new F();
+	// Make F QUnit's constructor so that we can add to the prototype later
+	QUnit.constructor = F;
+}());
+
+/**
+ * Config object: Maintain internal state
+ * Later exposed as QUnit.config
+ * `config` initialized at top of scope
+ */
+config = {
+	// The queue of tests to run
+	queue: [],
+
+	// block until document ready
+	blocking: true,
+
+	// when enabled, show only failing tests
+	// gets persisted through sessionStorage and can be changed in UI via checkbox
+	hidepassed: false,
+
+	// by default, run previously failed tests first
+	// very useful in combination with "Hide passed tests" checked
+	reorder: true,
+
+	// by default, modify document.title when suite is done
+	altertitle: true,
+
+	// when enabled, all tests must call expect()
+	requireExpects: false,
+
+	// add checkboxes that are persisted in the query-string
+	// when enabled, the id is set to `true` as a `QUnit.config` property
+	urlConfig: [
+		{
+			id: "noglobals",
+			label: "Check for Globals",
+			tooltip: "Enabling this will test if any test introduces new properties on the `window` object. Stored as query-strings."
+		},
+		{
+			id: "notrycatch",
+			label: "No try-catch",
+			tooltip: "Enabling this will run tests outside of a try-catch block. Makes debugging exceptions in IE reasonable. Stored as query-strings."
+		}
+	],
+
+	// logging callback queues
+	begin: [],
+	done: [],
+	log: [],
+	testStart: [],
+	testDone: [],
+	moduleStart: [],
+	moduleDone: []
+};
+
+// Initialize more QUnit.config and QUnit.urlParams
+(function() {
+	var i,
+		location = window.location || { search: "", protocol: "file:" },
+		params = location.search.slice( 1 ).split( "&" ),
+		length = params.length,
+		urlParams = {},
+		current;
+
+	if ( params[ 0 ] ) {
+		for ( i = 0; i < length; i++ ) {
+			current = params[ i ].split( "=" );
+			current[ 0 ] = decodeURIComponent( current[ 0 ] );
+			// allow just a key to turn on a flag, e.g., test.html?noglobals
+			current[ 1 ] = current[ 1 ] ? decodeURIComponent( current[ 1 ] ) : true;
+			urlParams[ current[ 0 ] ] = current[ 1 ];
+		}
+	}
+
+	QUnit.urlParams = urlParams;
+
+	// String search anywhere in moduleName+testName
+	config.filter = urlParams.filter;
+
+	// Exact match of the module name
+	config.module = urlParams.module;
+
+	config.testNumber = parseInt( urlParams.testNumber, 10 ) || null;
+
+	// Figure out if we're running the tests from a server or not
+	QUnit.isLocal = location.protocol === "file:";
+}());
+
+// Export global variables, unless an 'exports' object exists,
+// in that case we assume we're in CommonJS (dealt with on the bottom of the script)
+if ( typeof exports === "undefined" ) {
+	extend( window, QUnit );
+
+	// Expose QUnit object
+	window.QUnit = QUnit;
+}
+
+// Extend QUnit object,
+// these after set here because they should not be exposed as global functions
+extend( QUnit, {
+	config: config,
 
 	// Initialize the configuration options
 	init: function() {
-		config = {
+		extend( config, {
 			stats: { all: 0, bad: 0 },
 			moduleStats: { all: 0, bad: 0 },
-			started: +new Date,
+			started: +new Date(),
 			updateRate: 1000,
 			blocking: false,
+			autostart: true,
 			autorun: false,
-			assertions: [],
-			filters: [],
-			queue: []
-		};
+			filter: "",
+			queue: [],
+			semaphore: 0
+		});
 
-		var tests = id("qunit-tests"),
-			banner = id("qunit-banner"),
-			result = id("qunit-testresult");
+		var tests, banner, result,
+			qunit = id( "qunit" );
+
+		if ( qunit ) {
+			qunit.innerHTML =
+				"<h1 id='qunit-header'>" + escapeInnerText( document.title ) + "</h1>" +
+				"<h2 id='qunit-banner'></h2>" +
+				"<div id='qunit-testrunner-toolbar'></div>" +
+				"<h2 id='qunit-userAgent'></h2>" +
+				"<ol id='qunit-tests'></ol>";
+		}
+
+		tests = id( "qunit-tests" );
+		banner = id( "qunit-banner" );
+		result = id( "qunit-testresult" );
 
 		if ( tests ) {
 			tests.innerHTML = "";
@@ -41,603 +701,590 @@ var QUnit = {
 		if ( result ) {
 			result.parentNode.removeChild( result );
 		}
-	},
-	
-	// call on start of module test to prepend name to all tests
-	module: function(name, testEnvironment) {
-		config.currentModule = name;
 
-		synchronize(function() {
-			if ( config.currentModule ) {
-				QUnit.moduleDone( config.currentModule, config.moduleStats.bad, config.moduleStats.all );
-			}
-
-			config.currentModule = name;
-			config.moduleTestEnvironment = testEnvironment;
-			config.moduleStats = { all: 0, bad: 0 };
-
-			QUnit.moduleStart( name, testEnvironment );
-		});
-	},
-
-	asyncTest: function(testName, expected, callback) {
-		if ( arguments.length === 2 ) {
-			callback = expected;
-			expected = 0;
-		}
-
-		QUnit.test(testName, expected, callback, true);
-	},
-	
-	test: function(testName, expected, callback, async) {
-		var name = testName, testEnvironment, testEnvironmentArg;
-
-		if ( arguments.length === 2 ) {
-			callback = expected;
-			expected = null;
-		}
-		// is 2nd argument a testEnvironment?
-		if ( expected && typeof expected === 'object') {
-			testEnvironmentArg =  expected;
-			expected = null;
-		}
-
-		if ( config.currentModule ) {
-			name = config.currentModule + " module: " + name;
-		}
-
-		if ( !validTest(name) ) {
-			return;
-		}
-
-		synchronize(function() {
-			QUnit.testStart( testName );
-
-			testEnvironment = extend({
-				setup: function() {},
-				teardown: function() {}
-			}, config.moduleTestEnvironment);
-			if (testEnvironmentArg) {
-				extend(testEnvironment,testEnvironmentArg);
-			}
-
-			// allow utility functions to access the current test environment
-			QUnit.current_testEnvironment = testEnvironment;
-			
-			config.assertions = [];
-			config.expected = expected;
-
-			try {
-				if ( !config.pollution ) {
-					saveGlobal();
-				}
-
-				testEnvironment.setup.call(testEnvironment);
-			} catch(e) {
-				QUnit.ok( false, "Setup failed on " + name + ": " + e.message );
-			}
-
-			if ( async ) {
-				QUnit.stop();
-			}
-
-			try {
-				callback.call(testEnvironment);
-			} catch(e) {
-				fail("Test " + name + " died, exception and test follows", e, callback);
-				QUnit.ok( false, "Died on test #" + (config.assertions.length + 1) + ": " + e.message );
-				// else next test will carry the responsibility
-				saveGlobal();
-
-				// Restart the tests if they're blocking
-				if ( config.blocking ) {
-					start();
-				}
-			}
-		});
-
-		synchronize(function() {
-			try {
-				checkPollution();
-				testEnvironment.teardown.call(testEnvironment);
-			} catch(e) {
-				QUnit.ok( false, "Teardown failed on " + name + ": " + e.message );
-			}
-
-			try {
-				QUnit.reset();
-			} catch(e) {
-				fail("reset() failed, following Test " + name + ", exception and reset fn follows", e, reset);
-			}
-
-			if ( config.expected && config.expected != config.assertions.length ) {
-				QUnit.ok( false, "Expected " + config.expected + " assertions, but " + config.assertions.length + " were run" );
-			}
-
-			var good = 0, bad = 0,
-				tests = id("qunit-tests");
-
-			config.stats.all += config.assertions.length;
-			config.moduleStats.all += config.assertions.length;
-
-			if ( tests ) {
-				var ol  = document.createElement("ol");
-				ol.style.display = "none";
-
-				for ( var i = 0; i < config.assertions.length; i++ ) {
-					var assertion = config.assertions[i];
-
-					var li = document.createElement("li");
-					li.className = assertion.result ? "pass" : "fail";
-					li.appendChild(document.createTextNode(assertion.message || "(no message)"));
-					ol.appendChild( li );
-
-					if ( assertion.result ) {
-						good++;
-					} else {
-						bad++;
-						config.stats.bad++;
-						config.moduleStats.bad++;
-					}
-				}
-
-				var b = document.createElement("strong");
-				b.innerHTML = name + " <b style='color:black;'>(<b class='fail'>" + bad + "</b>, <b class='pass'>" + good + "</b>, " + config.assertions.length + ")</b>";
-				
-				addEvent(b, "click", function() {
-					var next = b.nextSibling, display = next.style.display;
-					next.style.display = display === "none" ? "block" : "none";
-				});
-				
-				addEvent(b, "dblclick", function(e) {
-					var target = e && e.target ? e.target : window.event.srcElement;
-					if ( target.nodeName.toLowerCase() === "strong" ) {
-						var text = "", node = target.firstChild;
-
-						while ( node.nodeType === 3 ) {
-							text += node.nodeValue;
-							node = node.nextSibling;
-						}
-
-						text = text.replace(/(^\s*|\s*$)/g, "");
-
-						if ( window.location ) {
-							window.location.href = window.location.href.match(/^(.+?)(\?.*)?$/)[1] + "?" + encodeURIComponent(text);
-						}
-					}
-				});
-
-				var li = document.createElement("li");
-				li.className = bad ? "fail" : "pass";
-				li.appendChild( b );
-				li.appendChild( ol );
-				tests.appendChild( li );
-
-				if ( bad ) {
-					var toolbar = id("qunit-testrunner-toolbar");
-					if ( toolbar ) {
-						toolbar.style.display = "block";
-						id("qunit-filter-pass").disabled = null;
-						id("qunit-filter-missing").disabled = null;
-					}
-				}
-
-			} else {
-				for ( var i = 0; i < config.assertions.length; i++ ) {
-					if ( !config.assertions[i].result ) {
-						bad++;
-						config.stats.bad++;
-						config.moduleStats.bad++;
-					}
-				}
-			}
-
-			QUnit.testDone( testName, bad, config.assertions.length );
-
-			if ( !window.setTimeout && !config.queue.length ) {
-				done();
-			}
-		});
-
-		if ( window.setTimeout && !config.doneTimer ) {
-			config.doneTimer = window.setTimeout(function(){
-				if ( !config.queue.length ) {
-					done();
-				} else {
-					synchronize( done );
-				}
-			}, 13);
+		if ( tests ) {
+			result = document.createElement( "p" );
+			result.id = "qunit-testresult";
+			result.className = "result";
+			tests.parentNode.insertBefore( result, tests );
+			result.innerHTML = "Running...<br/>&nbsp;";
 		}
 	},
-	
-	/**
-	 * Specify the number of expected assertions to gurantee that failed test (no assertions are run at all) don't slip through.
-	 */
-	expect: function(asserts) {
-		config.expected = asserts;
-	},
 
-	/**
-	 * Asserts true.
-	 * @example ok( "asdfasdf".length > 5, "There must be at least 5 chars" );
-	 */
-	ok: function(a, msg) {
-		QUnit.log(a, msg);
-
-		config.assertions.push({
-			result: !!a,
-			message: msg
-		});
-	},
-
-	/**
-	 * Checks that the first two arguments are equal, with an optional message.
-	 * Prints out both actual and expected values.
-	 *
-	 * Prefered to ok( actual == expected, message )
-	 *
-	 * @example equal( format("Received {0} bytes.", 2), "Received 2 bytes." );
-	 *
-	 * @param Object actual
-	 * @param Object expected
-	 * @param String message (optional)
-	 */
-	equal: function(actual, expected, message) {
-		push(expected == actual, actual, expected, message);
-	},
-
-	notEqual: function(actual, expected, message) {
-		push(expected != actual, actual, expected, message);
-	},
-	
-	deepEqual: function(a, b, message) {
-		push(QUnit.equiv(a, b), a, b, message);
-	},
-
-	notDeepEqual: function(a, b, message) {
-		push(!QUnit.equiv(a, b), a, b, message);
-	},
-
-	strictEqual: function(actual, expected, message) {
-		push(expected === actual, actual, expected, message);
-	},
-
-	notStrictEqual: function(actual, expected, message) {
-		push(expected !== actual, actual, expected, message);
-	},
-	
-	start: function() {
-		// A slight delay, to avoid any current callbacks
-		if ( window.setTimeout ) {
-			window.setTimeout(function() {
-				if ( config.timeout ) {
-					clearTimeout(config.timeout);
-				}
-
-				config.blocking = false;
-				process();
-			}, 13);
-		} else {
-			config.blocking = false;
-			process();
-		}
-	},
-	
-	stop: function(timeout) {
-		config.blocking = true;
-
-		if ( timeout && window.setTimeout ) {
-			config.timeout = window.setTimeout(function() {
-				QUnit.ok( false, "Test timed out" );
-				QUnit.start();
-			}, timeout);
-		}
-	},
-	
-	/**
-	 * Resets the test setup. Useful for tests that modify the DOM.
-	 */
+	// Resets the test setup. Useful for tests that modify the DOM.
+	// If jQuery is available, uses jQuery's html(), otherwise just innerHTML.
 	reset: function() {
+		var fixture;
+
 		if ( window.jQuery ) {
-			jQuery("#main").html( config.fixture );
-			jQuery.event.global = {};
-			jQuery.ajaxSettings = extend({}, config.ajaxSettings);
+			jQuery( "#qunit-fixture" ).html( config.fixture );
+		} else {
+			fixture = id( "qunit-fixture" );
+			if ( fixture ) {
+				fixture.innerHTML = config.fixture;
+			}
 		}
 	},
-	
-	/**
-	 * Trigger an event on an element.
-	 *
-	 * @example triggerEvent( document.body, "click" );
-	 *
-	 * @param DOMElement elem
-	 * @param String type
-	 */
+
+	// Trigger an event on an element.
+	// @example triggerEvent( document.body, "click" );
 	triggerEvent: function( elem, type, event ) {
 		if ( document.createEvent ) {
-			event = document.createEvent("MouseEvents");
+			event = document.createEvent( "MouseEvents" );
 			event.initMouseEvent(type, true, true, elem.ownerDocument.defaultView,
 				0, 0, 0, 0, 0, false, false, false, false, 0, null);
-			elem.dispatchEvent( event );
 
+			elem.dispatchEvent( event );
 		} else if ( elem.fireEvent ) {
-			elem.fireEvent("on"+type);
+			elem.fireEvent( "on" + type );
 		}
 	},
-	
+
 	// Safe object type checking
 	is: function( type, obj ) {
-		return Object.prototype.toString.call( obj ) === "[object "+ type +"]";
+		return QUnit.objectType( obj ) == type;
 	},
-	
-	// Logging callbacks
-	done: function(failures, total) {},
-	log: function(result, message) {},
-	testStart: function(name) {},
-	testDone: function(name, failures, total) {},
-	moduleStart: function(name, testEnvironment) {},
-	moduleDone: function(name, failures, total) {}
-};
 
-// Backwards compatibility, deprecated
-QUnit.equals = QUnit.equal;
-QUnit.same = QUnit.deepEqual;
-
-// Maintain internal state
-var config = {
-	// The queue of tests to run
-	queue: [],
-
-	// block until document ready
-	blocking: true
-};
-
-// Load paramaters
-(function() {
-	var location = window.location || { search: "", protocol: "file:" },
-		GETParams = location.search.slice(1).split('&');
-
-	for ( var i = 0; i < GETParams.length; i++ ) {
-		GETParams[i] = decodeURIComponent( GETParams[i] );
-		if ( GETParams[i] === "noglobals" ) {
-			GETParams.splice( i, 1 );
-			i--;
-			config.noglobals = true;
-		} else if ( GETParams[i].search('=') > -1 ) {
-			GETParams.splice( i, 1 );
-			i--;
+	objectType: function( obj ) {
+		if ( typeof obj === "undefined" ) {
+				return "undefined";
+		// consider: typeof null === object
 		}
-	}
-	
-	// restrict modules/tests by get parameters
-	config.filters = GETParams;
-	
-	// Figure out if we're running the tests from a server or not
-	QUnit.isLocal = !!(location.protocol === 'file:');
-})();
+		if ( obj === null ) {
+				return "null";
+		}
 
-// Expose the API as global variables, unless an 'exports'
-// object exists, in that case we assume we're in CommonJS
-if ( typeof exports === "undefined" || typeof require === "undefined" ) {
-	extend(window, QUnit);
-	window.QUnit = QUnit;
-} else {
-	extend(exports, QUnit);
-	exports.QUnit = QUnit;
-}
+		var type = toString.call( obj ).match(/^\[object\s(.*)\]$/)[1] || "";
+
+		switch ( type ) {
+			case "Number":
+				if ( isNaN(obj) ) {
+					return "nan";
+				}
+				return "number";
+			case "String":
+			case "Boolean":
+			case "Array":
+			case "Date":
+			case "RegExp":
+			case "Function":
+				return type.toLowerCase();
+		}
+		if ( typeof obj === "object" ) {
+			return "object";
+		}
+		return undefined;
+	},
+
+	push: function( result, actual, expected, message ) {
+		if ( !config.current ) {
+			throw new Error( "assertion outside test context, was " + sourceFromStacktrace() );
+		}
+
+		var output, source,
+			details = {
+				result: result,
+				message: message,
+				actual: actual,
+				expected: expected
+			};
+
+		message = escapeInnerText( message ) || ( result ? "okay" : "failed" );
+		message = "<span class='test-message'>" + message + "</span>";
+		output = message;
+
+		if ( !result ) {
+			expected = escapeInnerText( QUnit.jsDump.parse(expected) );
+			actual = escapeInnerText( QUnit.jsDump.parse(actual) );
+			output += "<table><tr class='test-expected'><th>Expected: </th><td><pre>" + expected + "</pre></td></tr>";
+
+			if ( actual != expected ) {
+				output += "<tr class='test-actual'><th>Result: </th><td><pre>" + actual + "</pre></td></tr>";
+				output += "<tr class='test-diff'><th>Diff: </th><td><pre>" + QUnit.diff( expected, actual ) + "</pre></td></tr>";
+			}
+
+			source = sourceFromStacktrace();
+
+			if ( source ) {
+				details.source = source;
+				output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeInnerText( source ) + "</pre></td></tr>";
+			}
+
+			output += "</table>";
+		}
+
+		runLoggingCallbacks( "log", QUnit, details );
+
+		config.current.assertions.push({
+			result: !!result,
+			message: output
+		});
+	},
+
+	pushFailure: function( message, source, actual ) {
+		if ( !config.current ) {
+			throw new Error( "pushFailure() assertion outside test context, was " + sourceFromStacktrace(2) );
+		}
+
+		var output,
+			details = {
+				result: false,
+				message: message
+			};
+
+		message = escapeInnerText( message ) || "error";
+		message = "<span class='test-message'>" + message + "</span>";
+		output = message;
+
+		output += "<table>";
+
+		if ( actual ) {
+			output += "<tr class='test-actual'><th>Result: </th><td><pre>" + escapeInnerText( actual ) + "</pre></td></tr>";
+		}
+
+		if ( source ) {
+			details.source = source;
+			output += "<tr class='test-source'><th>Source: </th><td><pre>" + escapeInnerText( source ) + "</pre></td></tr>";
+		}
+
+		output += "</table>";
+
+		runLoggingCallbacks( "log", QUnit, details );
+
+		config.current.assertions.push({
+			result: false,
+			message: output
+		});
+	},
+
+	url: function( params ) {
+		params = extend( extend( {}, QUnit.urlParams ), params );
+		var key,
+			querystring = "?";
+
+		for ( key in params ) {
+			if ( !hasOwn.call( params, key ) ) {
+				continue;
+			}
+			querystring += encodeURIComponent( key ) + "=" +
+				encodeURIComponent( params[ key ] ) + "&";
+		}
+		return window.location.pathname + querystring.slice( 0, -1 );
+	},
+
+	extend: extend,
+	id: id,
+	addEvent: addEvent
+	// load, equiv, jsDump, diff: Attached later
+});
+
+/**
+ * @deprecated: Created for backwards compatibility with test runner that set the hook function
+ * into QUnit.{hook}, instead of invoking it and passing the hook function.
+ * QUnit.constructor is set to the empty F() above so that we can add to it's prototype here.
+ * Doing this allows us to tell if the following methods have been overwritten on the actual
+ * QUnit object.
+ */
+extend( QUnit.constructor.prototype, {
+
+	// Logging callbacks; all receive a single argument with the listed properties
+	// run test/logs.html for any related changes
+	begin: registerLoggingCallback( "begin" ),
+
+	// done: { failed, passed, total, runtime }
+	done: registerLoggingCallback( "done" ),
+
+	// log: { result, actual, expected, message }
+	log: registerLoggingCallback( "log" ),
+
+	// testStart: { name }
+	testStart: registerLoggingCallback( "testStart" ),
+
+	// testDone: { name, failed, passed, total }
+	testDone: registerLoggingCallback( "testDone" ),
+
+	// moduleStart: { name }
+	moduleStart: registerLoggingCallback( "moduleStart" ),
+
+	// moduleDone: { name, failed, passed, total }
+	moduleDone: registerLoggingCallback( "moduleDone" )
+});
 
 if ( typeof document === "undefined" || document.readyState === "complete" ) {
 	config.autorun = true;
 }
 
-addEvent(window, "load", function() {
+QUnit.load = function() {
+	runLoggingCallbacks( "begin", QUnit, {} );
+
 	// Initialize the config, saving the execution queue
-	var oldconfig = extend({}, config);
+	var banner, filter, i, label, len, main, ol, toolbar, userAgent, val, urlConfigCheckboxes,
+		urlConfigHtml = "",
+		oldconfig = extend( {}, config );
+
 	QUnit.init();
 	extend(config, oldconfig);
 
 	config.blocking = false;
 
-	var userAgent = id("qunit-userAgent");
+	len = config.urlConfig.length;
+
+	for ( i = 0; i < len; i++ ) {
+		val = config.urlConfig[i];
+		if ( typeof val === "string" ) {
+			val = {
+				id: val,
+				label: val,
+				tooltip: "[no tooltip available]"
+			};
+		}
+		config[ val.id ] = QUnit.urlParams[ val.id ];
+		urlConfigHtml += "<input id='qunit-urlconfig-" + val.id + "' name='" + val.id + "' type='checkbox'" + ( config[ val.id ] ? " checked='checked'" : "" ) + " title='" + val.tooltip + "'><label for='qunit-urlconfig-" + val.id + "' title='" + val.tooltip + "'>" + val.label + "</label>";
+	}
+
+	// `userAgent` initialized at top of scope
+	userAgent = id( "qunit-userAgent" );
 	if ( userAgent ) {
 		userAgent.innerHTML = navigator.userAgent;
 	}
-	
-	var toolbar = id("qunit-testrunner-toolbar");
+
+	// `banner` initialized at top of scope
+	banner = id( "qunit-header" );
+	if ( banner ) {
+		banner.innerHTML = "<a href='" + QUnit.url({ filter: undefined, module: undefined, testNumber: undefined }) + "'>" + banner.innerHTML + "</a> ";
+	}
+
+	// `toolbar` initialized at top of scope
+	toolbar = id( "qunit-testrunner-toolbar" );
 	if ( toolbar ) {
-		toolbar.style.display = "none";
-		
-		var filter = document.createElement("input");
+		// `filter` initialized at top of scope
+		filter = document.createElement( "input" );
 		filter.type = "checkbox";
 		filter.id = "qunit-filter-pass";
-		filter.disabled = true;
+
 		addEvent( filter, "click", function() {
-			var li = document.getElementsByTagName("li");
-			for ( var i = 0; i < li.length; i++ ) {
-				if ( li[i].className.indexOf("pass") > -1 ) {
-					li[i].style.display = filter.checked ? "none" : "";
+			var tmp,
+				ol = document.getElementById( "qunit-tests" );
+
+			if ( filter.checked ) {
+				ol.className = ol.className + " hidepass";
+			} else {
+				tmp = " " + ol.className.replace( /[\n\t\r]/g, " " ) + " ";
+				ol.className = tmp.replace( / hidepass /, " " );
+			}
+			if ( defined.sessionStorage ) {
+				if (filter.checked) {
+					sessionStorage.setItem( "qunit-filter-passed-tests", "true" );
+				} else {
+					sessionStorage.removeItem( "qunit-filter-passed-tests" );
 				}
 			}
 		});
+
+		if ( config.hidepassed || defined.sessionStorage && sessionStorage.getItem( "qunit-filter-passed-tests" ) ) {
+			filter.checked = true;
+			// `ol` initialized at top of scope
+			ol = document.getElementById( "qunit-tests" );
+			ol.className = ol.className + " hidepass";
+		}
 		toolbar.appendChild( filter );
 
-		var label = document.createElement("label");
-		label.setAttribute("for", "qunit-filter-pass");
+		// `label` initialized at top of scope
+		label = document.createElement( "label" );
+		label.setAttribute( "for", "qunit-filter-pass" );
+		label.setAttribute( "title", "Only show tests and assertons that fail. Stored in sessionStorage." );
 		label.innerHTML = "Hide passed tests";
 		toolbar.appendChild( label );
 
-		var missing = document.createElement("input");
-		missing.type = "checkbox";
-		missing.id = "qunit-filter-missing";
-		missing.disabled = true;
-		addEvent( missing, "click", function() {
-			var li = document.getElementsByTagName("li");
-			for ( var i = 0; i < li.length; i++ ) {
-				if ( li[i].className.indexOf("fail") > -1 && li[i].innerHTML.indexOf('missing test - untested code is broken code') > - 1 ) {
-					li[i].parentNode.parentNode.style.display = missing.checked ? "none" : "block";
-				}
-			}
+		urlConfigCheckboxes = document.createElement( 'span' );
+		urlConfigCheckboxes.innerHTML = urlConfigHtml;
+		addEvent( urlConfigCheckboxes, "change", function( event ) {
+			var params = {};
+			params[ event.target.name ] = event.target.checked ? true : undefined;
+			window.location = QUnit.url( params );
 		});
-		toolbar.appendChild( missing );
-
-		label = document.createElement("label");
-		label.setAttribute("for", "qunit-filter-missing");
-		label.innerHTML = "Hide missing tests (untested code is broken code)";
-		toolbar.appendChild( label );
+		toolbar.appendChild( urlConfigCheckboxes );
 	}
 
-	var main = id('main');
+	// `main` initialized at top of scope
+	main = id( "qunit-fixture" );
 	if ( main ) {
 		config.fixture = main.innerHTML;
 	}
 
-	if ( window.jQuery ) {
-		config.ajaxSettings = window.jQuery.ajaxSettings;
+	if ( config.autostart ) {
+		QUnit.start();
+	}
+};
+
+addEvent( window, "load", QUnit.load );
+
+// `onErrorFnPrev` initialized at top of scope
+// Preserve other handlers
+onErrorFnPrev = window.onerror;
+
+// Cover uncaught exceptions
+// Returning true will surpress the default browser handler,
+// returning false will let it run.
+window.onerror = function ( error, filePath, linerNr ) {
+	var ret = false;
+	if ( onErrorFnPrev ) {
+		ret = onErrorFnPrev( error, filePath, linerNr );
 	}
 
-	QUnit.start();
-});
+	// Treat return value as window.onerror itself does,
+	// Only do our handling if not surpressed.
+	if ( ret !== true ) {
+		if ( QUnit.config.current ) {
+			if ( QUnit.config.current.ignoreGlobalErrors ) {
+				return true;
+			}
+			QUnit.pushFailure( error, filePath + ":" + linerNr );
+		} else {
+			QUnit.test( "global failure", function() {
+				QUnit.pushFailure( error, filePath + ":" + linerNr );
+			});
+		}
+		return false;
+	}
+
+	return ret;
+};
 
 function done() {
-	if ( config.doneTimer && window.clearTimeout ) {
-		window.clearTimeout( config.doneTimer );
-		config.doneTimer = null;
-	}
-
-	if ( config.queue.length ) {
-		config.doneTimer = window.setTimeout(function(){
-			if ( !config.queue.length ) {
-				done();
-			} else {
-				synchronize( done );
-			}
-		}, 13);
-
-		return;
-	}
-
 	config.autorun = true;
 
 	// Log the last module results
 	if ( config.currentModule ) {
-		QUnit.moduleDone( config.currentModule, config.moduleStats.bad, config.moduleStats.all );
+		runLoggingCallbacks( "moduleDone", QUnit, {
+			name: config.currentModule,
+			failed: config.moduleStats.bad,
+			passed: config.moduleStats.all - config.moduleStats.bad,
+			total: config.moduleStats.all
+		});
 	}
 
-	var banner = id("qunit-banner"),
-		tests = id("qunit-tests"),
-		html = ['Tests completed in ',
-		+new Date - config.started, ' milliseconds.<br/>',
-		'<span class="passed">', config.stats.all - config.stats.bad, '</span> tests of <span class="total">', config.stats.all, '</span> passed, <span class="failed">', config.stats.bad,'</span> failed.'].join('');
+	var i, key,
+		banner = id( "qunit-banner" ),
+		tests = id( "qunit-tests" ),
+		runtime = +new Date() - config.started,
+		passed = config.stats.all - config.stats.bad,
+		html = [
+			"Tests completed in ",
+			runtime,
+			" milliseconds.<br/>",
+			"<span class='passed'>",
+			passed,
+			"</span> tests of <span class='total'>",
+			config.stats.all,
+			"</span> passed, <span class='failed'>",
+			config.stats.bad,
+			"</span> failed."
+		].join( "" );
 
 	if ( banner ) {
-		banner.className = (config.stats.bad ? "qunit-fail" : "qunit-pass");
+		banner.className = ( config.stats.bad ? "qunit-fail" : "qunit-pass" );
 	}
 
-	if ( tests ) {	
-		var result = id("qunit-testresult");
+	if ( tests ) {
+		id( "qunit-testresult" ).innerHTML = html;
+	}
 
-		if ( !result ) {
-			result = document.createElement("p");
-			result.id = "qunit-testresult";
-			result.className = "result";
-			tests.parentNode.insertBefore( result, tests.nextSibling );
+	if ( config.altertitle && typeof document !== "undefined" && document.title ) {
+		// show ✖ for good, ✔ for bad suite result in title
+		// use escape sequences in case file gets loaded with non-utf-8-charset
+		document.title = [
+			( config.stats.bad ? "\u2716" : "\u2714" ),
+			document.title.replace( /^[\u2714\u2716] /i, "" )
+		].join( " " );
+	}
+
+	// clear own sessionStorage items if all tests passed
+	if ( config.reorder && defined.sessionStorage && config.stats.bad === 0 ) {
+		// `key` & `i` initialized at top of scope
+		for ( i = 0; i < sessionStorage.length; i++ ) {
+			key = sessionStorage.key( i++ );
+			if ( key.indexOf( "qunit-test-" ) === 0 ) {
+				sessionStorage.removeItem( key );
+			}
 		}
-
-		result.innerHTML = html;
 	}
 
-	QUnit.done( config.stats.bad, config.stats.all );
+	runLoggingCallbacks( "done", QUnit, {
+		failed: config.stats.bad,
+		passed: passed,
+		total: config.stats.all,
+		runtime: runtime
+	});
 }
 
-function validTest( name ) {
-	var i = config.filters.length,
-		run = false;
+/** @return Boolean: true if this test should be ran */
+function validTest( test ) {
+	var include,
+		filter = config.filter && config.filter.toLowerCase(),
+		module = config.module && config.module.toLowerCase(),
+		fullName = (test.module + ": " + test.testName).toLowerCase();
 
-	if ( !i ) {
+	if ( config.testNumber ) {
+		return test.testNumber === config.testNumber;
+	}
+
+	if ( module && ( !test.module || test.module.toLowerCase() !== module ) ) {
+		return false;
+	}
+
+	if ( !filter ) {
 		return true;
 	}
-	
-	while ( i-- ) {
-		var filter = config.filters[i],
-			not = filter.charAt(0) == '!';
 
-		if ( not ) {
-			filter = filter.slice(1);
-		}
-
-		if ( name.indexOf(filter) !== -1 ) {
-			return !not;
-		}
-
-		if ( not ) {
-			run = true;
-		}
+	include = filter.charAt( 0 ) !== "!";
+	if ( !include ) {
+		filter = filter.slice( 1 );
 	}
 
-	return run;
+	// If the filter matches, we need to honour include
+	if ( fullName.indexOf( filter ) !== -1 ) {
+		return include;
+	}
+
+	// Otherwise, do the opposite
+	return !include;
 }
 
-function push(result, actual, expected, message) {
-	message = message || (result ? "okay" : "failed");
-	QUnit.ok( result, result ? message + ": " + QUnit.jsDump.parse(expected) : message + ", expected: " + QUnit.jsDump.parse(expected) + " result: " + QUnit.jsDump.parse(actual) );
+// so far supports only Firefox, Chrome and Opera (buggy), Safari (for real exceptions)
+// Later Safari and IE10 are supposed to support error.stack as well
+// See also https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error/Stack
+function extractStacktrace( e, offset ) {
+	offset = offset === undefined ? 3 : offset;
+
+	var stack, include, i, regex;
+
+	if ( e.stacktrace ) {
+		// Opera
+		return e.stacktrace.split( "\n" )[ offset + 3 ];
+	} else if ( e.stack ) {
+		// Firefox, Chrome
+		stack = e.stack.split( "\n" );
+		if (/^error$/i.test( stack[0] ) ) {
+			stack.shift();
+		}
+		if ( fileName ) {
+			include = [];
+			for ( i = offset; i < stack.length; i++ ) {
+				if ( stack[ i ].indexOf( fileName ) != -1 ) {
+					break;
+				}
+				include.push( stack[ i ] );
+			}
+			if ( include.length ) {
+				return include.join( "\n" );
+			}
+		}
+		return stack[ offset ];
+	} else if ( e.sourceURL ) {
+		// Safari, PhantomJS
+		// hopefully one day Safari provides actual stacktraces
+		// exclude useless self-reference for generated Error objects
+		if ( /qunit.js$/.test( e.sourceURL ) ) {
+			return;
+		}
+		// for actual exceptions, this is useful
+		return e.sourceURL + ":" + e.line;
+	}
+}
+function sourceFromStacktrace( offset ) {
+	try {
+		throw new Error();
+	} catch ( e ) {
+		return extractStacktrace( e, offset );
+	}
 }
 
-function synchronize( callback ) {
+function escapeInnerText( s ) {
+	if ( !s ) {
+		return "";
+	}
+	s = s + "";
+	return s.replace( /[\&<>]/g, function( s ) {
+		switch( s ) {
+			case "&": return "&amp;";
+			case "<": return "&lt;";
+			case ">": return "&gt;";
+			default: return s;
+		}
+	});
+}
+
+function synchronize( callback, last ) {
 	config.queue.push( callback );
 
 	if ( config.autorun && !config.blocking ) {
-		process();
+		process( last );
 	}
 }
 
-function process() {
-	var start = (new Date()).getTime();
+function process( last ) {
+	function next() {
+		process( last );
+	}
+	var start = new Date().getTime();
+	config.depth = config.depth ? config.depth + 1 : 1;
 
 	while ( config.queue.length && !config.blocking ) {
-		if ( config.updateRate <= 0 || (((new Date()).getTime() - start) < config.updateRate) ) {
+		if ( !defined.setTimeout || config.updateRate <= 0 || ( ( new Date().getTime() - start ) < config.updateRate ) ) {
 			config.queue.shift()();
-
 		} else {
-			setTimeout( process, 13 );
+			window.setTimeout( next, 13 );
 			break;
 		}
+	}
+	config.depth--;
+	if ( last && !config.blocking && !config.queue.length && config.depth === 0 ) {
+		done();
 	}
 }
 
 function saveGlobal() {
 	config.pollution = [];
-	
+
 	if ( config.noglobals ) {
 		for ( var key in window ) {
+			// in Opera sometimes DOM element ids show up here, ignore them
+			if ( !hasOwn.call( window, key ) || /^qunit-test-output/.test( key ) ) {
+				continue;
+			}
 			config.pollution.push( key );
 		}
 	}
 }
 
 function checkPollution( name ) {
-	var old = config.pollution;
+	var newGlobals,
+		deletedGlobals,
+		old = config.pollution;
+
 	saveGlobal();
-	
-	var newGlobals = diff( old, config.pollution );
+
+	newGlobals = diff( config.pollution, old );
 	if ( newGlobals.length > 0 ) {
-		ok( false, "Introduced global variable(s): " + newGlobals.join(", ") );
-		config.expected++;
+		QUnit.pushFailure( "Introduced global variable(s): " + newGlobals.join(", ") );
 	}
 
-	var deletedGlobals = diff( config.pollution, old );
+	deletedGlobals = diff( old, config.pollution );
 	if ( deletedGlobals.length > 0 ) {
-		ok( false, "Deleted global variable(s): " + deletedGlobals.join(", ") );
-		config.expected++;
+		QUnit.pushFailure( "Deleted global variable(s): " + deletedGlobals.join(", ") );
 	}
 }
 
 // returns a new Array with the elements that are in a but not in b
 function diff( a, b ) {
-	var result = a.slice();
-	for ( var i = 0; i < result.length; i++ ) {
-		for ( var j = 0; j < b.length; j++ ) {
+	var i, j,
+		result = a.slice();
+
+	for ( i = 0; i < result.length; i++ ) {
+		for ( j = 0; j < b.length; j++ ) {
 			if ( result[i] === b[j] ) {
-				result.splice(i, 1);
+				result.splice( i, 1 );
 				i--;
 				break;
 			}
@@ -646,26 +1293,21 @@ function diff( a, b ) {
 	return result;
 }
 
-function fail(message, exception, callback) {
-	if ( typeof console !== "undefined" && console.error && console.warn ) {
-		console.error(message);
-		console.error(exception);
-		console.warn(callback.toString());
-
-	} else if ( window.opera && opera.postError ) {
-		opera.postError(message, exception, callback.toString);
-	}
-}
-
-function extend(a, b) {
+function extend( a, b ) {
 	for ( var prop in b ) {
-		a[prop] = b[prop];
+		if ( b[ prop ] === undefined ) {
+			delete a[ prop ];
+
+		// Avoid "Member not found" error in IE8 caused by setting window.constructor
+		} else if ( prop !== "constructor" || a !== window ) {
+			a[ prop ] = b[ prop ];
+		}
 	}
 
 	return a;
 }
 
-function addEvent(elem, type, fn) {
+function addEvent( elem, type, fn ) {
 	if ( elem.addEventListener ) {
 		elem.addEventListener( type, fn, false );
 	} else if ( elem.attachEvent ) {
@@ -675,230 +1317,220 @@ function addEvent(elem, type, fn) {
 	}
 }
 
-function id(name) {
-	return !!(typeof document !== "undefined" && document && document.getElementById) &&
+function id( name ) {
+	return !!( typeof document !== "undefined" && document && document.getElementById ) &&
 		document.getElementById( name );
 }
 
+function registerLoggingCallback( key ) {
+	return function( callback ) {
+		config[key].push( callback );
+	};
+}
+
+// Supports deprecated method of completely overwriting logging callbacks
+function runLoggingCallbacks( key, scope, args ) {
+	//debugger;
+	var i, callbacks;
+	if ( QUnit.hasOwnProperty( key ) ) {
+		QUnit[ key ].call(scope, args );
+	} else {
+		callbacks = config[ key ];
+		for ( i = 0; i < callbacks.length; i++ ) {
+			callbacks[ i ].call( scope, args );
+		}
+	}
+}
+
 // Test for equality any JavaScript type.
-// Discussions and reference: http://philrathe.com/articles/equiv
-// Test suites: http://philrathe.com/tests/equiv
 // Author: Philippe Rathé <prathe@gmail.com>
-QUnit.equiv = function () {
+QUnit.equiv = (function() {
 
-    var innerEquiv; // the real equiv function
-    var callers = []; // stack to decide between skip/abort functions
-    var parents = []; // stack to avoiding loops from circular referencing
+	// Call the o related callback with the given arguments.
+	function bindCallbacks( o, callbacks, args ) {
+		var prop = QUnit.objectType( o );
+		if ( prop ) {
+			if ( QUnit.objectType( callbacks[ prop ] ) === "function" ) {
+				return callbacks[ prop ].apply( callbacks, args );
+			} else {
+				return callbacks[ prop ]; // or undefined
+			}
+		}
+	}
 
+	// the real equiv function
+	var innerEquiv,
+		// stack to decide between skip/abort functions
+		callers = [],
+		// stack to avoiding loops from circular referencing
+		parents = [],
 
-    // Determine what is o.
-    function hoozit(o) {
-        if (QUnit.is("String", o)) {
-            return "string";
-            
-        } else if (QUnit.is("Boolean", o)) {
-            return "boolean";
+		getProto = Object.getPrototypeOf || function ( obj ) {
+			return obj.__proto__;
+		},
+		callbacks = (function () {
 
-        } else if (QUnit.is("Number", o)) {
+			// for string, boolean, number and null
+			function useStrictEquality( b, a ) {
+				if ( b instanceof a.constructor || a instanceof b.constructor ) {
+					// to catch short annotaion VS 'new' annotation of a
+					// declaration
+					// e.g. var i = 1;
+					// var j = new Number(1);
+					return a == b;
+				} else {
+					return a === b;
+				}
+			}
 
-            if (isNaN(o)) {
-                return "nan";
-            } else {
-                return "number";
-            }
+			return {
+				"string": useStrictEquality,
+				"boolean": useStrictEquality,
+				"number": useStrictEquality,
+				"null": useStrictEquality,
+				"undefined": useStrictEquality,
 
-        } else if (typeof o === "undefined") {
-            return "undefined";
+				"nan": function( b ) {
+					return isNaN( b );
+				},
 
-        // consider: typeof null === object
-        } else if (o === null) {
-            return "null";
+				"date": function( b, a ) {
+					return QUnit.objectType( b ) === "date" && a.valueOf() === b.valueOf();
+				},
 
-        // consider: typeof [] === object
-        } else if (QUnit.is( "Array", o)) {
-            return "array";
-        
-        // consider: typeof new Date() === object
-        } else if (QUnit.is( "Date", o)) {
-            return "date";
+				"regexp": function( b, a ) {
+					return QUnit.objectType( b ) === "regexp" &&
+						// the regex itself
+						a.source === b.source &&
+						// and its modifers
+						a.global === b.global &&
+						// (gmi) ...
+						a.ignoreCase === b.ignoreCase &&
+						a.multiline === b.multiline;
+				},
 
-        // consider: /./ instanceof Object;
-        //           /./ instanceof RegExp;
-        //          typeof /./ === "function"; // => false in IE and Opera,
-        //                                          true in FF and Safari
-        } else if (QUnit.is( "RegExp", o)) {
-            return "regexp";
+				// - skip when the property is a method of an instance (OOP)
+				// - abort otherwise,
+				// initial === would have catch identical references anyway
+				"function": function() {
+					var caller = callers[callers.length - 1];
+					return caller !== Object && typeof caller !== "undefined";
+				},
 
-        } else if (typeof o === "object") {
-            return "object";
+				"array": function( b, a ) {
+					var i, j, len, loop;
 
-        } else if (QUnit.is( "Function", o)) {
-            return "function";
-        } else {
-            return undefined;
-        }
-    }
+					// b could be an object literal here
+					if ( QUnit.objectType( b ) !== "array" ) {
+						return false;
+					}
 
-    // Call the o related callback with the given arguments.
-    function bindCallbacks(o, callbacks, args) {
-        var prop = hoozit(o);
-        if (prop) {
-            if (hoozit(callbacks[prop]) === "function") {
-                return callbacks[prop].apply(callbacks, args);
-            } else {
-                return callbacks[prop]; // or undefined
-            }
-        }
-    }
-    
-    var callbacks = function () {
+					len = a.length;
+					if ( len !== b.length ) {
+						// safe and faster
+						return false;
+					}
 
-        // for string, boolean, number and null
-        function useStrictEquality(b, a) {
-            if (b instanceof a.constructor || a instanceof b.constructor) {
-                // to catch short annotaion VS 'new' annotation of a declaration
-                // e.g. var i = 1;
-                //      var j = new Number(1);
-                return a == b;
-            } else {
-                return a === b;
-            }
-        }
+					// track reference to avoid circular references
+					parents.push( a );
+					for ( i = 0; i < len; i++ ) {
+						loop = false;
+						for ( j = 0; j < parents.length; j++ ) {
+							if ( parents[j] === a[i] ) {
+								loop = true;// dont rewalk array
+							}
+						}
+						if ( !loop && !innerEquiv(a[i], b[i]) ) {
+							parents.pop();
+							return false;
+						}
+					}
+					parents.pop();
+					return true;
+				},
 
-        return {
-            "string": useStrictEquality,
-            "boolean": useStrictEquality,
-            "number": useStrictEquality,
-            "null": useStrictEquality,
-            "undefined": useStrictEquality,
+				"object": function( b, a ) {
+					var i, j, loop,
+						// Default to true
+						eq = true,
+						aProperties = [],
+						bProperties = [];
 
-            "nan": function (b) {
-                return isNaN(b);
-            },
+					// comparing constructors is more strict than using
+					// instanceof
+					if ( a.constructor !== b.constructor ) {
+						// Allow objects with no prototype to be equivalent to
+						// objects with Object as their constructor.
+						if ( !(( getProto(a) === null && getProto(b) === Object.prototype ) ||
+							( getProto(b) === null && getProto(a) === Object.prototype ) ) ) {
+								return false;
+						}
+					}
 
-            "date": function (b, a) {
-                return hoozit(b) === "date" && a.valueOf() === b.valueOf();
-            },
+					// stack constructor before traversing properties
+					callers.push( a.constructor );
+					// track reference to avoid circular references
+					parents.push( a );
 
-            "regexp": function (b, a) {
-                return hoozit(b) === "regexp" &&
-                    a.source === b.source && // the regex itself
-                    a.global === b.global && // and its modifers (gmi) ...
-                    a.ignoreCase === b.ignoreCase &&
-                    a.multiline === b.multiline;
-            },
+					for ( i in a ) { // be strict: don't ensures hasOwnProperty
+									// and go deep
+						loop = false;
+						for ( j = 0; j < parents.length; j++ ) {
+							if ( parents[j] === a[i] ) {
+								// don't go down the same path twice
+								loop = true;
+							}
+						}
+						aProperties.push(i); // collect a's properties
 
-            // - skip when the property is a method of an instance (OOP)
-            // - abort otherwise,
-            //   initial === would have catch identical references anyway
-            "function": function () {
-                var caller = callers[callers.length - 1];
-                return caller !== Object &&
-                        typeof caller !== "undefined";
-            },
+						if (!loop && !innerEquiv( a[i], b[i] ) ) {
+							eq = false;
+							break;
+						}
+					}
 
-            "array": function (b, a) {
-                var i, j, loop;
-                var len;
+					callers.pop(); // unstack, we are done
+					parents.pop();
 
-                // b could be an object literal here
-                if ( ! (hoozit(b) === "array")) {
-                    return false;
-                }   
-                
-                len = a.length;
-                if (len !== b.length) { // safe and faster
-                    return false;
-                }
-                
-                //track reference to avoid circular references
-                parents.push(a);
-                for (i = 0; i < len; i++) {
-                    loop = false;
-                    for(j=0;j<parents.length;j++){
-                        if(parents[j] === a[i]){
-                            loop = true;//dont rewalk array
-                        }
-                    }
-                    if (!loop && ! innerEquiv(a[i], b[i])) {
-                        parents.pop();
-                        return false;
-                    }
-                }
-                parents.pop();
-                return true;
-            },
+					for ( i in b ) {
+						bProperties.push( i ); // collect b's properties
+					}
 
-            "object": function (b, a) {
-                var i, j, loop;
-                var eq = true; // unless we can proove it
-                var aProperties = [], bProperties = []; // collection of strings
+					// Ensures identical properties name
+					return eq && innerEquiv( aProperties.sort(), bProperties.sort() );
+				}
+			};
+		}());
 
-                // comparing constructors is more strict than using instanceof
-                if ( a.constructor !== b.constructor) {
-                    return false;
-                }
+	innerEquiv = function() { // can take multiple arguments
+		var args = [].slice.apply( arguments );
+		if ( args.length < 2 ) {
+			return true; // end transition
+		}
 
-                // stack constructor before traversing properties
-                callers.push(a.constructor);
-                //track reference to avoid circular references
-                parents.push(a);
-                
-                for (i in a) { // be strict: don't ensures hasOwnProperty and go deep
-                    loop = false;
-                    for(j=0;j<parents.length;j++){
-                        if(parents[j] === a[i])
-                            loop = true; //don't go down the same path twice
-                    }
-                    aProperties.push(i); // collect a's properties
+		return (function( a, b ) {
+			if ( a === b ) {
+				return true; // catch the most you can
+			} else if ( a === null || b === null || typeof a === "undefined" ||
+					typeof b === "undefined" ||
+					QUnit.objectType(a) !== QUnit.objectType(b) ) {
+				return false; // don't lose time with error prone cases
+			} else {
+				return bindCallbacks(a, callbacks, [ b, a ]);
+			}
 
-                    if (!loop && ! innerEquiv(a[i], b[i])) {
-                        eq = false;
-                        break;
-                    }
-                }
+			// apply transition with (1..n) arguments
+		}( args[0], args[1] ) && arguments.callee.apply( this, args.splice(1, args.length - 1 )) );
+	};
 
-                callers.pop(); // unstack, we are done
-                parents.pop();
-
-                for (i in b) {
-                    bProperties.push(i); // collect b's properties
-                }
-
-                // Ensures identical properties name
-                return eq && innerEquiv(aProperties.sort(), bProperties.sort());
-            }
-        };
-    }();
-
-    innerEquiv = function () { // can take multiple arguments
-        var args = Array.prototype.slice.apply(arguments);
-        if (args.length < 2) {
-            return true; // end transition
-        }
-
-        return (function (a, b) {
-            if (a === b) {
-                return true; // catch the most you can
-            } else if (a === null || b === null || typeof a === "undefined" || typeof b === "undefined" || hoozit(a) !== hoozit(b)) {
-                return false; // don't lose time with error prone cases
-            } else {
-                return bindCallbacks(a, callbacks, [b, a]);
-            }
-
-        // apply transition with (1..n) arguments
-        })(args[0], args[1]) && arguments.callee.apply(this, args.splice(1, args.length -1));
-    };
-
-    return innerEquiv;
-
-}();
+	return innerEquiv;
+}());
 
 /**
- * jsDump
- * Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com | http://flesler.blogspot.com
- * Licensed under BSD (http://www.opensource.org/licenses/bsd-license.php)
- * Date: 5/15/2008
+ * jsDump Copyright (c) 2008 Ariel Flesler - aflesler(at)gmail(dot)com |
+ * http://flesler.blogspot.com Licensed under BSD
+ * (http://www.opensource.org/licenses/bsd-license.php) Date: 5/15/2008
+ *
  * @projectDescription Advanced and extensible data dumping for Javascript.
  * @version 1.0.0
  * @author Ariel Flesler
@@ -906,164 +1538,397 @@ QUnit.equiv = function () {
  */
 QUnit.jsDump = (function() {
 	function quote( str ) {
-		return '"' + str.toString().replace(/"/g, '\\"') + '"';
-	};
+		return '"' + str.toString().replace( /"/g, '\\"' ) + '"';
+	}
 	function literal( o ) {
-		return o + '';	
-	};
+		return o + "";
+	}
 	function join( pre, arr, post ) {
 		var s = jsDump.separator(),
 			base = jsDump.indent(),
 			inner = jsDump.indent(1);
-		if ( arr.join )
-			arr = arr.join( ',' + s + inner );
-		if ( !arr )
+		if ( arr.join ) {
+			arr = arr.join( "," + s + inner );
+		}
+		if ( !arr ) {
 			return pre + post;
+		}
 		return [ pre, inner + arr, base + post ].join(s);
-	};
-	function array( arr ) {
-		var i = arr.length,	ret = Array(i);					
+	}
+	function array( arr, stack ) {
+		var i = arr.length, ret = new Array(i);
 		this.up();
-		while ( i-- )
-			ret[i] = this.parse( arr[i] );				
+		while ( i-- ) {
+			ret[i] = this.parse( arr[i] , undefined , stack);
+		}
 		this.down();
-		return join( '[', ret, ']' );
-	};
-	
-	var reName = /^function (\w+)/;
-	
-	var jsDump = {
-		parse:function( obj, type ) { //type is used mostly internally, you can fix a (custom)type in advance
-			var	parser = this.parsers[ type || this.typeOf(obj) ];
-			type = typeof parser;			
-			
-			return type == 'function' ? parser.call( this, obj ) :
-				   type == 'string' ? parser :
-				   this.parsers.error;
-		},
-		typeOf:function( obj ) {
-			var type;
-			if ( obj === null ) {
-				type = "null";
-			} else if (typeof obj === "undefined") {
-				type = "undefined";
-			} else if (QUnit.is("RegExp", obj)) {
-				type = "regexp";
-			} else if (QUnit.is("Date", obj)) {
-				type = "date";
-			} else if (QUnit.is("Function", obj)) {
-				type = "function";
-			} else if (obj.setInterval && obj.document && !obj.nodeType) {
-				type = "window";
-			} else if (obj.nodeType === 9) {
-				type = "document";
-			} else if (obj.nodeType) {
-				type = "node";
-			} else if (typeof obj === "object" && typeof obj.length === "number" && obj.length >= 0) {
-				type = "array";
-			} else {
-				type = typeof obj;
-			}
-			return type;
-		},
-		separator:function() {
-			return this.multiline ?	this.HTML ? '<br />' : '\n' : this.HTML ? '&nbsp;' : ' ';
-		},
-		indent:function( extra ) {// extra can be a number, shortcut for increasing-calling-decreasing
-			if ( !this.multiline )
-				return '';
-			var chr = this.indentChar;
-			if ( this.HTML )
-				chr = chr.replace(/\t/g,'   ').replace(/ /g,'&nbsp;');
-			return Array( this._depth_ + (extra||0) ).join(chr);
-		},
-		up:function( a ) {
-			this._depth_ += a || 1;
-		},
-		down:function( a ) {
-			this._depth_ -= a || 1;
-		},
-		setParser:function( name, parser ) {
-			this.parsers[name] = parser;
-		},
-		// The next 3 are exposed so you can use them
-		quote:quote, 
-		literal:literal,
-		join:join,
-		//
-		_depth_: 1,
-		// This is the list of parsers, to modify them, use jsDump.setParser
-		parsers:{
-			window: '[Window]',
-			document: '[Document]',
-			error:'[ERROR]', //when no parser is found, shouldn't happen
-			unknown: '[Unknown]',
-			'null':'null',
-			undefined:'undefined',
-			'function':function( fn ) {
-				var ret = 'function',
-					name = 'name' in fn ? fn.name : (reName.exec(fn)||[])[1];//functions never have name in IE
-				if ( name )
-					ret += ' ' + name;
-				ret += '(';
-				
-				ret = [ ret, this.parse( fn, 'functionArgs' ), '){'].join('');
-				return join( ret, this.parse(fn,'functionCode'), '}' );
-			},
-			array: array,
-			nodelist: array,
-			arguments: array,
-			object:function( map ) {
-				var ret = [ ];
-				this.up();
-				for ( var key in map )
-					ret.push( this.parse(key,'key') + ': ' + this.parse(map[key]) );
-				this.down();
-				return join( '{', ret, '}' );
-			},
-			node:function( node ) {
-				var open = this.HTML ? '&lt;' : '<',
-					close = this.HTML ? '&gt;' : '>';
-					
-				var tag = node.nodeName.toLowerCase(),
-					ret = open + tag;
-					
-				for ( var a in this.DOMAttrs ) {
-					var val = node[this.DOMAttrs[a]];
-					if ( val )
-						ret += ' ' + a + '=' + this.parse( val, 'attribute' );
+		return join( "[", ret, "]" );
+	}
+
+	var reName = /^function (\w+)/,
+		jsDump = {
+			parse: function( obj, type, stack ) { //type is used mostly internally, you can fix a (custom)type in advance
+				stack = stack || [ ];
+				var inStack, res,
+					parser = this.parsers[ type || this.typeOf(obj) ];
+
+				type = typeof parser;
+				inStack = inArray( obj, stack );
+
+				if ( inStack != -1 ) {
+					return "recursion(" + (inStack - stack.length) + ")";
 				}
-				return ret + close + open + '/' + tag + close;
+				//else
+				if ( type == "function" )  {
+					stack.push( obj );
+					res = parser.call( this, obj, stack );
+					stack.pop();
+					return res;
+				}
+				// else
+				return ( type == "string" ) ? parser : this.parsers.error;
 			},
-			functionArgs:function( fn ) {//function calls it internally, it's the arguments part of the function
-				var l = fn.length;
-				if ( !l ) return '';				
-				
-				var args = Array(l);
-				while ( l-- )
-					args[l] = String.fromCharCode(97+l);//97 is 'a'
-				return ' ' + args.join(', ') + ' ';
+			typeOf: function( obj ) {
+				var type;
+				if ( obj === null ) {
+					type = "null";
+				} else if ( typeof obj === "undefined" ) {
+					type = "undefined";
+				} else if ( QUnit.is( "regexp", obj) ) {
+					type = "regexp";
+				} else if ( QUnit.is( "date", obj) ) {
+					type = "date";
+				} else if ( QUnit.is( "function", obj) ) {
+					type = "function";
+				} else if ( typeof obj.setInterval !== undefined && typeof obj.document !== "undefined" && typeof obj.nodeType === "undefined" ) {
+					type = "window";
+				} else if ( obj.nodeType === 9 ) {
+					type = "document";
+				} else if ( obj.nodeType ) {
+					type = "node";
+				} else if (
+					// native arrays
+					toString.call( obj ) === "[object Array]" ||
+					// NodeList objects
+					( typeof obj.length === "number" && typeof obj.item !== "undefined" && ( obj.length ? obj.item(0) === obj[0] : ( obj.item( 0 ) === null && typeof obj[0] === "undefined" ) ) )
+				) {
+					type = "array";
+				} else {
+					type = typeof obj;
+				}
+				return type;
 			},
-			key:quote, //object calls it internally, the key part of an item in a map
-			functionCode:'[code]', //function calls it internally, it's the content of the function
-			attribute:quote, //node calls it internally, it's an html attribute value
-			string:quote,
-			date:quote,
-			regexp:literal, //regex
-			number:literal,
-			'boolean':literal
-		},
-		DOMAttrs:{//attributes to dump from nodes, name=>realName
-			id:'id',
-			name:'name',
-			'class':'className'
-		},
-		HTML:false,//if true, entities are escaped ( <, >, \t, space and \n )
-		indentChar:'   ',//indentation unit
-		multiline:false //if true, items in a collection, are separated by a \n, else just a space.
-	};
+			separator: function() {
+				return this.multiline ?	this.HTML ? "<br />" : "\n" : this.HTML ? "&nbsp;" : " ";
+			},
+			indent: function( extra ) {// extra can be a number, shortcut for increasing-calling-decreasing
+				if ( !this.multiline ) {
+					return "";
+				}
+				var chr = this.indentChar;
+				if ( this.HTML ) {
+					chr = chr.replace( /\t/g, "   " ).replace( / /g, "&nbsp;" );
+				}
+				return new Array( this._depth_ + (extra||0) ).join(chr);
+			},
+			up: function( a ) {
+				this._depth_ += a || 1;
+			},
+			down: function( a ) {
+				this._depth_ -= a || 1;
+			},
+			setParser: function( name, parser ) {
+				this.parsers[name] = parser;
+			},
+			// The next 3 are exposed so you can use them
+			quote: quote,
+			literal: literal,
+			join: join,
+			//
+			_depth_: 1,
+			// This is the list of parsers, to modify them, use jsDump.setParser
+			parsers: {
+				window: "[Window]",
+				document: "[Document]",
+				error: "[ERROR]", //when no parser is found, shouldn"t happen
+				unknown: "[Unknown]",
+				"null": "null",
+				"undefined": "undefined",
+				"function": function( fn ) {
+					var ret = "function",
+						name = "name" in fn ? fn.name : (reName.exec(fn) || [])[1];//functions never have name in IE
+
+					if ( name ) {
+						ret += " " + name;
+					}
+					ret += "( ";
+
+					ret = [ ret, QUnit.jsDump.parse( fn, "functionArgs" ), "){" ].join( "" );
+					return join( ret, QUnit.jsDump.parse(fn,"functionCode" ), "}" );
+				},
+				array: array,
+				nodelist: array,
+				"arguments": array,
+				object: function( map, stack ) {
+					var ret = [ ], keys, key, val, i;
+					QUnit.jsDump.up();
+					if ( Object.keys ) {
+						keys = Object.keys( map );
+					} else {
+						keys = [];
+						for ( key in map ) {
+							keys.push( key );
+						}
+					}
+					keys.sort();
+					for ( i = 0; i < keys.length; i++ ) {
+						key = keys[ i ];
+						val = map[ key ];
+						ret.push( QUnit.jsDump.parse( key, "key" ) + ": " + QUnit.jsDump.parse( val, undefined, stack ) );
+					}
+					QUnit.jsDump.down();
+					return join( "{", ret, "}" );
+				},
+				node: function( node ) {
+					var a, val,
+						open = QUnit.jsDump.HTML ? "&lt;" : "<",
+						close = QUnit.jsDump.HTML ? "&gt;" : ">",
+						tag = node.nodeName.toLowerCase(),
+						ret = open + tag;
+
+					for ( a in QUnit.jsDump.DOMAttrs ) {
+						val = node[ QUnit.jsDump.DOMAttrs[a] ];
+						if ( val ) {
+							ret += " " + a + "=" + QUnit.jsDump.parse( val, "attribute" );
+						}
+					}
+					return ret + close + open + "/" + tag + close;
+				},
+				functionArgs: function( fn ) {//function calls it internally, it's the arguments part of the function
+					var args,
+						l = fn.length;
+
+					if ( !l ) {
+						return "";
+					}
+
+					args = new Array(l);
+					while ( l-- ) {
+						args[l] = String.fromCharCode(97+l);//97 is 'a'
+					}
+					return " " + args.join( ", " ) + " ";
+				},
+				key: quote, //object calls it internally, the key part of an item in a map
+				functionCode: "[code]", //function calls it internally, it's the content of the function
+				attribute: quote, //node calls it internally, it's an html attribute value
+				string: quote,
+				date: quote,
+				regexp: literal, //regex
+				number: literal,
+				"boolean": literal
+			},
+			DOMAttrs: {
+				//attributes to dump from nodes, name=>realName
+				id: "id",
+				name: "name",
+				"class": "className"
+			},
+			HTML: false,//if true, entities are escaped ( <, >, \t, space and \n )
+			indentChar: "  ",//indentation unit
+			multiline: true //if true, items in a collection, are separated by a \n, else just a space.
+		};
 
 	return jsDump;
-})();
+}());
 
-})(this);
+// from Sizzle.js
+function getText( elems ) {
+	var i, elem,
+		ret = "";
+
+	for ( i = 0; elems[i]; i++ ) {
+		elem = elems[i];
+
+		// Get the text from text nodes and CDATA nodes
+		if ( elem.nodeType === 3 || elem.nodeType === 4 ) {
+			ret += elem.nodeValue;
+
+		// Traverse everything else, except comment nodes
+		} else if ( elem.nodeType !== 8 ) {
+			ret += getText( elem.childNodes );
+		}
+	}
+
+	return ret;
+}
+
+// from jquery.js
+function inArray( elem, array ) {
+	if ( array.indexOf ) {
+		return array.indexOf( elem );
+	}
+
+	for ( var i = 0, length = array.length; i < length; i++ ) {
+		if ( array[ i ] === elem ) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/*
+ * Javascript Diff Algorithm
+ *  By John Resig (http://ejohn.org/)
+ *  Modified by Chu Alan "sprite"
+ *
+ * Released under the MIT license.
+ *
+ * More Info:
+ *  http://ejohn.org/projects/javascript-diff-algorithm/
+ *
+ * Usage: QUnit.diff(expected, actual)
+ *
+ * QUnit.diff( "the quick brown fox jumped over", "the quick fox jumps over" ) == "the  quick <del>brown </del> fox <del>jumped </del><ins>jumps </ins> over"
+ */
+QUnit.diff = (function() {
+	function diff( o, n ) {
+		var i,
+			ns = {},
+			os = {};
+
+		for ( i = 0; i < n.length; i++ ) {
+			if ( ns[ n[i] ] == null ) {
+				ns[ n[i] ] = {
+					rows: [],
+					o: null
+				};
+			}
+			ns[ n[i] ].rows.push( i );
+		}
+
+		for ( i = 0; i < o.length; i++ ) {
+			if ( os[ o[i] ] == null ) {
+				os[ o[i] ] = {
+					rows: [],
+					n: null
+				};
+			}
+			os[ o[i] ].rows.push( i );
+		}
+
+		for ( i in ns ) {
+			if ( !hasOwn.call( ns, i ) ) {
+				continue;
+			}
+			if ( ns[i].rows.length == 1 && typeof os[i] != "undefined" && os[i].rows.length == 1 ) {
+				n[ ns[i].rows[0] ] = {
+					text: n[ ns[i].rows[0] ],
+					row: os[i].rows[0]
+				};
+				o[ os[i].rows[0] ] = {
+					text: o[ os[i].rows[0] ],
+					row: ns[i].rows[0]
+				};
+			}
+		}
+
+		for ( i = 0; i < n.length - 1; i++ ) {
+			if ( n[i].text != null && n[ i + 1 ].text == null && n[i].row + 1 < o.length && o[ n[i].row + 1 ].text == null &&
+						n[ i + 1 ] == o[ n[i].row + 1 ] ) {
+
+				n[ i + 1 ] = {
+					text: n[ i + 1 ],
+					row: n[i].row + 1
+				};
+				o[ n[i].row + 1 ] = {
+					text: o[ n[i].row + 1 ],
+					row: i + 1
+				};
+			}
+		}
+
+		for ( i = n.length - 1; i > 0; i-- ) {
+			if ( n[i].text != null && n[ i - 1 ].text == null && n[i].row > 0 && o[ n[i].row - 1 ].text == null &&
+						n[ i - 1 ] == o[ n[i].row - 1 ]) {
+
+				n[ i - 1 ] = {
+					text: n[ i - 1 ],
+					row: n[i].row - 1
+				};
+				o[ n[i].row - 1 ] = {
+					text: o[ n[i].row - 1 ],
+					row: i - 1
+				};
+			}
+		}
+
+		return {
+			o: o,
+			n: n
+		};
+	}
+
+	return function( o, n ) {
+		o = o.replace( /\s+$/, "" );
+		n = n.replace( /\s+$/, "" );
+
+		var i, pre,
+			str = "",
+			out = diff( o === "" ? [] : o.split(/\s+/), n === "" ? [] : n.split(/\s+/) ),
+			oSpace = o.match(/\s+/g),
+			nSpace = n.match(/\s+/g);
+
+		if ( oSpace == null ) {
+			oSpace = [ " " ];
+		}
+		else {
+			oSpace.push( " " );
+		}
+
+		if ( nSpace == null ) {
+			nSpace = [ " " ];
+		}
+		else {
+			nSpace.push( " " );
+		}
+
+		if ( out.n.length === 0 ) {
+			for ( i = 0; i < out.o.length; i++ ) {
+				str += "<del>" + out.o[i] + oSpace[i] + "</del>";
+			}
+		}
+		else {
+			if ( out.n[0].text == null ) {
+				for ( n = 0; n < out.o.length && out.o[n].text == null; n++ ) {
+					str += "<del>" + out.o[n] + oSpace[n] + "</del>";
+				}
+			}
+
+			for ( i = 0; i < out.n.length; i++ ) {
+				if (out.n[i].text == null) {
+					str += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
+				}
+				else {
+					// `pre` initialized at top of scope
+					pre = "";
+
+					for ( n = out.n[i].row + 1; n < out.o.length && out.o[n].text == null; n++ ) {
+						pre += "<del>" + out.o[n] + oSpace[n] + "</del>";
+					}
+					str += " " + out.n[i].text + nSpace[i] + pre;
+				}
+			}
+		}
+
+		return str;
+	};
+}());
+
+// for CommonJS enviroments, export everything
+if ( typeof exports !== "undefined" ) {
+	extend(exports, QUnit);
+}
+
+// get at whatever the global object is, like window in browsers
+}( (function() {return this;}.call()) ));

--- a/tests/tabnote_tests.js
+++ b/tests/tabnote_tests.js
@@ -19,32 +19,32 @@ Vex.Flow.Test.TabNote.ticks = function() {
 
   var note = new Vex.Flow.TabNote(
       { positions: [{str: 6, fret: 6 }], duration: "w"});
-  equals(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
+  equal(note.getTicks(), BEAT * 4, "Whole note has 4 beats");
 
-  var note = new Vex.Flow.TabNote(
+  note = new Vex.Flow.TabNote(
       { positions: [{str: 3, fret: 4 }], duration: "q"});
-  equals(note.getTicks(), BEAT, "Quarter note has 1 beat");
+  equal(note.getTicks(), BEAT, "Quarter note has 1 beat");
 }
 
 Vex.Flow.Test.TabNote.tabStaveLine = function() {
   var note = new Vex.Flow.TabNote(
       { positions: [{str: 6, fret: 6 }, {str: 4, fret: 5}], duration: "w"});
   var positions = note.getPositions();
-  equals(positions[0].str, 6, "String 6, Fret 6");
-  equals(positions[0].fret, 6, "String 6, Fret 6");
-  equals(positions[1].str, 4, "String 4, Fret 5");
-  equals(positions[1].fret, 5, "String 4, Fret 5");
+  equal(positions[0].str, 6, "String 6, Fret 6");
+  equal(positions[0].fret, 6, "String 6, Fret 6");
+  equal(positions[1].str, 4, "String 4, Fret 5");
+  equal(positions[1].fret, 5, "String 4, Fret 5");
 
   var stave = new Vex.Flow.Stave(10, 10, 300);
   note.setStave(stave);
 
   var ys = note.getYs();
-  equals(ys.length, 2, "Chord should be rendered on two lines");
-  equals(ys[0], 100, "Line for String 6, Fret 6");
-  equals(ys[1], 80, "Line for String 4, Fret 5");
+  equal(ys.length, 2, "Chord should be rendered on two lines");
+  equal(ys[0], 100, "Line for String 6, Fret 6");
+  equal(ys[1], 80, "Line for String 4, Fret 5");
 }
 
-Vex.Flow.Test.TabNote.width = function(options) {
+Vex.Flow.Test.TabNote.width = function() {
   expect(1);
   var note = new Vex.Flow.TabNote(
       { positions: [{str: 6, fret: 6 }, {str: 4, fret: 5}], duration: "w"});
@@ -52,12 +52,12 @@ Vex.Flow.Test.TabNote.width = function(options) {
   try {
     var width = note.getWidth();
   } catch (e) {
-    equals(e.code, "UnformattedNote",
+    equal(e.code, "UnformattedNote",
         "Unformatted note should have no width");
   }
 }
 
-Vex.Flow.Test.TabNote.tickContext = function(options) {
+Vex.Flow.Test.TabNote.tickContext = function() {
   var note = new Vex.Flow.TabNote(
       { positions: [{str: 6, fret: 6 }, {str: 4, fret: 5}], duration: "w"});
   var tickContext = new Vex.Flow.TickContext();
@@ -66,7 +66,7 @@ Vex.Flow.Test.TabNote.tickContext = function(options) {
   tickContext.setX(10);
   tickContext.setPadding(0);
 
-  equals(tickContext.getWidth(), 6);
+  equal(tickContext.getWidth(), 6);
 }
 
 Vex.Flow.Test.TabNote.showNote = function(tab_struct, stave, ctx, x) {

--- a/tests/tabstave_tests.js
+++ b/tests/tabstave_tests.js
@@ -25,10 +25,10 @@ Vex.Flow.Test.TabStave.draw = function(options, contextBuilder) {
   stave.setContext(ctx);
   stave.draw();
 
-  equals(stave.getYForNote(0), 127, "getYForNote(0)");
-  equals(stave.getYForLine(5), 127, "getYForLine(5)");
-  equals(stave.getYForLine(0), 62, "getYForLine(0) - Top Line");
-  equals(stave.getYForLine(4), 114, "getYForLine(4) - Bottom Line");
+  equal(stave.getYForNote(0), 127, "getYForNote(0)");
+  equal(stave.getYForLine(5), 127, "getYForLine(5)");
+  equal(stave.getYForLine(0), 62, "getYForLine(0) - Top Line");
+  equal(stave.getYForLine(4), 114, "getYForLine(4) - Bottom Line");
 
   ok(true, "all pass");
 }

--- a/tests/tickcontext_tests.js
+++ b/tests/tickcontext_tests.js
@@ -11,12 +11,12 @@ Vex.Flow.Test.TickContext.Start = function() {
   test("Tracking Test", Vex.Flow.Test.TickContext.tracking);
 }
 
-Vex.Flow.Test.TickContext.currentTick = function(options) {
+Vex.Flow.Test.TickContext.currentTick = function() {
   var tc = new Vex.Flow.TickContext();
-  equals(tc.getCurrentTick(), 0, "New tick context has no ticks");
+  equal(tc.getCurrentTick(), 0, "New tick context has no ticks");
 }
 
-Vex.Flow.Test.TickContext.tracking = function(options) {
+Vex.Flow.Test.TickContext.tracking = function() {
   function createTickable() {
     return new Vex.Flow.Test.MockTickable(Vex.Flow.Test.TIME4_4);
   }
@@ -34,15 +34,15 @@ Vex.Flow.Test.TickContext.tracking = function(options) {
   tc.setPadding(0);
 
   tc.addTickable(tickables[0]);
-  equals(tc.getMaxTicks(), BEAT);
+  equal(tc.getMaxTicks(), BEAT);
 
   tc.addTickable(tickables[1]);
-  equals(tc.getMaxTicks(), BEAT * 2);
+  equal(tc.getMaxTicks(), BEAT * 2);
 
   tc.addTickable(tickables[2]);
-  equals(tc.getMaxTicks(), BEAT * 2);
+  equal(tc.getMaxTicks(), BEAT * 2);
 
-  equals(tc.getWidth(), 0);
+  equal(tc.getWidth(), 0);
   tc.preFormat();
-  equals(tc.getWidth(), 30);
+  equal(tc.getWidth(), 30);
 }

--- a/tests/timesignature_tests.js
+++ b/tests/timesignature_tests.js
@@ -18,11 +18,11 @@ Vex.Flow.Test.TimeSignature.catchError = function(ts, spec) {
   try {
     ts.parseTimeSpec(spec);
   } catch (e) {  
-    equals(e.code, "BadTimeSignature", e.message); 
+    equal(e.code, "BadTimeSignature", e.message);
   }
 }
 
-Vex.Flow.Test.TimeSignature.parser = function(options) {
+Vex.Flow.Test.TimeSignature.parser = function() {
   expect(6);
   var ts = new Vex.Flow.TimeSignature();
   
@@ -34,12 +34,12 @@ Vex.Flow.Test.TimeSignature.parser = function(options) {
   Vex.Flow.Test.TimeSignature.catchError(ts, "4567");
   Vex.Flow.Test.TimeSignature.catchError(ts, "C+");
 
-  ts.parseTimeSpec("4/4")
-  ts.parseTimeSpec("10/12")
-  ts.parseTimeSpec("1/8")
-  ts.parseTimeSpec("1234567890/1234567890")
-  ts.parseTimeSpec("C")
-  ts.parseTimeSpec("C|")
+  ts.parseTimeSpec("4/4");
+  ts.parseTimeSpec("10/12");
+  ts.parseTimeSpec("1/8");
+  ts.parseTimeSpec("1234567890/1234567890");
+  ts.parseTimeSpec("C");
+  ts.parseTimeSpec("C|");
 
   ok(true, "all pass");
 }

--- a/tests/tuning_tests.js
+++ b/tests/tuning_tests.js
@@ -15,24 +15,24 @@ Vex.Flow.Test.Tuning.checkStandard = function(tuning) {
   try {
     tuning.getValueForString(0);
   } catch (e) {
-    equals(e.code, "BadArguments", "String 0");
+    equal(e.code, "BadArguments", "String 0");
   }
 
   try {
     tuning.getValueForString(7);
   } catch (e) {
-    equals(e.code, "BadArguments", "String 7");
+    equal(e.code, "BadArguments", "String 7");
   }
 
-  equals(tuning.getValueForString(6), 40, "Low E string");
-  equals(tuning.getValueForString(5), 45, "A string");
-  equals(tuning.getValueForString(4), 50, "D string");
-  equals(tuning.getValueForString(3), 55, "G string");
-  equals(tuning.getValueForString(2), 59, "B string");
-  equals(tuning.getValueForString(1), 64, "High E string");
+  equal(tuning.getValueForString(6), 40, "Low E string");
+  equal(tuning.getValueForString(5), 45, "A string");
+  equal(tuning.getValueForString(4), 50, "D string");
+  equal(tuning.getValueForString(3), 55, "G string");
+  equal(tuning.getValueForString(2), 59, "B string");
+  equal(tuning.getValueForString(1), 64, "High E string");
 }
 
-Vex.Flow.Test.Tuning.standard = function(options) {
+Vex.Flow.Test.Tuning.standard = function() {
   expect(16);
 
   var tuning = new Vex.Flow.Tuning();
@@ -43,25 +43,25 @@ Vex.Flow.Test.Tuning.standard = function(options) {
   Vex.Flow.Test.Tuning.checkStandard(tuning);
 }
 
-Vex.Flow.Test.Tuning.noteForFret = function(options) {
+Vex.Flow.Test.Tuning.noteForFret = function() {
   expect(8);
   var tuning = new Vex.Flow.Tuning("E/5,B/4,G/4,D/4,A/3,E/3");
   try {
     tuning.getNoteForFret(-1, 1);
   } catch(e) {
-    equals(e.code, "BadArguments", "Fret -1");
+    equal(e.code, "BadArguments", "Fret -1");
   }
 
   try {
     tuning.getNoteForFret(1, -1);
   } catch(e) {
-    equals(e.code, "BadArguments", "String -1");
+    equal(e.code, "BadArguments", "String -1");
   }
 
-  equals(tuning.getNoteForFret(0, 1), "E/5", "High E string");
-  equals(tuning.getNoteForFret(5, 1), "A/5", "High E string, fret 5");
-  equals(tuning.getNoteForFret(0, 2), "B/4", "B string");
-  equals(tuning.getNoteForFret(0, 3), "G/4", "G string");
-  equals(tuning.getNoteForFret(12, 2), "B/5", "B string, fret 12");
-  equals(tuning.getNoteForFret(0, 6), "E/3", "Low E string");
+  equal(tuning.getNoteForFret(0, 1), "E/5", "High E string");
+  equal(tuning.getNoteForFret(5, 1), "A/5", "High E string, fret 5");
+  equal(tuning.getNoteForFret(0, 2), "B/4", "B string");
+  equal(tuning.getNoteForFret(0, 3), "G/4", "G string");
+  equal(tuning.getNoteForFret(12, 2), "B/5", "B string, fret 12");
+  equal(tuning.getNoteForFret(0, 6), "E/3", "Low E string");
 }

--- a/tests/voice_tests.js
+++ b/tests/voice_tests.js
@@ -11,7 +11,7 @@ Vex.Flow.Test.Voice.Start = function() {
   test("Ignore Test", Vex.Flow.Test.Voice.ignore);
 }
 
-Vex.Flow.Test.Voice.basic = function(options) {
+Vex.Flow.Test.Voice.basic = function() {
   expect(7);
   function createTickable() {
     return new Vex.Flow.Test.MockTickable(Vex.Flow.Test.TIME4_4);
@@ -27,24 +27,24 @@ Vex.Flow.Test.Voice.basic = function(options) {
   ];
 
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4);
-  equals(voice.totalTicks, BEAT * 4, "4/4 Voice has 4 beats");
-  equals(voice.ticksUsed, BEAT * 0, "No beats in voice");
+  equal(voice.totalTicks, BEAT * 4, "4/4 Voice has 4 beats");
+  equal(voice.ticksUsed, BEAT * 0, "No beats in voice");
   voice.addTickables(tickables);
-  equals(voice.ticksUsed, BEAT * 3, "Three beats in voice");
+  equal(voice.ticksUsed, BEAT * 3, "Three beats in voice");
   voice.addTickable(createTickable().setTicks(BEAT));
-  equals(voice.ticksUsed, BEAT * 4, "Four beats in voice");
-  equals(voice.isComplete(), true, "Voice is complete");
+  equal(voice.ticksUsed, BEAT * 4, "Four beats in voice");
+  equal(voice.isComplete(), true, "Voice is complete");
 
   try {
     voice.addTickable(createTickable().setTicks(BEAT));
   } catch (e) {
-    equals(e.code, "BadArgument", "Too many ticks exception");
+    equal(e.code, "BadArgument", "Too many ticks exception");
   }
 
-  equals(voice.getSmallestTickCount(), BEAT, "Smallest tick count is BEAT");
+  equal(voice.getSmallestTickCount(), BEAT, "Smallest tick count is BEAT");
 }
 
-Vex.Flow.Test.Voice.ignore = function(options) {
+Vex.Flow.Test.Voice.ignore = function() {
   function createTickable() {
     return new Vex.Flow.Test.MockTickable(Vex.Flow.Test.TIME4_4);
   }

--- a/vextab/vextab_tests.js
+++ b/vextab/vextab_tests.js
@@ -31,7 +31,7 @@ Vex.Flow.Test.VexTab.Start = function() {
 Vex.Flow.Test.VexTab.catchError = function(tab, code) {
   try {
     tab.parse(code);
-  } catch (e) {  equals(e.code, "ParseError", e.message); }
+  } catch (e) {  equal(e.code, "ParseError", e.message); }
 }
 
 Vex.Flow.Test.VexTab.basic = function() {
@@ -208,7 +208,6 @@ Vex.Flow.Test.VexTab.duration = function() {
 }
 
 Vex.Flow.Test.VexTab.notationOnly = function() {
-  expect(114);
   var tab = new Vex.Flow.VexTab();
 
   tab.parse("tabstave notation=true");
@@ -226,44 +225,44 @@ Vex.Flow.Test.VexTab.notationOnly = function() {
   Vex.Flow.Test.VexTab.catchError(tab, "tabstave notation=false tablature=false");
 
   /* CLEF TESTS */
-  clefs = ["treble", "alto", "tenor", "bass"]
-  for (var i = 0; i < clefs.lenght; i++) {
-    clef = clefs[i];
-    tab.parse("tabstave notation=true clef=" + clef)
-    ok(true, "Simple stave with " + clef + " clef")
+  var clefs = ["treble", "alto", "tenor", "bass"];
+  for (var c = 0; c < clefs.length; c++) {
+    var clef = clefs[c];
+    tab.parse("tabstave notation=true clef=" + clef);
+    ok(true, "Simple stave with " + clef + " clef");
 
-    tab.parse("tabstave clef=" + clef)
-    ok(true, "Simple stave with " + clef + " clef but notation off")
+    tab.parse("tabstave clef=" + clef);
+    ok(true, "Simple stave with " + clef + " clef but notation off");
   }
-  Vex.Flow.Test.VexTab.catchError(tab, "tabstave clef=blah")
+  Vex.Flow.Test.VexTab.catchError(tab, "tabstave clef=blah");
 
   /* KEY SIGNATURE TESTS */
   for (var key in Vex.Flow.keySignature.keySpecs) {
-    tab.parse("tabstave key=" + key)
-    ok(true, "Notation plus Key Signature for " + key)
+    tab.parse("tabstave key=" + key);
+    ok(true, "Notation plus Key Signature for " + key);
 
-    tab.parse("tabstave notation=true key=" + key)
-    ok(true, "Notation plus Key Signature for " + key)
+    tab.parse("tabstave notation=true key=" + key);
+    ok(true, "Notation plus Key Signature for " + key);
 
-    tab.parse("tabstave notation=true tablature=true key=" + key)
-    ok(true, "Notation plus Tablature plus Key Signature for " + key)
+    tab.parse("tabstave notation=true tablature=true key=" + key);
+    ok(true, "Notation plus Tablature plus Key Signature for " + key);
   }
-  Vex.Flow.Test.VexTab.catchError(tab, "tabstave notation=true key=rrr")
+  Vex.Flow.Test.VexTab.catchError(tab, "tabstave notation=true key=rrr");
 
   /* TIME SIGNATURE TESTS */
-  times = ["C", "C|", "2/4", "4/4", "100/4"];
+  var times = ["C", "C|", "2/4", "4/4", "100/4"];
   for (var i = 0; i < times.length; i++ ) {
-    time = times[i];
-    tab.parse("tabstave time=" + time)
-    ok(true, "Notation plus Time Signature for " + time)
+    var time = times[i];
+    tab.parse("tabstave time=" + time);
+    ok(true, "Notation plus Time Signature for " + time);
 
-    tab.parse("tabstave notation=true time=" + time)
-    ok(true, "Notation plus Time Signature for " + time)
+    tab.parse("tabstave notation=true time=" + time);
+    ok(true, "Notation plus Time Signature for " + time);
 
-    tab.parse("tabstave notation=true tablature=true time=" + time)
-    ok(true, "Notation plus Tablature plus Time Signature for " + time)
+    tab.parse("tabstave notation=true tablature=true time=" + time);
+    ok(true, "Notation plus Tablature plus Time Signature for " + time);
   }
-  Vex.Flow.Test.VexTab.catchError(tab, "tabstave notation=true time=rrr")
+  Vex.Flow.Test.VexTab.catchError(tab, "tabstave notation=true time=rrr");
   ok(true, "all pass");
 }
 


### PR DESCRIPTION
Upgraded QUnit to version 1.10.0.  The QUnit file that was replaced didn't even have a version in the header, so I'm assuming it was pretty old.
The new version is documented at: http://qunitjs.com/

In order to get the tests up and running, I had to go through and update many of them.  Most notably, the equals() function is now equal().

In addition to fixing the breaking changes between the two versions, I took the liberty of fixing some of the most egregious lint errors in the tests.
