### PR TITLE
Added automatic accidental generation

### DIFF
--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -395,8 +395,21 @@
   Vex.Flow.Formatter.FormatAndDraw(ctx, stave, notes);
 </script>
     </div>
+
     Above, the accidentals are positioned such that they don't overlap but
     maintain their X-relation to the associated note.
+
+      <p>
+      Creating each accidental explictly can be annoying. Fortunately, VexFlow
+      provides an auto-formatting method called 
+      <code>Accidental.applyAccidentals()</code> which determines the 
+      accidentals to render on an array of voices. You can optionally provide a
+      key signature as well.
+      </p>
+
+      <code>
+        Accidental.applyAccidentals([voice], "Cb");
+      </code>
     </div>
 
     <h2>Step 3.5: An Interlude</h2>

--- a/src/accidental.js
+++ b/src/accidental.js
@@ -117,47 +117,12 @@ Vex.Flow.Accidental = (function(){
     }
   });
   
-  // ## Private Helper
-  // 
-  // This is helper method for `Accidental.generateAccidentals()`. It's used to
-  // create a scale map that represents the pitch state for a `keySignature`. 
-  // For example, passing a `G` to `keySignature` would return a scale map 
-  // with every note naturalized except for `F` which has an `F#` state.
-  function createScaleMap(keySignature) {
-    var music = new Vex.Flow.Music();
-    var keySigParts = music.getKeyParts(keySignature);
-    var scaleName = Vex.Flow.KeyManager.scales[keySigParts.type];
-
-    var keySigString = keySigParts.root;
-    if (keySigParts.accidental) keySigString += keySigParts.accidental;
-
-    if (!scaleName) throw new Vex.RERR("BadArguments", "Unsupported key type: " + keySignature);
-
-    var scale = music.getScaleTones(music.getNoteValue(keySigString), scaleName);
-    var noteLocation = Vex.Flow.Music.root_indices[keySigParts.root];
-
-    var scaleMap = {};
-    for (var i = 0; i < Vex.Flow.Music.roots.length; ++i) {
-      var index = (noteLocation + i) % Vex.Flow.Music.roots.length;
-      var rootName = Vex.Flow.Music.roots[index];
-      var noteName = music.getRelativeNoteName(rootName, scale[i]);
-
-      if (noteName.length === 1) {
-        noteName += "n";
-      }
-
-      scaleMap[rootName] = noteName;
-    }
-
-    return scaleMap;
-  }
-
   // ## Static Methods
   // 
   // Use this method to automatically apply accidentals to a set of `voices`.
   // The accidentals will be remembered between all the voices provided.
   // Optionally, you can also provide an initial `keySignature`. 
