### PR TITLE
Break secondary beams - new pull request

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -122,7 +122,7 @@ Vex.Flow.Beam = (function() {
       return maxBeamCount;
     },
 
-    setSecondaryBeamBreakIndices: function(indices) {
+    breakSecondaryAt: function(indices) {
       this.break_on_indices = indices;
       return this;
     },

--- a/tests/beam_tests.js
+++ b/tests/beam_tests.js
@@ -226,14 +226,14 @@ Vex.Flow.Test.Beam.breakSecondaryBeams = function(options, contextBuilder) {
   var beam1_1 = new Vex.Flow.Beam(notes.slice(0, 6));
   var beam1_2 = new Vex.Flow.Beam(notes.slice(6, 12));
 
-  beam1_1.setSecondaryBeamBreakIndices([1, 3]);
-  beam1_2.setSecondaryBeamBreakIndices([2]);
+  beam1_1.breakSecondaryAt([1, 3]);
+  beam1_2.breakSecondaryAt([2]);
 
   var beam2_1 = new Vex.Flow.Beam(notes2.slice(0, 12));
   var beam2_2 = new Vex.Flow.Beam(notes2.slice(12, 18));
 
-  beam2_1.setSecondaryBeamBreakIndices([3, 7, 11]);
-  beam2_2.setSecondaryBeamBreakIndices([3]);
+  beam2_1.breakSecondaryAt([3, 7, 11]);
+  beam2_2.breakSecondaryAt([3]);
 
   voice.draw(c.context, c.stave);
   voice2.draw(c.context, c.stave);


### PR DESCRIPTION
Works like this:

``` javascript
beam.setSecondaryBeamBreakIndices([1, 3]); // renders groups of two in a 6 note beam
```

Also, it looks like I accidentally committed the secondary bream break test in the grace note branch. But it's been updated now to work with this new implementation.

![image](https://f.cloud.github.com/assets/1631625/2455463/78ad037a-aeff-11e3-93b6-d5c4ddd11517.png)
