### PR TITLE
Beam groups

### DIFF
--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -92,6 +92,11 @@ Vex.Flow.StemmableNote = (function(){
       return stem_x;
     },
 
+    // Used for TabNote stems and Stemlets over rests
+    getCenterGlyphX: function(){
+      return this.getAbsoluteX() + this.x_shift + (this.glyph.head_width / 2);
+    },
+
     // Manuallly set note stem length
     setStemLength: function(height) {
       this.stem_extension = (height - Stem.HEIGHT);

--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -173,7 +173,7 @@ Vex.Flow.TabNote = (function() {
     },
 
     getStemX: function() {
-      return this.getAbsoluteX() + this.x_shift + (this.glyph.head_width / 2);
+      return this.getCenterGlyphX();
     },
 
     getStemY: function(){

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -9,6 +9,14 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.moreSimple0);
   Vex.Flow.Test.runTest("More Simple Auto Beaming 1",
                         Vex.Flow.Test.AutoBeamFormatting.moreSimple1);
+  Vex.Flow.Test.runTest("Auto Beaming - Beam Across All Rests",
+                        Vex.Flow.Test.AutoBeamFormatting.beamAcrossAllRests);
+  Vex.Flow.Test.runTest("Auto Beaming - Beam Across All Rests with Stemlets",
+                        Vex.Flow.Test.AutoBeamFormatting.beamAcrossAllRestsWithStemlets);
+  Vex.Flow.Test.runTest("Auto Beaming - Break Beams on Middle Rests Only",
+                        Vex.Flow.Test.AutoBeamFormatting.beamAcrossMiddleRests);
+  Vex.Flow.Test.runTest("Auto Beaming - Break Beams on Rest",
+                        Vex.Flow.Test.AutoBeamFormatting.breakBeamsOnRests);
   Vex.Flow.Test.runTest("Odd Time - Guessing Default Beam Groups",
                         Vex.Flow.Test.AutoBeamFormatting.autoOddBeamGroups);
   Vex.Flow.Test.runTest("Custom Beam Groups",
@@ -25,7 +33,7 @@ Vex.Flow.Test.AutoBeamFormatting.setupContext = function(options, x, y) {
   var ctx = new options.contextBuilder(options.canvas_sel, x || 450, y || 140);
   ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
   ctx.font = " 10pt Arial";
-  var stave = new Vex.Flow.Stave(10, 10, x || 450).addTrebleGlyph().
+  var stave = new Vex.Flow.Stave(10, 40, x || 450).addTrebleGlyph().
     setContext(ctx).draw();
 
   return {context: ctx, stave: stave};
@@ -35,7 +43,7 @@ function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
 
 Vex.Flow.Test.AutoBeamFormatting.simpleAuto = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["f/5"], duration: "8"}),
@@ -67,12 +75,12 @@ Vex.Flow.Test.AutoBeamFormatting.simpleAuto = function(options, contextBuilder) 
     beam.setContext(c.context).draw();
   });
 
-  ok(true, "Auto Beam Applicator Test");
+  ok(true, "Auto Beaming Applicator Test");
 }
 
 Vex.Flow.Test.AutoBeamFormatting.oddBeamGroups = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["f/5"], duration: "8"}),
@@ -118,7 +126,7 @@ Vex.Flow.Test.AutoBeamFormatting.oddBeamGroups = function(options, contextBuilde
 
 Vex.Flow.Test.AutoBeamFormatting.moreSimple0 = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["c/4"], duration: "8"}),
@@ -150,25 +158,25 @@ Vex.Flow.Test.AutoBeamFormatting.moreSimple0 = function(options, contextBuilder)
 
 Vex.Flow.Test.AutoBeamFormatting.moreSimple1 = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["c/5"], duration: "16"}),
     newNote({ keys: ["g/5"], duration: "16"}),
     newNote({ keys: ["c/5"], duration: "16"}),
