### PR TITLE
Fix key parsing for explicitly major keys.

### DIFF
--- a/src/music.js
+++ b/src/music.js
@@ -167,14 +167,12 @@ Vex.Flow.Music = (function() {
       if (!keyString || keyString.length < 1)
         throw new Vex.RERR("BadArguments", "Invalid key: " + keyString);
 
-      var key = keyString.toLowerCase();
-
       // Support Major, Minor, Melodic Minor, and Harmonic Minor key types.
-      var regex = /^([cdefgab])(b|#)?(mel|harm|m|M)?$/;
-      var match = regex.exec(key);
+      var regex = /^([a-gA-G])(b|#)?(mel|harm|m|M)?$/;
+      var match = regex.exec(keyString);
 
       if (match != null) {
-        var root = match[1];
+        var root = match[1].toLowerCase();
         var accidental = match[2];
         var type = match[3];
 

--- a/tests/music_tests.js
+++ b/tests/music_tests.js
@@ -54,7 +54,7 @@ Vex.Flow.Test.Music.validNotes = function() {
 }
 
 Vex.Flow.Test.Music.validKeys = function() {
-  expect(18);
+  expect(21);
 
   var music = new Vex.Flow.Music();
 
@@ -66,6 +66,11 @@ Vex.Flow.Test.Music.validKeys = function() {
   parts = music.getKeyParts("d#");
   equal(parts.root, "d");
   equal(parts.accidental, "#");
+  equal(parts.type, "M");
+
+  parts = music.getKeyParts("BbM");
+  equal(parts.root, "b");
+  equal(parts.accidental, "b");
   equal(parts.type, "M");
 
   parts = music.getKeyParts("fbm");


### PR DESCRIPTION
`Vex.Flow.Music#getKeyParts()` is broken for major keys that explicitly use the suffix "M", rather than relying on major as the default when no key type is specified. For example, "CM" is interpreted as C minor, rather than C major as expected.

This is because the entire key string is lowercased before parsing, including the key type suffix. With this change, only the note-name portion of the key is case-insensitive, to properly distinguish between key types "m" and "M".
