### PR TITLE
Fixes key style bug

### DIFF
--- a/src/notehead.js
+++ b/src/notehead.js
@@ -60,7 +60,7 @@ Vex.Flow.NoteHead = (function() {
       }
       this.glyph_font_scale = head_options.glyph_font_scale;
       this.context = null;
-      this.key_style = null;
+      this.key_style = head_options.key_style;
       this.slashed = head_options.slashed;
     },
 


### PR DESCRIPTION
Key styles weren't being passed to the `NoteHead`. Test now actually renders with a styled key:

![image](https://f.cloud.github.com/assets/1631625/2456077/9f36306a-af0f-11e3-8ad8-d280dee9358a.png)
