### PR TITLE
Implement Cautionary/Curtesy Accidentals

### DIFF
--- a/src/accidental.js
+++ b/src/accidental.js
@@ -29,10 +29,25 @@ Vex.Flow.Accidental.prototype.init = function(type) {
   };
 
   this.accidental = Vex.Flow.accidentalCodes(this.type);
+
+  this.cautionary = false;      // true - draw as cautionary accidental
+  this.paren_left = null;
+  this.paren_right = null;
+
   this.setWidth(this.accidental.width);
 }
 
 Vex.Flow.Accidental.prototype.getCategory = function() { return "accidentals"; }
+Vex.Flow.Accidental.prototype.setAsCautionary = function() { 
+  this.cautionary = true;
+  // Set accidental size smaller than normal
+  this.render_options.font_scale = 28;
+  this.paren_left = Vex.Flow.accidentalCodes("{");
+  this.paren_right = Vex.Flow.accidentalCodes("}");
+  var width_adjust = (this.type == "##" || this.type == "bb") ? 6 : 4;
+  this.setWidth(this.paren_left.width + this.accidental.width + this.paren_right.width - width_adjust);
+  return this;
+}
 
 Vex.Flow.Accidental.prototype.draw = function() {
   if (!this.context) throw new Vex.RERR("NoContext",
@@ -44,6 +59,19 @@ Vex.Flow.Accidental.prototype.draw = function() {
   var acc_x = (start.x + this.x_shift) - this.width;
   var acc_y = start.y + this.y_shift;
 
-  Vex.Flow.renderGlyph(this.context, acc_x, acc_y,
-                       this.render_options.font_scale, this.accidental.code);
+  if (!this.cautionary) {
+    Vex.Flow.renderGlyph(this.context, acc_x, acc_y,
+                         this.render_options.font_scale, this.accidental.code);
+  } else {
+    acc_x += 3;
+    Vex.Flow.renderGlyph(this.context, acc_x, acc_y,
+                         this.render_options.font_scale, this.paren_left.code);
+    acc_x += 2;
+    Vex.Flow.renderGlyph(this.context, acc_x, acc_y,
+                         this.render_options.font_scale, this.accidental.code);
+    acc_x += this.accidental.width - 2;
+    if (this.type == "##" || this.type == "bb") acc_x -= 2;
+    Vex.Flow.renderGlyph(this.context, acc_x, acc_y,
+                         this.render_options.font_scale, this.paren_right.code);
+  }
 }

--- a/src/tables.js
+++ b/src/tables.js
@@ -343,6 +343,18 @@ Vex.Flow.accidentalCodes.accidentals = {
     width: 8,
     shift_right: 0,
     shift_down: 0
+  },
+  "{": {   // Left paren for cautionary accidentals
+    code: "v9c",
+    width: 5,
+    shift_right: 2,
+    shift_down: 0
+  },
+  "}": {   // Right paren for cautionary accidentals
+    code: "v84",
+    width: 5,
+    shift_right: 0,
+    shift_down: 0
   }
 };
 

--- a/tests/accidental_tests.js
+++ b/tests/accidental_tests.js
@@ -72,6 +72,14 @@ Vex.Flow.Test.Accidental.basic = function(options, contextBuilder) {
       addAccidental(4, newAcc("bb")).
       addAccidental(5, newAcc("##")).
       addAccidental(6, newAcc("#")),
+
+    newNote({ keys: ["a/3", "c/4", "e/4", "b/4", "d/5", "g/5"], duration: "w"}).
+      addAccidental(0, newAcc("#")).
+      addAccidental(1, newAcc("##").setAsCautionary()).
+      addAccidental(2, newAcc("#").setAsCautionary()).
+      addAccidental(3, newAcc("b")).
+      addAccidental(4, newAcc("bb").setAsCautionary()).
+      addAccidental(5, newAcc("b").setAsCautionary()),
   ];
 
   for (var i = 0; i < notes.length; ++i) {


### PR DESCRIPTION
accidentals.js - add setAsCautionary function and modify draw function
to draw a smaller accidental surrounded by parentheses.

tabls.js - add left and right paren to accidentalCodes.

accidental_tests.js - add sample cautionary accidentals to basic test.
