### PR TITLE
Correct y position for 'inline' articulations

### DIFF
--- a/src/modifiercontext.js
+++ b/src/modifiercontext.js
@@ -746,7 +746,12 @@ Vex.Flow.ModifierContext.prototype.formatArticulations = function() {
     articulation.setTextLine(text_line);
     var width = articulation.getWidth() > max_width ?
       articulation.getWidth() : max_width;
-    text_line += 1.5;
+
+    var type = Vex.Flow.articulationCodes(articulation.type);
+    if(type.between_lines)
+      text_line += 1;
+    else
+      text_line += 1.5;
   }
 
   this.state.left_shift += width / 2;

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -163,6 +163,28 @@ Vex.Flow.StaveNote.prototype.getBoundingBox = function() {
   return new Vex.Flow.BoundingBox(x, min_y, w, max_y - min_y);
 }
 
+/** Gets the line number of the top or bottom note in the chord.
+  * If (is_top_note === true), get top note
+  * Otherwise, get bottom note */
+Vex.Flow.StaveNote.prototype.getLineNumber = function(is_top_note) {
+  if(!this.keyProps.length) throw new Vex.RERR("NoKeyProps",
+      "Can't get bottom note line, because note is not initialized properly.");
+  var result_line = this.keyProps[0].line;
+
+  // No precondition assumed for sortedness of keyProps array
+  for(var i=0; i<this.keyProps.length; i++){
+    var this_line = this.keyProps[i].line;
+    if(is_top_note)
+      if(this_line > result_line)
+            result_line = this_line;
+    else
+      if(this_line < result_line)
+        result_line = this_line;
+  }
+
+  return result_line;
+}
+
 Vex.Flow.StaveNote.prototype.isRest = function() {
   return this.glyph.rest;
 }

--- a/src/tables.js
+++ b/src/tables.js
@@ -216,96 +216,109 @@ Vex.Flow.articulationCodes = function(artic) {
 }
 
 Vex.Flow.articulationCodes.articulations = {
-  "a.": {   // Stacato
+  "a.": {   // Staccato
     code: "v23",
     width: 4,
     shift_right: -2,
-    shift_up: 0,
-    shift_down: 0
+    shift_up: 8,
+    shift_down: 0,
+    between_lines: true
   },
   "av": {   // Staccatissimo
     code: "v28",
     width: 4,
     shift_right: 0,
-    shift_up: 2,
-    shift_down: 5
+    shift_up: 11,
+    shift_down: 5,
+    between_lines: true
   },
   "a>": {   // Accent
     code: "v42",
     width: 10,
     shift_right: 5,
-    shift_up: -2,
-    shift_down: 2
+    shift_up: 8,
+    shift_down: 1,
+    between_lines: true
   },
   "a-": {   // Tenuto
     code: "v25",
     width: 9,
     shift_right: -4,
-    shift_up: 8,
-    shift_down: 10
+    shift_up: 17,
+    shift_down: 10,
+    between_lines: true
   },
   "a^": {   // Marcato
     code: "va",
     width: 8,
     shift_right: 0,
-    shift_up: -10,
-    shift_down: -1
+    shift_up: -4,
+    shift_down: -2,
+    between_lines: false
   },
   "a+": {   // Left hand pizzicato
     code: "v8b",
     width: 9,
     shift_right: -4,
-    shift_up: 6,
-    shift_down: 12
+    shift_up: 12,
+    shift_down: 12,
+    between_lines: false
   },
   "ao": {   // Snap pizzicato
     code: "v94",
     width: 8,
     shift_right: 0,
     shift_up: -4,
-    shift_down: 4
+    shift_down: 6,
+    between_lines: false
   },
   "ah": {   // Natural harmonic or open note
     code: "vb9",
     width: 7,
     shift_right: 0,
     shift_up: -4,
-    shift_down: 4
+    shift_down: 4,
+    between_lines: false
   },
   "a@a": {   // Fermata above staff
     code: "v43",
     width: 25,
     shift_right: 0,
-    shift_up: 5,
-    shift_down: 0
+    shift_up: 8,
+    shift_down: 10,
+    between_lines: false
   },
   "a@u": {   // Fermata below staff
     code: "v5b",
     width: 25,
     shift_right: 0,
     shift_up: 0,
-    shift_down: -3
+    shift_down: -4,
+    between_lines: false
   },
   "a|": {   // Bow up - up stroke
     code: "v75",
     width: 8,
     shift_right: 0,
-    shift_up: 0,
-    shift_down: 11
+    shift_up: 8,
+    shift_down: 10,
+    between_lines: false
   },
   "am": {   // Bow down - down stroke
     code: "v97",
     width: 13,
     shift_right: 0,
-    shift_up: 0,
-    shift_down: 14
+    shift_up: 10,
+    shift_down: 12,
+    between_lines: false
   },
   "a,": {   // Choked
     code: "vb3",
     width: 6,
     shift_right: 8,
     shift_up: -4,
-    shift_down: 4
+    shift_down: 4,
+    between_lines: false
   }
 };
 

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -32,6 +32,10 @@ Vex.Flow.Test.Articulation.Start = function() {
     "a@a","a@u",Vex.Flow.Test.Articulation.drawFermata);
   Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Fermata Above/Below (Raphael)",
     "a@a","a@u",Vex.Flow.Test.Articulation.drawFermata);
