### PR TITLE
End secondary beams

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -261,6 +261,11 @@ Vex.Flow.Beam = (function() {
             } else {
               current_beam = beam_lines[beam_lines.length - 1];
               current_beam.end = stem_x;
+              
+              // End secondary beams
+              if (note.end_secondary_beams && parseInt(duration, 10) >= 8) {
+                beam_started = false;
+              }
             }
           } else {
             if (!beam_started) {

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -110,6 +110,8 @@ Vex.Flow.StaveNote = (function() {
         this.setStemDirection(note_struct.stem_direction);
       }
 
+      this.end_secondary_beams = note_struct.end_secondary_beams;
+
       // Calculate left/right padding
       this.calcExtraPx();
     },


### PR DESCRIPTION
Initial pull request for issue #171

> My initial implementation is very simple. I added a `StaveNote.end_secondary_beams` property, which you can set on construction. So to break up the group into groups of three, add the flag every third `StaveNote`.
> 
> ![image](https://f.cloud.github.com/assets/1631625/2433676/fcba409a-ad99-11e3-9d58-f1b6b4b70da4.png)

```
new Vex.Flow.StaveNote({ keys: ["c/4"], stem_direction: -1, duration: "16", end_secondary_beams: true}),
```

> Another option would be to store an array in the `Beam` which would contain indices of the notes to break on.
> 
> Probably the best - and more complex - option is to set secondary beam groups in a way similar to the new auto-beaming, to automatically set secondary beam groups based on a rational or sequence of rationals.