-  Accidental.generateAccidentals = function(voices, keySignature) {
+  Accidental.applyAccidentals = function(voices, keySignature) {
     var tickPositions = [];
     var tickNoteMap = {};
 
@@ -185,7 +150,7 @@ Vex.Flow.Accidental = (function(){
     if (!keySignature) keySignature = "C";
 
     // Get the scale map, which represents the current state of each pitch
-    var scaleMap = createScaleMap(keySignature);
+    var scaleMap = music.createScaleMap(keySignature);
 
     tickPositions.forEach(function(tick) {
       var notes = tickNoteMap[tick];

--- a/src/music.js
+++ b/src/music.js
@@ -318,7 +318,41 @@ Vex.Flow.Music = (function() {
 
       if (difference < 0) difference += Music.NUM_TONES;
       return difference;
+    },
+
+    // Create a scale map that represents the pitch state for a
+    // `keySignature`. For example, passing a `G` to `keySignature` would 
+    // return a scale map with every note naturalized except for `F` which
+    // has an `F#` state.
+    createScaleMap: function(keySignature) {
+      var music = new Vex.Flow.Music();
+      var keySigParts = this.getKeyParts(keySignature);
+      var scaleName = Vex.Flow.KeyManager.scales[keySigParts.type];
+
+      var keySigString = keySigParts.root;
+      if (keySigParts.accidental) keySigString += keySigParts.accidental;
+
+      if (!scaleName) throw new Vex.RERR("BadArguments", "Unsupported key type: " + keySignature);
+
+      var scale = this.getScaleTones(this.getNoteValue(keySigString), scaleName);
+      var noteLocation = Vex.Flow.Music.root_indices[keySigParts.root];
+
+      var scaleMap = {};
+      for (var i = 0; i < Vex.Flow.Music.roots.length; ++i) {
+        var index = (noteLocation + i) % Vex.Flow.Music.roots.length;
+        var rootName = Vex.Flow.Music.roots[index];
+        var noteName = this.getRelativeNoteName(rootName, scale[i]);
+
+        if (noteName.length === 1) {
+          noteName += "n";
+        }
+
+        scaleMap[rootName] = noteName;
+      }
+
+      return scaleMap;
     }
+
   };
 
   return Music;

--- a/tests/accidental_tests.js
+++ b/tests/accidental_tests.js
@@ -314,7 +314,7 @@ Vex.Flow.Test.Accidental.automaticAccidentals0 = function(options, contextBuilde
     .setMode(Vex.Flow.Voice.Mode.SOFT);
   voice.addTickables(notes);
 
-  Vex.Flow.Accidental.generateAccidentals([voice], "C");
+  Vex.Flow.Accidental.applyAccidentals([voice], "C");
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
@@ -345,7 +345,7 @@ Vex.Flow.Test.Accidental.automaticAccidentals1 = function(options, contextBuilde
     .setMode(Vex.Flow.Voice.Mode.SOFT);
   voice.addTickables(notes);
 
-  Vex.Flow.Accidental.generateAccidentals([voice], "Ab");
+  Vex.Flow.Accidental.applyAccidentals([voice], "Ab");
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
@@ -376,7 +376,7 @@ Vex.Flow.Test.Accidental.automaticAccidentals2 = function(options, contextBuilde
     .setMode(Vex.Flow.Voice.Mode.SOFT);
   voice.addTickables(notes);
 
-  Vex.Flow.Accidental.generateAccidentals([voice], "A");
+  Vex.Flow.Accidental.applyAccidentals([voice], "A");
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
@@ -423,7 +423,7 @@ Vex.Flow.Test.Accidental.automaticAccidentalsMultiVoiceInline = function(options
   voice1.addTickables(notes1);
 
   // Ab Major
-  Vex.Flow.Accidental.generateAccidentals([voice0, voice1], "Ab");
+  Vex.Flow.Accidental.applyAccidentals([voice0, voice1], "Ab");
 
   equal(hasAccidental(notes0[0]), false);
   equal(hasAccidental(notes0[1]), true);
@@ -490,7 +490,7 @@ Vex.Flow.Test.Accidental.automaticAccidentalsMultiVoiceOffset = function(options
   voice1.addTickables(notes1);
 
   // Cb Major (All flats)
-  Vex.Flow.Accidental.generateAccidentals([voice0, voice1], "Cb");
+  Vex.Flow.Accidental.applyAccidentals([voice0, voice1], "Cb");
 
   equal(hasAccidental(notes0[0]), true);
   equal(hasAccidental(notes0[1]), true);
@@ -535,7 +535,7 @@ Vex.Flow.Test.Accidental.autoAccidentalWorking = function(options, contextBuilde
   voice.addTickables(notes);
 
   // F Major (Bb)
-  Vex.Flow.Accidental.generateAccidentals([voice], "F");
+  Vex.Flow.Accidental.applyAccidentals([voice], "F");
 
   equal(hasAccidental(notes[0]), false, "No flat because of key signature");
   equal(hasAccidental(notes[1]), false, "No flat because of key signature");
@@ -562,7 +562,7 @@ Vex.Flow.Test.Accidental.autoAccidentalWorking = function(options, contextBuilde
   voice.addTickables(notes);
 
   // A Major (F#,G#,C#)
-  Vex.Flow.Accidental.generateAccidentals([voice], "A");
+  Vex.Flow.Accidental.applyAccidentals([voice], "A");
 
   equal(hasAccidental(notes[0]), true, "Added sharp");
   equal(hasAccidental(notes[1]), true, "Added flat");
@@ -592,7 +592,7 @@ Vex.Flow.Test.Accidental.autoAccidentalWorking = function(options, contextBuilde
   voice.addTickables(notes);
 
   // C Major (no sharps/flats)
-  Vex.Flow.Accidental.generateAccidentals([voice], "C");
+  Vex.Flow.Accidental.applyAccidentals([voice], "C");
 
   equal(hasAccidental(notes[0]), false, "No accidental");
   equal(hasAccidental(notes[1]), true, "Added flat");


### PR DESCRIPTION
### Summary

This pull request adds the `Accidental.generateAccidentals(voices, keySignature)` static method for applying accidentals to voices. Works with double sharps/flats.

To be used like this:

``` javascript
Vex.Flow.Accidental.generateAccidentals([voice0, voice1], "Ab");
```

By passing in multiple voices, the accidentals will be remembered between the voices. This facilitates a few different accidental placement styles where accidental "remembering" can happen per voice, per staff or even per grandstaff. Simply include the voices you wish to have accidentals remembered between.

However, I'm thinking about changing the name of the method. `generateAccidentals` sounds like it would return an array of `Accidental` objects (like `generateBeams()`). When in reality, it simply adds them to the StaveNote. So maybe I should rename it to `autoApplyAccicdentals()` or something else ?
### Tests

**Basic**
![image](https://cloud.githubusercontent.com/assets/1631625/2883344/fd95d002-d499-11e3-85dc-818e5aa9c850.png)
**C major scale over Ab key signature**
![image](https://cloud.githubusercontent.com/assets/1631625/2883346/0ae925b0-d49a-11e3-9a42-96256cf676f6.png)
**A major scale with A major key signature**
![image](https://cloud.githubusercontent.com/assets/1631625/2883352/182a080c-d49a-11e3-8599-37b4d9328445.png)
**Multi-voice, with similar accidentals inline.**
![image](https://cloud.githubusercontent.com/assets/1631625/2883357/260309b0-d49a-11e3-96eb-41e0319fb733.png)
**Multi-voice, same as above, but the 1st voice is offset, so the accidentals are remembered**
![image](https://cloud.githubusercontent.com/assets/1631625/2883360/2d782108-d49a-11e3-9205-d1b6dbf3bc7c.png)
