### PR TITLE
fix top text annotation collision with note head

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -121,10 +121,10 @@ Vex.Flow.Annotation = (function() {
         y = yt + ( yb - yt ) / 2 + text_height / 2;
       } else if (this.vert_justification ==
                  Annotation.VerticalJustify.TOP) {
-        y = this.note.stave.getYForTopText(this.text_line);
-        if (stem_ext)
-          y = Vex.Min(y, (stem_ext.topY - 5) - (spacing * this.text_line));
-      } else /* CENTER_STEM */{
+        y = Vex.Min(this.note.stave.getYForTopText(this.text_line), this.note.ys[0] - 10);
+		if (stem_ext)
+			y = Vex.Min(y, (stem_ext.topY - 5) - (spacing * this.text_line));
+     } else /* CENTER_STEM */{
         var extents = this.note.getStemExtents();
         y = extents.topY + ( extents.baseY - extents.topY ) / 2 +
           text_height / 2;

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -182,15 +182,17 @@ Vex.Flow.Test.Annotation.justification = function(options, contextBuilder) {
       addClef("treble").setContext(ctx).draw();
 
     notes = [];
-
-    notes.push(newNote({ keys: ["c/3"], duration: "q"}).addAnnotation(0, newAnnotation("Text", 1, v)));
-    notes.push(newNote({ keys: ["c/4"], duration: "q"}).addAnnotation(0, newAnnotation("Text", 2, v)));
-    notes.push(newNote({ keys: ["c/5"], duration: "q"}).addAnnotation(0, newAnnotation("Text", 3, v)));
-    notes.push(newNote({ keys: ["c/6"], duration: "q"}).addAnnotation(0, newAnnotation("Text", 4, v)));
+    notes.push(newNote({ keys: ["c/3"], duration: "8", stem_direction:-1}).addAnnotation(0, newAnnotation("Text", 1, v)));
+    notes.push(newNote({ keys: ["c/4"], duration: "8", stem_direction:-1}).addAnnotation(0, newAnnotation("Text", 2, v)));
+    notes.push(newNote({ keys: ["c/5"], duration: "8", stem_direction:-1}).addAnnotation(0, newAnnotation("Text", 3, v)));
+    notes.push(newNote({ keys: ["c/6"], duration: "8", stem_direction:-1}).addAnnotation(0, newAnnotation("Text", 4, v)));
+    notes.push(newNote({ keys: ["c/3"], duration: "8", stem_direction:1}).addAnnotation(0, newAnnotation("Text", 1, v)));
+    notes.push(newNote({ keys: ["c/4"], duration: "8", stem_direction:1}).addAnnotation(0, newAnnotation("Text", 2, v)));
+    notes.push(newNote({ keys: ["c/5"], duration: "8", stem_direction:1}).addAnnotation(0, newAnnotation("Text", 3, v)));
+    notes.push(newNote({ keys: ["c/6"], duration: "8", stem_direction:1}).addAnnotation(0, newAnnotation("Text", 4, v)));
 
     Vex.Flow.Formatter.FormatAndDraw(ctx, stave, notes, 100);
   }
-
   ok(true, "Test Justification Annotation");
 }
 


### PR DESCRIPTION
Added test for text annotation with stems up and down. fixed the problem with top text annotation. still there are problems with the bottom annotation that I couldn't solve.

images are the tests of the 
![after](https://f.cloud.github.com/assets/4021701/2238881/8d26d3c8-9c06-11e3-95d7-35776ba16088.jpg)
![before](https://f.cloud.github.com/assets/4021701/2238882/8d28da9c-9c06-11e3-9550-ac7791b62121.jpg)

 annotation before and after the commit
