### PR TITLE
Added duration based Crescendo class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,6 +90,7 @@ base_sources = [
   "src/strokes.js",
   "src/curve.js",
   "src/staveline.js",
+  "src/crescendo.js"
 ]
 
 # Don't minify these files.

--- a/src/crescendo.js
+++ b/src/crescendo.js
@@ -1,0 +1,114 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+// 
+// This file implements the `Crescendo` object which draws crescendos and 
+// decrescendo dynamics markings. A `Crescendo` is initialized with a 
+// duration and formatted as part of a `Voice` like any other `Note`
+// type in VexFlow. This object would most likely be formatted in a Voice
+// with `TextNotes` - which are used to represent other dynamics markings.
+Vex.Flow.Crescendo = (function() {
+  function Crescendo(note_struct) {
+    if (arguments.length > 0) this.init(note_struct);
+  }
+
+  // To enable logging for this class. Set `Vex.Flow.Crescendo.DEBUG` to `true`.
+  function L() { if (Crescendo.DEBUG) Vex.L("Vex.Flow.Crescendo", arguments); }
+
+  // Private helper to draw the hairpin
+  function renderHairpin(ctx, params) {
+    var begin_x = params.begin_x;
+    var end_x = params.end_x;
+    var y = params.y;
+    var height = params.height;
+    var half_height =  params.height / 2;
+
+    ctx.beginPath();
+
+    if (params.reverse) {
+        ctx.moveTo(begin_x, y - half_height);
+        ctx.lineTo(end_x,  y);
+        ctx.lineTo(begin_x, y + half_height);
+    } else {
+        ctx.moveTo(end_x,  y - half_height);
+        ctx.lineTo(begin_x, y);
+        ctx.lineTo(end_x,  y + half_height);
+    }
+
+    ctx.stroke();
+    ctx.closePath();
+  }
+
+  // ## Prototype Methods
+  Vex.Inherit(Crescendo, Vex.Flow.Note, {
+    // Initialize the crescendo's properties
+    init: function(note_struct) {
+      Crescendo.superclass.init.call(this, note_struct);
+
+      // Whether the object is a decrescendo
+      this.decrescendo = false;
+
+      // The staff line to be placed on
+      this.line = note_struct.line || 0;
+
+      // The height at the open end of the cresc/decresc
+      this.height = 15;
+
+      Vex.Merge(this.render_options, {
+        // Extensions to the length of the crescendo on either side
+        extend_left: 0,
+        extend_right: 0,
+        // Vertical shift
+        y_shift: 0
+      });
+    },
+
+    // Set the line to center the element on 
+    setLine: function(line) { this.line = line; return this; },
+
+    // Set the full height at the open end
+    setHeight: function(height) { this.height = height; return this; },
+
+    // Set whether the sign should be a descresendo by passing a bool
+    // to `decresc`
+    setDecrescendo: function(decresc) {
+      this.decrescendo = decresc;
+      return this;
+    },
+
+    // Preformat the note
+    preFormat: function() { this.preFormatted = true; return this; },
+
+    // Render the Crescendo object onto the canvas
+    draw: function() {
+      if (!this.context) throw new Vex.RERR("NoContext",
+        "Can't draw Hairpin without a context.");
+
+      var tick_context = this.getTickContext();
+      var next_context = Vex.Flow.TickContext.getNextContext(tick_context);
+
+      var begin_x = this.getAbsoluteX();
+      var end_x;
+      if (next_context) {
+        end_x = next_context.getX();
+      } else {
+        end_x = this.stave.x + this.stave.width;
+      }
+
+      var y = this.stave.getYForLine(this.line + (-3)) + 1;
+
+      L("Drawing ",  this.decrescendo ? "decrescendo " : "crescendo ",
+        this.height, "x", begin_x - end_x);
+
+      renderHairpin(this.context, {
+        begin_x: begin_x - this.render_options.extend_left,
+        end_x: end_x + this.render_options.extend_right,
+        y: y + this.render_options.y_shift,
+        height: this.height,
+        reverse: this.decrescendo
+      });
+    }
+  });
+
+  return Crescendo;
+})();

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -81,6 +81,7 @@ Vex.Flow.Formatter = (function() {
     var totalTicks = voices[0].getTotalTicks();
     var tickToContextMap = {};
     var tickList = [];
+    var contexts = [];
 
     var resolutionMultiplier = 1;
 
@@ -126,8 +127,11 @@ Vex.Flow.Formatter = (function() {
         var integerTicks = ticksUsed.numerator;
 
         // If we have no tick context for this tick, create one.
-        if (!tickToContextMap[integerTicks])
-          tickToContextMap[integerTicks] = new context_type();
+        if (!tickToContextMap[integerTicks]) {
+          var newContext = new context_type();
+          contexts.push(newContext);
+          tickToContextMap[integerTicks] = newContext;
+        }
 
         // Add this tickable to the TickContext.
         add_fn(tickable, tickToContextMap[integerTicks]);
@@ -140,6 +144,7 @@ Vex.Flow.Formatter = (function() {
 
     return {
       map: tickToContextMap,
+      array: contexts,
       list: Vex.SortAndUnique(tickList, function(a, b) { return a - b; },
           function(a, b) { return a === b; } ),
       resolutionMultiplier: resolutionMultiplier
@@ -386,6 +391,10 @@ Vex.Flow.Formatter = (function() {
       var contexts = createContexts(voices,
           Vex.Flow.TickContext,
           function(tickable, context) { context.addTickable(tickable); });
+
+      contexts.array.forEach(function(context, index, contexts) {
+        context.tContexts = contexts;
+      });
 
       this.totalTicks = voices[0].getTicksUsed().clone();
       this.tContexts = contexts;

--- a/src/tickcontext.js
+++ b/src/tickcontext.js
@@ -23,6 +23,8 @@ Vex.Flow.TickContext = (function() {
       this.notePx = 0;       // width of widest note in this context
       this.extraLeftPx = 0;  // Extra left pixels for modifers & displace notes
       this.extraRightPx = 0; // Extra right pixels for modifers & displace notes
+      
+      this.tContexts = [];   // Parent array of tick contexts
 
       // Ignore this tick context for formatting and justification
       this.ignore_ticks = true;
@@ -133,6 +135,13 @@ Vex.Flow.TickContext = (function() {
       this.postFormatted = true;
       return this;
     }
+  };
+
+  TickContext.getNextContext = function(tContext) {
+    var contexts = tContext.tContexts;
+    var index = contexts.indexOf(tContext);
+
+    return contexts[index+1];
   };
 
   return TickContext;

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -120,6 +120,7 @@
   <script src="../src/gracenotegroup.js"></script>
   <script src="../src/curve.js"></script>
   <script src="../src/staveline.js"></script>
+  <script src="../src/crescendo.js"></script>
 
   <!-- Compiled Source -->
   <script src="../support/vexflow-min.js"></script>

--- a/tests/textnote_tests.js
+++ b/tests/textnote_tests.js
@@ -15,6 +15,10 @@ Vex.Flow.Test.TextNote = (function() {
           Vex.Flow.Test.TextNote.formatTextGlyphs0);
       Vex.Flow.Test.runTest("TextNote Formatting With Glyphs 1",
           Vex.Flow.Test.TextNote.formatTextGlyphs1);
+      Vex.Flow.Test.runTest("TextNote Formatting With Glyphs",
+          Vex.Flow.Test.TextNote.formatTextGlyphs);
+      Vex.Flow.Test.runTest("Crescendo",
+          Vex.Flow.Test.TextNote.crescendo);
     },
 
     renderNotes: function(notes1, notes2, ctx, stave, justify) {
@@ -192,6 +196,35 @@ Vex.Flow.Test.TextNote = (function() {
       ];
 
       Vex.Flow.Test.TextNote.renderNotes(notes1, notes2, ctx, stave);
+
+      ok(true);
+    },
+
+    crescendo: function(options) {
+      Vex.Flow.Test.resizeCanvas(options.canvas_sel, 600, 180);
+      var ctx = Vex.Flow.Renderer.getCanvasContext(options.canvas_sel);
+      ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+      var stave = new Vex.Flow.Stave(10, 20, 500);
+      stave.setContext(ctx);
+      stave.draw();
+
+      var notes = [
+        new Vex.Flow.TextNote({glyph: "p", duration: "16"}).setContext(ctx),
+        new Vex.Flow.Crescendo({duration: "4d"}).setLine(0).setHeight(25),
+        new Vex.Flow.TextNote({glyph: "f", duration: "16"}).setContext(ctx),
+        new Vex.Flow.Crescendo({duration: "4"}).setLine(5),
+        new Vex.Flow.Crescendo({duration: "4"}).setLine(10).setDecrescendo(true).setHeight(5)
+      ];
+
+      var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+      voice.addTickables(notes);
+
+      var formatter = new Vex.Flow.Formatter().formatToStave([voice], stave); 
+
+      notes.forEach(function(note) {
+        note.setStave(stave);
+        note.setContext(ctx).draw();
+      });
 
       ok(true);
     }


### PR DESCRIPTION
What's one more pull request right? Just making sure you have more than enough to review when you get back. :) We can move the discussion from #188 here. Consider this a preliminary PR because I'm not sure about my implementation.

**Wide:**
![image](https://cloud.githubusercontent.com/assets/1631625/2757649/9b4c985e-c986-11e3-916c-6b3598db5872.png)

**Short**
![image](https://cloud.githubusercontent.com/assets/1631625/2757726/84a4d426-c987-11e3-816f-dbcecf3c7eea.png)

I talked about my implemenation in the issue (#188) but here it is again:

> since a `tickContext.width` doesn't occupy the entire space the formatter allocates, I had to give each `TickContext` a reference to its following `TickContext`. That way s the `x` value bounds are accessible when drawing the hairpin through a `TickContext.getNextContextX()`. Is that too hacky?
