### PR TITLE
Colors and glow for individual keys in stave notes.

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,6 +68,14 @@ Vex.Flow.Renderer.bolsterCanvasContext = function(ctx) {
     this.strokeStyle = style;
     return this;
   }
+  ctx.setShadowColor = function(style) {
+    this.shadowColor = style;
+    return this;
+  }
+  ctx.setShadowBlur = function(blur) {
+    this.shadowBlur = blur;
+    return this;
+  }
   return ctx;
 }
 

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -39,6 +39,7 @@ Vex.Flow.StaveNote.prototype.init = function(note_struct) {
   this.notes_displaced = false;   // if true, displace note to right
   this.dot_shiftY = 0;
   this.keyProps = [];             // per-note properties
+  this.keyStyles = [];            // per-note colors or gradients
 
   // Pull per-note location and other rendering properties.
   this.displaced = false;
@@ -74,6 +75,7 @@ Vex.Flow.StaveNote.prototype.init = function(note_struct) {
 
     last_line = line;
     this.keyProps.push(props);
+    this.keyStyles.push(null);
   }
 
   // Sort the notes from lowest line to highest line
@@ -369,6 +371,11 @@ Vex.Flow.StaveNote.prototype.getGlyph = function() {
   return this.glyph;
 }
 
+Vex.Flow.StaveNote.prototype.setKeyStyle = function(index, style) {
+  this.keyStyles[index] = style;
+  return this;
+}
+
 Vex.Flow.StaveNote.prototype.addToModifierContext = function(mc) {
   this.setModifierContext(mc);
   for (var i = 0; i < this.modifiers.length; ++i) {
@@ -545,6 +552,7 @@ Vex.Flow.StaveNote.prototype.draw = function() {
 
   for (var i = start_i; i != end_i; i += step_i) {
     var note_props = this.keyProps[i];
+    var key_style = this.keyStyles[i];
     var line = note_props.line;
     highest_line = line > highest_line ? line : highest_line;
     lowest_line = line < lowest_line ? line : lowest_line;
@@ -585,7 +593,15 @@ Vex.Flow.StaveNote.prototype.draw = function() {
 
     // Draw the head.
     if (render_head) {
-     head_x = Math.round(head_x);
+      head_x = Math.round(head_x);
+
+      ctx.save();
+
+      if (key_style) {
+        if (key_style.shadowColor) ctx.setShadowColor(key_style.shadowColor);
+        if (key_style.shadowBlur) ctx.setShadowBlur(key_style.shadowBlur);
+        if (key_style.fillStyle) ctx.setFillStyle(key_style.fillStyle);
+      }
 
       // if a slash note, draw 'manually' as font glyphs do not slant enough
       // and are too small.
@@ -595,6 +611,8 @@ Vex.Flow.StaveNote.prototype.draw = function() {
         Vex.Flow.renderGlyph(ctx, head_x,
             y, this.render_options.glyph_font_scale, code_head);
       }
+
+      ctx.restore();
 
       // If note above/below the staff, draw the small staff
       if (line <= 0 || line >= 6) {

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -62,6 +62,11 @@ Vex.Flow.Test.StaveNote.Start = function() {
   Vex.Flow.Test.runTest("StaveNote Draw - Bass", Vex.Flow.Test.StaveNote.drawBass);
   Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Bass(Raphael)",
       Vex.Flow.Test.StaveNote.drawBass);
+
+  Vex.Flow.Test.runTest("StaveNote Draw - Key Styles",
+      Vex.Flow.Test.StaveNote.drawKeyStyles);
+  Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Key Styles (Raphael)",
+      Vex.Flow.Test.StaveNote.drawKeyStyles);
 }
 
 Vex.Flow.Test.StaveNote.ticks = function(options) {
@@ -680,4 +685,23 @@ Vex.Flow.Test.StaveNote.drawSlash = function(options, contextBuilder) {
     ok(staveNote.getX() > 0, "Note " + i + " has X value");
     ok(staveNote.getYs().length > 0, "Note " + i + " has Y values");
   }
+}
+
+Vex.Flow.Test.StaveNote.drawKeyStyles = function(options, contextBuilder) {
+  var ctx = new contextBuilder(options.canvas_sel, 300, 180);
+  var stave = new Vex.Flow.Stave(10, 10, 200);
+  stave.setContext(ctx);
+  stave.draw();
+
+  var note_struct = { keys: ["g/4","b/4","d/5"], duration: "q" };
+  var note = new Vex.Flow.StaveNote(note_struct);
+  note.setKeyStyle(1, {shadowBlur:15, shadowColor:'blue', fillStyle:'blue'});
+
+  var tickContext = new Vex.Flow.TickContext();
+  tickContext.addTickable(note).preFormat().setX(25).setPixelsUsed(20);
+  note.setContext(ctx).setStave(stave);
+  note.draw();
+
+  ok(note.getX() > 0, "Note has X value");
+  ok(note.getYs().length > 0, "Note has Y values");
 }


### PR DESCRIPTION
The API is very simple, though I'm happy to make any changes necessary. Fully tested in canvas, Raphael, and Node.js canvas (on my `colors` branch, from which this was cherry-picked).

```
var note_struct = { keys: ["g/4","b/4","d/5"], duration: "q" };
var note = new Vex.Flow.StaveNote(note_struct);
note.setKeyStyle(1, {shadowBlur:15, shadowColor:'blue', fillStyle:'blue'});
```

![Screen shot](https://f.cloud.github.com/assets/20748/510614/893e09ee-bddf-11e2-997c-fa566e9be16b.png)
