### PR TITLE
Added `maintain_stem_directions` config option to `generateBeams()`

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -568,13 +568,18 @@ Vex.Flow.Beam = (function() {
         var totalTicks = getTotalTicks(currentGroup).value();
 
         // Double the amount of ticks in a group, if it's an unbeamable tuplet
-        if (parseInt(unprocessedNote.duration, 10) < 8 && unprocessedNote.tuplet) {
+        var unbeamable = parseInt(unprocessedNote.duration, 10) < 8;
+        if (unbeamable && unprocessedNote.tuplet) {
           ticksPerGroup *= 2;
         }
 
         // If the note that was just added overflows the group tick total
         if (totalTicks > ticksPerGroup) {
-          nextGroup.push(currentGroup.pop());
+          // If the overflow note can be beamed, start the next group 
+          // with it. Unbeamable notes leave the group overflowed.
+          if (!unbeamable) {
+            nextGroup.push(currentGroup.pop());
+          }
           noteGroups.push(currentGroup);
           currentGroup = nextGroup;
           nextTickGroup();

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -22,8 +22,10 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.maintainStemDirections);
   Vex.Flow.Test.runTest("Maintain Stem Directions - Beam Over Rests",
                         Vex.Flow.Test.AutoBeamFormatting.maintainStemDirectionsBeamAcrossRests);
-  Vex.Flow.Test.runTest("Beat group with unbeamable note",
+  Vex.Flow.Test.runTest("Beat group with unbeamable note - 2/2",
                         Vex.Flow.Test.AutoBeamFormatting.groupWithUnbeamableNote);
+  Vex.Flow.Test.runTest("Offset beat grouping - 6/8 ",
+                        Vex.Flow.Test.AutoBeamFormatting.groupWithUnbeamableNote1);
   Vex.Flow.Test.runTest("Odd Time - Guessing Default Beam Groups",
                         Vex.Flow.Test.AutoBeamFormatting.autoOddBeamGroups);
   Vex.Flow.Test.runTest("Custom Beam Groups",
@@ -535,6 +537,43 @@ Vex.Flow.Test.AutoBeamFormatting.groupWithUnbeamableNote = function(options, con
 
   var beams = Vex.Flow.Beam.generateBeams(notes, {
     groups: [new Vex.Flow.Fraction(2, 2)],
+    beam_rests: false,
+    maintain_stem_directions: true
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beam Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.groupWithUnbeamableNote1 = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options, 450, 200);
+
+  c.stave.addTimeSignature('6/8');
+
+  c.context.clear();
+  c.stave.draw();
+
+  var notes = [
+    newNote({ keys: ["b/4"], duration: "4", stem_direction: 1}),
+    newNote({ keys: ["b/4"], duration: "4", stem_direction: 1}),
+    newNote({ keys: ["b/4"], duration: "8", stem_direction: 1}),
+    newNote({ keys: ["b/4"], duration: "8", stem_direction: 1})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    groups: [new Vex.Flow.Fraction(3, 8)],
     beam_rests: false,
     maintain_stem_directions: true
   });


### PR DESCRIPTION
Test (assume 4/4 time signature):
![image](https://cloud.githubusercontent.com/assets/1631625/2867293/690ad9ee-d234-11e3-9d08-62cd57518149.png)

Test with `beam_rests`:

![image](https://cloud.githubusercontent.com/assets/1631625/2867290/5e7f6710-d234-11e3-84f8-fcdadfd214b0.png)

Additionally I fixed a couple bugs. One with stem down beams and rests:
![image](https://cloud.githubusercontent.com/assets/1631625/2848789/ac897006-d0c5-11e3-84e5-dba020e461c4.png)

Fixed:
![image](https://cloud.githubusercontent.com/assets/1631625/2848794/c8b17756-d0c5-11e3-994e-8baadc73c48e.png)

Additionally, I fixed issue #215 where auto-beaming broke if a beat-group contained an unbeamable note.

![image](https://cloud.githubusercontent.com/assets/1631625/2849040/97eb669e-d0cb-11e3-88ff-0ca01c04e8e2.png)
