### PR TITLE
Bug fix: Slashed note heads

### DIFF
--- a/src/notehead.js
+++ b/src/notehead.js
@@ -15,12 +15,12 @@ Vex.Flow.NoteHead = (function() {
     var width = 15 + (Vex.Flow.STEM_WIDTH / 2);
     ctx.setLineWidth(Vex.Flow.STEM_WIDTH);
 
-    var fill = true;
+    var fill = false;
     if (duration != 1 &&
         duration != 2 &&
         duration != "h" &&
         duration != "w") {
-      fill = false;
+      fill = true;
     }
 
     if (!fill) x -= (Vex.Flow.STEM_WIDTH / 2) * stem_direction;


### PR DESCRIPTION
Minor fix. `fill` boolean was backwards. Was filling in Whole notes and half notes, and leaving everything shorter unfilled.
**Bug:**
![image](https://f.cloud.github.com/assets/1631625/2466282/904b40d8-afad-11e3-820b-db223ad30132.png)
**Fixed:**
![image](https://f.cloud.github.com/assets/1631625/2466290/a1343c1a-afad-11e3-9568-84bae144e6ca.png)
