### PR TITLE
Added StaveLine class, draws configurable lines between notes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,8 @@ base_sources = [
   "src/frethandfinger.js",
   "src/stringnumber.js",
   "src/strokes.js",
-  "src/curve.js"
+  "src/curve.js",
+  "src/staveline.js",
 ]
 
 # Don't minify these files.

--- a/src/staveline.js
+++ b/src/staveline.js
@@ -1,0 +1,323 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+// 
+// This file implements `StaveLine` which are simply lines that connect
+// two notes. This object is highly configurable, see the `render_options`.
+// A simple line is often used for notating glissando articulations, but you 
+// can format a `StaveLine` with arrows or colors for more pedagogical
+// purposes, such as diagrams.
+Vex.Flow.StaveLine = (function() {
+  function StaveLine(notes) {
+    if (arguments.length > 0) this.init(notes);
+  }
+
+  // Text Positioning
+  StaveLine.TextVerticalPosition = {
+    TOP: 1,
+    BOTTOM: 2
+  };
+
+  StaveLine.TextJustification = {
+    LEFT: 1,
+    CENTER: 2,
+    RIGHT: 3
+  };
+
+  // ## Prototype Methods
+  StaveLine.prototype = {
+    // Initialize the StaveLine with the given `notes`.
+    // 
+    // `notes` is a struct that has:
+    //
+    //  ```
+    //  {
+    //    first_note: Note,
+    //    last_note: Note,
+    //    first_indices: [n1, n2, n3],
+    //    last_indices: [n1, n2, n3]
+    //  }
+    //  ```
+    init: function(notes) {
+      this.notes = notes;
+      this.context = null;
+
+      this.text = "";
+
+      this.font = {
+        family: "Arial",
+        size: 10,
+        weight: ""
+      };
+
+      this.render_options = {
+        // Space to add to the left or the right
+        padding_left: 4,
+        padding_right: 3,
+
+        // The width of the line in pixels
+        line_width: 1,
+        // An array of line/space lengths
+        line_dash: null,
+        // Can draw rounded line end, instead of a square
+        rounded_end: true,
+        // The color of the line and arrowheads
+        color: null,
+
+        // Flags to draw arrows on each end of the line
+        draw_start_arrow: false,
+        draw_end_arrow: false,
+
+        // The length of the arrowhead sides
+        arrowhead_length: 10,
+        // The angle of the arrowhead
+        arrowhead_angle: Math.PI / 8,
+
+        // The position of the text
+        text_position_vertical: StaveLine.TextVerticalPosition.TOP,
+        text_justification: StaveLine.TextJustification.CENTER
+      };
+
+      this.setNotes(notes);
+    },
+
+    // Set the rendering context
+    setContext: function(context) { this.context = context; return this; },
+    // Set the font for the `StaveLine` text
+    setFont: function(font) { this.font = font; return this; },
+    // The the annotation for the `StaveLine`
+    setText: function(text) { this.text = text; return this; },
+
+    // Set the notes for the `StaveLine`
+    setNotes: function(notes) {
+      if (!notes.first_note && !notes.last_note)
+        throw new Vex.RuntimeError("BadArguments",
+            "Notes needs to have either first_note or last_note set.");
+
+      if (!notes.first_indices) notes.first_indices = [0];
+      if (!notes.last_indices) notes.last_indices = [0];
+
+      if (notes.first_indices.length != notes.last_indices.length)
+        throw new Vex.RuntimeError("BadArguments", "Connected notes must have similar" +
+          " index sizes");
+
+      // Success. Lets grab 'em notes.
+      this.first_note = notes.first_note;
+      this.first_indices = notes.first_indices;
+      this.last_note = notes.last_note;
+      this.last_indices = notes.last_indices;
+      return this;
+    },
+
+    // Apply the style of the `StaveLine` to the context
+    applyLineStyle: function() {
+      if (!this.context) {
+        throw new Vex.RERR("NoContext","No context to apply the styling to");
+      }
+
+      var render_options = this.render_options;
+      var ctx = this.context;
+
+      if (render_options.line_dash) {
+        ctx.setLineDash(render_options.line_dash);
+      }
+
+      if (render_options.line_width) {
+        ctx.setLineWidth(render_options.line_width);
+      }
+
+      if (render_options.rounded_end) {
+        ctx.lineCap = "round";
+      } else {
+        ctx.lineCap = "square";
+      }
+
+      if (this.font) {
+        ctx.setFont(this.font.family, this.font.size, this.font.weight);
+      }
+    },
+
+    // Renders the `StaveLine` on the context
+    draw: function() {
+      if (!this.context) {
+        throw new Vex.RERR("NoContext", "No context to render StaveLine.");
+      }
+
+      var ctx = this.context;
+      var first_note = this.first_note;
+      var last_note = this.last_note;
+      var render_options = this.render_options;
+
+      ctx.save();
+      this.applyLineStyle();
+
+      // Cycle through each set of indices and draw lines
+      var start_position;
+      var end_position;
+      this.first_indices.forEach(function(first_index, i) {
+        var last_index = this.last_indices[i];
+
+        // Get initial coordinates for the start/end of the line
+        start_position = first_note.getModifierStartXY(2, first_index);
+        end_position = last_note.getModifierStartXY(1, last_index);
+        var upwards_slope = start_position.y > end_position.y;
+
+        // Adjust `x` coordinates for modifiers
+        start_position.x += first_note.getMetrics().modRightPx +
+                            render_options.padding_left;
+        end_position.x -= last_note.getMetrics().modLeftPx +
+                          render_options.padding_right;
+
+
+        // Adjust first `x` coordinates for displacements
+        var notehead_width = first_note.getGlyph().head_width;
+        var first_displaced = first_note.getKeyProps()[first_index].displaced;
+        if (first_displaced && first_note.getStemDirection() === 1) {
+          start_position.x += notehead_width + render_options.padding_left;
+        }
+
+        // Adjust last `x` coordinates for displacements
+        var last_displaced = last_note.getKeyProps()[last_index].displaced;
+        if (last_displaced && last_note.getStemDirection() === -1) {
+          end_position.x -= notehead_width + render_options.padding_right;
+        }
+
+        // Adjust y position better if it's not coming from the center of the note
+        start_position.y += upwards_slope ? -3 : 1;
+        end_position.y += upwards_slope ? 2 : 0;
+        
+        drawArrowLine(ctx, start_position, end_position, this.render_options);
+
+      }, this);
+    
+      // Determine the x coordinate where to start the ext
+      var text_width = ctx.measureText(this.text).width;
+      var justification = render_options.text_justification;
+      var x = 0;
+      if (justification === StaveLine.TextJustification.LEFT) {
+        x = start_position.x;
+      } else if (justification === StaveLine.TextJustification.CENTER) {
+        var delta_x = (end_position.x - start_position.x);
+        var center_x = (delta_x / 2 ) + start_position.x;
+        x = center_x - (text_width / 2);
+      } else if (justification === StaveLine.TextJustification.RIGHT) {
+        x = end_position.x  -  text_width;
+      }
+
+      // Determine the y value to start the text
+      var y;
+      var vertical_position = render_options.text_position_vertical;
+      if (vertical_position === StaveLine.TextVerticalPosition.TOP) {
+        y = first_note.getStave().getYForTopText();
+      } else if (vertical_position === StaveLine.TextVerticalPosition.BOTTOM) {
+        y = first_note.getStave().getYForBottomText();
+      }
+
+      // Draw the text
+      ctx.fillText(this.text, x, y);
+      ctx.restore();
+
+      return this;
+    }
+  };
+
+  // ## Private Helpers
+  // 
+  // Attribution: Arrow rendering implementations based off of
+  // Patrick Horgan's article, "Drawing lines and arcs with 
+  // arrow heads on  HTML5 Canvas"
+  // 
+  // Draw an arrow head that connects between 3 coordinates
+  function drawArrowHead(ctx, x0, y0, x1, y1, x2, y2) {
+    var radius = 3;
+    var twoPI = 2*Math.PI;
+
+    // all cases do this.
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(x0,y0);
+    ctx.lineTo(x1,y1);
+    ctx.lineTo(x2,y2);
+
+    // Close off the arrow lines with an arcTo curve
+    var backdist = Math.sqrt(((x2-x0)*(x2-x0))+((y2-y0)*(y2-y0)));
+    ctx.arcTo(x1, y1, x0, y0, 0.55 * backdist);
+
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // Helper function to draw a line with arrow heads
+  function drawArrowLine(ctx, point1, point2, config) {
+    var both_arrows = config.draw_start_arrow && config.draw_end_arrow;
+
+    var x1 = point1.x;
+    var y1 = point1.y;
+    var x2 = point2.x;
+    var y2 = point2.y;
+
+    // For ends with arrow we actually want to stop before we get to the arrow
+    // so that wide lines won't put a flat end on the arrow.
+    var distance = Math.sqrt((x2-x1)*(x2-x1)+(y2-y1)*(y2-y1));
+    var ratio = (distance - config.arrowhead_length/3) / distance;
+    var end_x, end_y, start_x, start_y;
+    if (config.draw_end_arrow || both_arrows) {
+      end_x = Math.round(x1 + (x2 - x1) * ratio);
+      end_y = Math.round(y1 + (y2 - y1) * ratio);
+    } else {
+      end_x = x2;
+      end_y = y2;
+    }
+
+    if (config.draw_start_arrow || both_arrows) {
+      start_x = x1 + (x2 - x1) * (1 - ratio);
+      start_y = y1 + (y2 - y1) * (1 - ratio);
+    } else {
+      start_x = x1;
+      start_y = y1;
+    }
+
+    // Draw the shaft of the arrow
+    ctx.beginPath();
+    ctx.setStrokeStyle(config.color);
+    ctx.setFillStyle(config.color);
+    ctx.moveTo(start_x, start_y);
+    ctx.lineTo(end_x,end_y);
+    ctx.stroke();
+
+    // calculate the angle of the line
+    var line_angle = Math.atan2(y2 - y1, x2 - x1);
+    // h is the line length of a side of the arrow head
+    var h = Math.abs(config.arrowhead_length / Math.cos(config.arrowhead_angle));
+
+    var angle1;
+    var top_x, top_y;
+    var bottom_x, bottom_y;
+
+    if (config.draw_end_arrow || both_arrows) {
+      angle1 = line_angle + Math.PI + config.arrowhead_angle;
+      top_x = x2 + Math.cos(angle1) * h;
+      top_y = y2 + Math.sin(angle1) * h;
+
+      angle2 = line_angle + Math.PI - config.arrowhead_angle;
+      bottom_x = x2 + Math.cos(angle2) * h;
+      bottom_y = y2 + Math.sin(angle2) * h;
+
+      drawArrowHead(ctx, top_x, top_y, x2, y2, bottom_x, bottom_y);
+    }
+
+    if (config.draw_start_arrow || both_arrows) {
+      angle1 = line_angle + config.arrowhead_angle;
+      top_x = x1 + Math.cos(angle1) * h;
+      top_y = y1 + Math.sin(angle1) * h;
+
+      angle2 = line_angle - config.arrowhead_angle;
+      bottom_x = x1 + Math.cos(angle2) * h;
+      bottom_y = y1 + Math.sin(angle2) * h;
+
+      drawArrowHead(ctx, top_x, top_y, x1, y1, bottom_x, bottom_y);
+    }
+  }
+
+  return StaveLine;
+}());

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -119,6 +119,7 @@
   <script src="../src/gracenote.js"></script>
   <script src="../src/gracenotegroup.js"></script>
   <script src="../src/curve.js"></script>
+  <script src="../src/staveline.js"></script>
 
   <!-- Compiled Source -->
   <script src="../support/vexflow-min.js"></script>
@@ -172,6 +173,7 @@
   <script src="gracenote_tests.js"></script>
   <script src="curve_tests.js"></script>
   <script src="notehead_tests.js"></script>
+  <script src="staveline_tests.js"></script>
 
   <script>
     $(function() {
@@ -215,6 +217,7 @@
       Vex.Flow.Test.ThreeVoices.Start();
       Vex.Flow.Test.Curve.Start();
       Vex.Flow.Test.TextNote.Start();
+      Vex.Flow.Test.StaveLine.Start();
 /*
       Vex.Flow.Test.Table.Start(); // These tests are way too rigid
 */

--- a/tests/staveline_tests.js
+++ b/tests/staveline_tests.js
@@ -1,0 +1,178 @@
+/**
+ * VexFlow - StaveLine Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ */
+
+Vex.Flow.Test.StaveLine = {};
+
+Vex.Flow.Test.StaveLine.Start = function() {
+  module("StaveLine");
+  Vex.Flow.Test.runTest("Simple StaveLine", Vex.Flow.Test.StaveLine.simple0);
+  Vex.Flow.Test.runTest("StaveLine Arrow Options", Vex.Flow.Test.StaveLine.simple1);
+};
+
+Vex.Flow.Test.StaveLine.simple0 = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 650, 140);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
+  stave.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+  var notes = [
+    {keys: ["c/4"], duration: "4", clef: "treble"},
+    {keys: ["c/5"], duration: "4", clef: "treble"},
+    {keys: ["c/4", "g/4", "b/4"], duration: "4", clef: "treble"},
+    {keys: ["f/4", "a/4", "f/5"], duration: "4", clef: "treble"}
+  ].map(newNote);
+
+
+  var staveLine = new Vex.Flow.StaveLine({
+    first_note: notes[0],
+    last_note: notes[1],
+    first_indices: [0],
+    last_indices: [0]
+  });
+
+  var staveLine2 = new Vex.Flow.StaveLine({
+    first_note: notes[2],
+    last_note: notes[3],
+    first_indices: [2, 1, 0],
+    last_indices: [0, 1, 2]
+  });
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice.addTickables(notes);
+
+  new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  staveLine.setText('gliss.');
+  staveLine.setFont({
+    family: "serif",
+    size: 12,
+    weight: "italic"
+  });
+
+  voice.draw(ctx, stave);
+  staveLine.setContext(ctx).draw();
+  staveLine2.setContext(ctx).draw();
+
+  ok(true);
+};
+
+
+Vex.Flow.Test.StaveLine.simple1 = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 770, 140);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave = new Vex.Flow.Stave(10, 10, 750).addTrebleGlyph();
+  stave.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+  var notes = [
+    {keys: ["c#/5", "d/5"], duration: "4", clef: "treble", stem_direction: -1},
+    {keys: ["c/4"], duration: "4", clef: "treble"},
+    {keys: ["c/4", "e/4", "g/4"], duration: "4", clef: "treble"},
+    {keys: ["f/4", "a/4", "c/5"], duration: "4", clef: "treble"},
+    {keys: ["c/4",], duration: "4", clef: "treble"},
+    {keys: ["c#/5", "d/5"], duration: "4", clef: "treble", stem_direction: -1},
+    {keys: ["c/4", "d/4", "g/4"], duration: "4", clef: "treble"},
+    {keys: ["f/4", "a/4", "c/5"], duration: "4", clef: "treble"}
+  ].map(newNote);
+
+  notes[0].addDotToAll();
+  notes[1].addAccidental(0, new Vex.Flow.Accidental("#"));
+  notes[3].addAccidental(2, new Vex.Flow.Accidental("#"));
+  notes[4].addAccidental(0, new Vex.Flow.Accidental("#"));
+  notes[7].addAccidental(2, new Vex.Flow.Accidental("#"));
+
+  var staveLine0 = new Vex.Flow.StaveLine({
+    first_note: notes[0],
+    last_note: notes[1],
+    first_indices: [0],
+    last_indices: [0]
+  });
+
+  var staveLine4 = new Vex.Flow.StaveLine({
+    first_note: notes[2],
+    last_note: notes[3],
+    first_indices: [1],
+    last_indices: [1]
+  });
+
+  var staveLine1 = new Vex.Flow.StaveLine({
+    first_note: notes[4],
+    last_note: notes[5],
+    first_indices: [0],
+    last_indices: [0]
+  });
+
+  var staveLine2 = new Vex.Flow.StaveLine({
+    first_note: notes[6],
+    last_note: notes[7],
+    first_indices: [1],
+    last_indices: [0]
+  });
+
+  var staveLine3 = new Vex.Flow.StaveLine({
+    first_note: notes[6],
+    last_note: notes[7],
+    first_indices: [2],
+    last_indices: [2]
+  });
+
+
+  staveLine0.render_options.draw_end_arrow = true;
+  staveLine0.setText('Left');
+  staveLine0.render_options.text_justification = 1;
+  staveLine0.render_options.text_position_vertical = 2;
+
+  staveLine1.render_options.draw_end_arrow = true;
+  staveLine1.render_options.arrowhead_length = 30;
+  staveLine1.render_options.line_width = 5;
+  staveLine1.setText('Center');
+  staveLine1.render_options.text_justification = 2;
+  staveLine1.render_options.text_position_vertical = 2;
+
+
+  staveLine4.render_options.line_width = 2;
+  staveLine4.render_options.draw_end_arrow = true;
+  staveLine4.render_options.draw_start_arrow = true;
+  staveLine4.render_options.arrowhead_angle = 0.5;
+  staveLine4.render_options.arrowhead_length = 20;
+  staveLine4.setText('Right');
+  staveLine4.render_options.text_justification = 3;
+  staveLine4.render_options.text_position_vertical = 2;
+
+  staveLine2.render_options.draw_start_arrow = true;
+  staveLine2.render_options.line_dash = [5, 4];
+  
+  staveLine3.render_options.draw_end_arrow = true;
+  staveLine3.render_options.draw_start_arrow = true;
+  staveLine3.render_options.color = "red";
+  staveLine3.setText('Top');
+  staveLine3.render_options.text_position_vertical = 1;
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice.addTickables(notes);
+
+  new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  voice.draw(ctx, stave);
+
+  staveLine0.setContext(ctx).draw();
+  staveLine1.setContext(ctx).draw();
+  staveLine2.setContext(ctx).draw();
+  staveLine3.setContext(ctx).draw();
+  staveLine4.setContext(ctx).draw();
+
+  ok(true);
+};


### PR DESCRIPTION
It's pretty simple, originally started as something to support glissando notation, but I evolved it to be a highly configurable line/arrow class that would certainly be useful for educational diagrams.

![image](https://cloud.githubusercontent.com/assets/1631625/2768222/26d608cc-ca42-11e3-8eed-22b9fe322a58.png)

![image](https://cloud.githubusercontent.com/assets/1631625/2768225/2ced1aa2-ca42-11e3-862d-2feccba427e8.png)

Here are the `render_options` for the class

``` javascript
this.render_options = {
    // Space to add to the left or the right
    padding_left: 4,
    padding_right: 3,

    // The width of the line in pixels
    line_width: 1,
    // An array of line/space lengths
    line_dash: null,
    // Can draw rounded line end, instead of a square
    rounded_end: true,
    // The color of the line and arrowheads
    color: null,

    // Flags to draw arrows on each end of the line
    draw_start_arrow: false,
    draw_end_arrow: false,

    // The length of the arrowhead sides
    arrowhead_length: 10,
    // The angle of the arrowhead
    arrowhead_angle: Math.PI / 8,

    // The position of the text
    text_position_vertical: StaveLine.TextVerticalPosition.TOP,
    text_justification: StaveLine.TextJustification.CENTER
  };
```