+  Vex.Flow.Test.Articulation.runTest("Articulation - Inline/Multiple (Canvas)",
+    "a.","a.", Vex.Flow.Test.Articulation.drawArticulations2);
+  Vex.Flow.Test.Articulation.runRaphaelTest("Articulation - Inline/Multiple (Raphael)",
+    "a.","a.", Vex.Flow.Test.Articulation.drawArticulations2);
 }
 
 Vex.Flow.Test.Articulation.runTest = function(name, sym1, sym2, func, params) {
@@ -171,4 +175,122 @@ Vex.Flow.Test.Articulation.drawFermata = function(options, contextBuilder, sym1,
 
   // Helper function to justify and draw a 4/4 voice
   Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
+}
+
+Vex.Flow.Test.Articulation.drawArticulations2 = function(options, contextBuilder, sym1, sym2) {
+  expect(0);
+
+  // Get the rendering context
+  var ctx = contextBuilder(options.canvas_sel, 725, 200);
+
+  // bar 1
+  var staveBar1 = new Vex.Flow.Stave(10, 30, 250);
+  staveBar1.setContext(ctx).draw();
+  var notesBar1 = [
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["d/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["e/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["f/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["g/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["d/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["e/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["f/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["g/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["b/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/6"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["d/6"], duration: "16", stem_direction: -1 })
+  ];
+  for(var i=0; i<16; i++){
+    notesBar1[i].addArticulation(0, new Vex.Flow.Articulation("a.").setPosition(4));
+    notesBar1[i].addArticulation(0, new Vex.Flow.Articulation("a>").setPosition(4));
+    
+    if(i === 15)
+      notesBar1[i].addArticulation(0, new Vex.Flow.Articulation("a@u").setPosition(4));
+  }
+
+  var beam1 = new Vex.Flow.Beam(notesBar1.slice(0,8));
+  var beam2 = new Vex.Flow.Beam(notesBar1.slice(8,16));
+  
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+  beam1.setContext(ctx).draw();
+  beam2.setContext(ctx).draw();
+
+  // bar 2 - juxtaposing second bar next to first bar
+  var staveBar2 = new Vex.Flow.Stave(staveBar1.width + staveBar1.x, staveBar1.y, 250);
+  staveBar2.setContext(ctx).draw();
+  var notesBar2 = [
+    new Vex.Flow.StaveNote({ keys: ["f/3"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["g/3"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/3"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["b/3"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["d/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["e/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["f/4"], duration: "16", stem_direction: 1 }),
+    new Vex.Flow.StaveNote({ keys: ["g/4"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/4"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["d/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["e/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["f/5"], duration: "16", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["g/5"], duration: "16", stem_direction: -1 })
+  ];
+  for(i=0; i<16; i++){
+    notesBar2[i].addArticulation(0, new Vex.Flow.Articulation("a-").setPosition(3));
+    notesBar2[i].addArticulation(0, new Vex.Flow.Articulation("a^").setPosition(3));
+    
+    if(i === 15)
+      notesBar2[i].addArticulation(0, new Vex.Flow.Articulation("a@u").setPosition(4));
+  }
+
+  var beam3 = new Vex.Flow.Beam(notesBar2.slice(0,8));
+  var beam4 = new Vex.Flow.Beam(notesBar2.slice(8,16));
+  
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
+  beam3.setContext(ctx).draw();
+  beam4.setContext(ctx).draw();
+
+  // bar 3 - juxtaposing second bar next to first bar
+  var staveBar3 = new Vex.Flow.Stave(staveBar2.width + staveBar2.x, staveBar2.y, 75);
+  staveBar3.setContext(ctx).draw();
+
+  var notesBar3 = [
+    new Vex.Flow.StaveNote({ keys: ["c/4"], duration: "w", stem_direction: 1 })
+  ];
+  notesBar3[0].addArticulation(0, new Vex.Flow.Articulation("a-").setPosition(3));
+  notesBar3[0].addArticulation(0, new Vex.Flow.Articulation("a>").setPosition(3));
+  notesBar3[0].addArticulation(0, new Vex.Flow.Articulation("a@a").setPosition(3));
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar3, notesBar3);
+  // bar 4 - juxtaposing second bar next to first bar
+  var staveBar4 = new Vex.Flow.Stave(staveBar3.width + staveBar3.x, staveBar3.y, 125);
+  staveBar4.setEndBarType(Vex.Flow.Barline.type.END);
+  staveBar4.setContext(ctx).draw();
+
+  var notesBar4 = [
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["c/5"], duration: "q", stem_direction: -1 }),
+    new Vex.Flow.StaveNote({ keys: ["a/5"], duration: "q", stem_direction: -1 })
+  ];
+  for(i=0; i<4; i++){
+    var position1 = 3;
+    var position2 = 4;
+    if(i > 1){
+      position1 = 4;
+      position2 = 3;
+    }
+    notesBar4[i].addArticulation(0, new Vex.Flow.Articulation("a-").setPosition(position1));
+  }
+
+  // Helper function to justify and draw a 4/4 voice
+  Vex.Flow.Formatter.FormatAndDraw(ctx, staveBar4, notesBar4);
 }


### PR DESCRIPTION
Staccato, Staccatissimo, Accent, and Tenuto are drawn between stave lines when appropriate, and they will avoid overlapping any lines.

Tweaked placement of some articulations so that they don't overlap when stacked on the same note.

There is still room for improvement in the drawing functionality when dealing with multiple articulations on a single StaveNote. Instead of keeping track of a single 'line_spacing', you could keep track of 'line_spacing_above' and 'line_spacing_below'. There is also still unwanted space between inline (i.e. staccato, staccatissimo, accent, tenuto) and non-inline articulations when they are all above the same Middle-C note.

New Functions:
- Vex.Flow.StaveNote.prototype.getLineNum(is_top_note)

New Tests:
- Articulation - Inline/Multiple (Canvas)
- Articulation - Inline/Multiple (Raphael)
  ![Articulation - Inline:Multiple](https://f.cloud.github.com/assets/134487/316674/4d4fa66a-9835-11e2-9c3c-01b67ac29747.png)
