### PR TITLE
Draw noteheads after stem

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -37,6 +37,7 @@ Vex.Flow.StaveNote = (function() {
       this.dot_shiftY = 0;
       this.keyProps = [];             // per-note properties
       this.keyStyles = [];            // per-note colors or gradients
+      this.note_heads = [];
 
       // Pull per-note location and other rendering properties.
       this.displaced = false;
@@ -483,8 +484,7 @@ Vex.Flow.StaveNote = (function() {
         });
 
         var head_x = note_head.getAbsoluteX();
-
-        note_head.setContext(this.context).draw();
+        this.note_heads.push(note_head);
 
         // If note above/below the staff, draw the small staff
         if (line <= 0 || line >= 6) {
@@ -539,6 +539,10 @@ Vex.Flow.StaveNote = (function() {
           stem_direction: stem_direction
         });
       }
+
+      this.note_heads.forEach(function(note_head) {
+        note_head.setContext(this.context).draw();
+      }, this);
 
       // Now it's the flag's turn.
       if (glyph.flag && render_flag) {

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -717,8 +717,9 @@ Vex.Flow.Test.StaveNote.drawSlash = function(options, contextBuilder) {
 }
 
 Vex.Flow.Test.StaveNote.drawKeyStyles = function(options, contextBuilder) {
-  var ctx = new contextBuilder(options.canvas_sel, 300, 180);
-  var stave = new Vex.Flow.Stave(10, 10, 200);
+  var ctx = new contextBuilder(options.canvas_sel, 300, 280);
+  var stave = new Vex.Flow.Stave(10, 0, 100);
+  ctx.scale(3, 3);
   stave.setContext(ctx);
   stave.draw();
 


### PR DESCRIPTION
This pull request re-orders the drawing order in `StaveNote`so that the note heads are rendered on top of the stem instead of the other way around. This really only matters when the note/stem are different colors.

**OLD**
![image](https://f.cloud.github.com/assets/1631625/2478092/eab762a0-b079-11e3-89c1-b7002c39aef4.png)

**NEW**
![image](https://f.cloud.github.com/assets/1631625/2478085/c5dcab48-b079-11e3-8477-b1860820d3d9.png)
