### PR TITLE
Fixed Staveline with Raphael

### DIFF
--- a/src/canvascontext.js
+++ b/src/canvascontext.js
@@ -73,6 +73,11 @@ Vex.Flow.CanvasContext = (function() {
       return this;
     },
 
+    setLineCap: function(cap_type) {
+      this.vexFlowCanvasContext.lineCap = cap_type;
+      return this;
+    },
+
     scale: function(x, y) {
       return this.vexFlowCanvasContext.scale(parseFloat(x), parseFloat(y));
     },

--- a/src/raphaelcontext.js
+++ b/src/raphaelcontext.js
@@ -93,6 +93,10 @@ Vex.Flow.RaphaelContext = (function() {
       this.lineWidth = width;
     },
 
+    // Empty because there is no equivalent in SVG
+    setLineDash: function() { return this; },
+    setLineCap: function() { return this; },
+
     scale: function(x, y) {
       this.state.scale = { x: x, y: y };
       this.attributes.scale = x + "," + y + ",0,0";

--- a/tests/staveline_tests.js
+++ b/tests/staveline_tests.js
@@ -8,7 +8,9 @@ Vex.Flow.Test.StaveLine = {};
 Vex.Flow.Test.StaveLine.Start = function() {
   module("StaveLine");
   Vex.Flow.Test.runTest("Simple StaveLine", Vex.Flow.Test.StaveLine.simple0);
+  Vex.Flow.Test.runRaphaelTest("Simple StaveLine", Vex.Flow.Test.StaveLine.simple0);
   Vex.Flow.Test.runTest("StaveLine Arrow Options", Vex.Flow.Test.StaveLine.simple1);
+  Vex.Flow.Test.runRaphaelTest("StaveLine Arrow Options", Vex.Flow.Test.StaveLine.simple1);
 };
 
 Vex.Flow.Test.StaveLine.simple0 = function(options, contextBuilder) {


### PR DESCRIPTION
A little bit of cleanup + `StaveLine` now works with Rapahel.

Here's a screenshot of all the StaveLine tests. Initial test run is Canvas, duplicate is Raphael.

![image](https://cloud.githubusercontent.com/assets/1631625/2855680/b5620db0-d15f-11e3-900f-93a8d24c7c51.png)