-    newNote({ keys: ["b/4"], duration: "16r"}),
-    newNote({ keys: ["b/4"], duration: "16r"}),
-    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["c/5"], duration: "16r"}),
+    newNote({ keys: ["c/5"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
     newNote({ keys: ["d/4"], duration: "16"}),
     newNote({ keys: ["a/5"], duration: "16"}),
     newNote({ keys: ["c/4"], duration: "16"}),
     newNote({ keys: ["g/4"], duration: "16"}),
     newNote({ keys: ["c/5"], duration: "16"}),
     newNote({ keys: ["b/4"], duration: "16r"}),
-    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["c/4", "e/4"], duration: "16"}),
     newNote({ keys: ["b/4"], duration: "16r"}),
     newNote({ keys: ["b/4"], duration: "16r"}),
-    newNote({ keys: ["a/5"], duration: "16"})
+    newNote({ keys: ["a/4"], duration: "16"})
   ];
 
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
@@ -176,6 +184,225 @@ Vex.Flow.Test.AutoBeamFormatting.moreSimple1 = function(options, contextBuilder)
   voice.addTickables(notes);
 
   var beams = Vex.Flow.Beam.applyAndGetBeams(voice);
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.breakBeamsOnRests = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["g/5"], duration: "16"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["a/5"], duration: "16"}),
+    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["g/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["g/4", "e/4"], duration: "32"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "16r"}),
+    newNote({ keys: ["a/4"], duration: "16"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: false
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+Vex.Flow.Test.AutoBeamFormatting.beamAcrossAllRestsWithStemlets = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["g/5"], duration: "16"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["a/5"], duration: "16"}),
+    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["g/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["g/4", "e/4"], duration: "32"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "16r"}),
+    newNote({ keys: ["a/4"], duration: "16"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: true,
+    show_stemlets: true
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.beamAcrossAllRests = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["a/5"], duration: "16"}),
+    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["g/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["g/4", "e/4"], duration: "32"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "16r"}),
+    newNote({ keys: ["a/4"], duration: "16"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: true
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+Vex.Flow.Test.AutoBeamFormatting.beamAcrossMiddleRests = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["g/5"], duration: "16"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["a/5"], duration: "16"}),
+    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["g/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["g/4", "e/4"], duration: "32"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "16r"}),
+    newNote({ keys: ["a/4"], duration: "16"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: true,
+    beam_middle_only: true
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.breakBeamsOnRests = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["g/5"], duration: "16"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["a/5"], duration: "16"}),
+    newNote({ keys: ["c/4"], duration: "16"}),
+    newNote({ keys: ["g/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16"}),
+    newNote({ keys: ["b/4"], duration: "16r"}),
+    newNote({ keys: ["g/4", "e/4"], duration: "32"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["b/4"], duration: "32r"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "16r"}),
+    newNote({ keys: ["a/4"], duration: "16"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: false
+  });
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
@@ -375,8 +602,8 @@ Vex.Flow.Test.AutoBeamFormatting.customBeamGroups = function(options, contextBui
 
   var group3 = [
     new Vex.Flow.Fraction(7, 16),
-    new Vex.Flow.Fraction(3, 16),
-    new Vex.Flow.Fraction(3, 16)
+    new Vex.Flow.Fraction(2, 16),
+    new Vex.Flow.Fraction(4, 16)
   ];
 
   var beams = Vex.Flow.Beam.applyAndGetBeams(voice1, undefined, group1);
@@ -408,7 +635,7 @@ Vex.Flow.Test.AutoBeamFormatting.customBeamGroups = function(options, contextBui
 
 Vex.Flow.Test.AutoBeamFormatting.simpleTuplets = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["c/4"], duration: "8"}),
@@ -448,7 +675,7 @@ Vex.Flow.Test.AutoBeamFormatting.simpleTuplets = function(options, contextBuilde
 
 Vex.Flow.Test.AutoBeamFormatting.moreSimpleTuplets = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["d/4"], duration: "4"}),
@@ -484,7 +711,7 @@ Vex.Flow.Test.AutoBeamFormatting.moreSimpleTuplets = function(options, contextBu
 
 Vex.Flow.Test.AutoBeamFormatting.moreBeaming = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
-  var c = Vex.Flow.Test.Beam.setupContext(options);
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
     newNote({ keys: ["c/4"], duration: "8"}),


### PR DESCRIPTION
This isn't quite ready to merge. I'm not really sure about my implementation of `getDefaultBeamGroups`.

What are your thoughts of having a "Time Signature Default Beam Group" table? If you look at my implementation, it first looks for a hard-corded default, and if unsuccessful, guesses off of the meter. But I think I need to do some more research on exact beam rules. Or, at least, what is used often enough to be considered a default.

I also solved a bug where >= quarter note triplets caused weird beam groups.
