### PR TITLE
Enables the 5th beam line representing 128th notes

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -300,7 +300,7 @@ Vex.Flow.Beam = (function() {
         return beam_lines;
       }
 
-      var valid_beam_durations = ["4", "8", "16", "32"];
+      var valid_beam_durations = ["4", "8", "16", "32", "64"];
 
       // Draw the beams.
       for (i = 0; i < valid_beam_durations.length; ++i) {


### PR DESCRIPTION
Previously, beaming 128th notes would not draw the 5th line, so they would resemble beamed 64th notes.
