### PR TITLE
Added PauseMarking class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,8 @@ base_sources = [
   "src/ornament.js",
   "src/pedalmarking.js",
   "src/textbracket.js",
-  "src/textdynamics.js"
+  "src/textdynamics.js",
+  "src/pausemarking.js"
 ]
 
 # Don't minify these files.

--- a/src/articulation.js
+++ b/src/articulation.js
@@ -90,7 +90,6 @@ Vex.Flow.Articulation = (function() {
       var line_spacing = 1;
       var spacing = stave.getSpacingBetweenLines();
       var is_tabnote = this.note.getCategory() === 'tabnotes';
-      var is_pause = this.note.getCategory() === 'pausemarkings';
 
       // Get the stem extents if it's a StemmableNote
       var stem_ext, top, bottom;
@@ -135,8 +134,8 @@ Vex.Flow.Articulation = (function() {
 
         if (this.articulation.between_lines)
           glyph_y = glyph_y_between_lines;
-        else if (is_pause)
-          glyph_y = Math.min(stave.getYForTopText(this.text_line), glyph_y - 25);
+        else if (this.note.hasFixedYs())
+          glyph_y = Math.min(stave.getYForTopText(this.text_line), glyph_y - this.note.getFixedYs().top);
         else
           glyph_y = Math.min(stave.getYForTopText(this.text_line) - 3, glyph_y_between_lines);
       } else {
@@ -145,8 +144,8 @@ Vex.Flow.Articulation = (function() {
         glyph_y_between_lines = bottom + 10 + spacing * (this.text_line + line_spacing);
         if (this.articulation.between_lines)
           glyph_y = glyph_y_between_lines;
-        else if (is_pause)
-          glyph_y = Math.max(stave.getYForBottomText(this.text_line), glyph_y + 30);
+        else if (this.note.hasFixedYs())
+          glyph_y = Math.max(stave.getYForBottomText(this.text_line), glyph_y + this.note.getFixedYs().bottom);
         else
           glyph_y = Math.max(stave.getYForBottomText(this.text_line), glyph_y_between_lines);
       }

--- a/src/articulation.js
+++ b/src/articulation.js
@@ -53,10 +53,11 @@ Vex.Flow.Articulation = (function() {
       if (!(this.note && (this.index !== null))) throw new Vex.RERR("NoAttachedNote",
         "Can't draw Articulation without a note and index.");
 
-      var stem_direction = 1;
+      var stem_direction = Vex.Flow.Stem.UP;
       if (this.note.getStemDirection) {
         stem_direction = this.note.getStemDirection();
       }
+      
       var stave = this.note.getStave();
 
       var is_on_head = (this.position === Modifier.Position.ABOVE &&

--- a/src/articulation.js
+++ b/src/articulation.js
@@ -53,7 +53,10 @@ Vex.Flow.Articulation = (function() {
       if (!(this.note && (this.index !== null))) throw new Vex.RERR("NoAttachedNote",
         "Can't draw Articulation without a note and index.");
 
-      var stem_direction = this.note.getStemDirection();
+      var stem_direction = 1;
+      if (this.note.getStemDirection) {
+        stem_direction = this.note.getStemDirection();
+      }
       var stave = this.note.getStave();
 
       var is_on_head = (this.position === Modifier.Position.ABOVE &&
@@ -87,14 +90,18 @@ Vex.Flow.Articulation = (function() {
       var line_spacing = 1;
       var spacing = stave.getSpacingBetweenLines();
       var is_tabnote = this.note.getCategory() === 'tabnotes';
-      var stem_ext = this.note.getStem().getExtents();
+      var is_pause = this.note.getCategory() === 'pausemarkings';
 
-      var top = stem_ext.topY;
-      var bottom = stem_ext.baseY;
-
-      if (stem_direction === Vex.Flow.StaveNote.STEM_DOWN) {
-        top = stem_ext.baseY;
-        bottom = stem_ext.topY;
+      // Get the stem extents if it's a StemmableNote
+      var stem_ext, top, bottom;
+      if (this.note.getStem) {
+        stem_ext = this.note.getStem().getExtents();
+        top = stem_ext.topY;
+        bottom = stem_ext.baseY;
+        if (stem_direction === Vex.Flow.StaveNote.STEM_DOWN) {
+          top = stem_ext.baseY;
+          bottom = stem_ext.topY;
+        }
       }
 
       // TabNotes don't have stems attached to them. Tab stems are rendered
@@ -128,6 +135,8 @@ Vex.Flow.Articulation = (function() {
 
         if (this.articulation.between_lines)
           glyph_y = glyph_y_between_lines;
+        else if (is_pause)
+          glyph_y = Math.min(stave.getYForTopText(this.text_line), glyph_y - 25);
         else
           glyph_y = Math.min(stave.getYForTopText(this.text_line) - 3, glyph_y_between_lines);
       } else {
@@ -136,6 +145,8 @@ Vex.Flow.Articulation = (function() {
         glyph_y_between_lines = bottom + 10 + spacing * (this.text_line + line_spacing);
         if (this.articulation.between_lines)
           glyph_y = glyph_y_between_lines;
+        else if (is_pause)
+          glyph_y = Math.max(stave.getYForBottomText(this.text_line), glyph_y + 30);
         else
           glyph_y = Math.max(stave.getYForBottomText(this.text_line), glyph_y_between_lines);
       }

--- a/src/note.js
+++ b/src/note.js
@@ -86,6 +86,7 @@ Vex.Flow.Note = (function() {
       this.right_modPx = 0;       // Max width of right modifiers
       this.voice = null;          // The voice that this note is in
       this.preFormatted = false;  // Is this note preFormatted?
+      this.has_fixed_ys = false;
       this.ys = [];               // list of y coordinates for each note
                                   // we need to hold on to these for ties and beams.
                                 
@@ -157,6 +158,11 @@ Vex.Flow.Note = (function() {
       if (this.ys.length === 0) throw new Vex.RERR("NoYValues",
           "No Y-values calculated for this note.");
       return this.ys;
+    },
+
+    // Check if the object has fixed Y boundaries
+    hasFixedYs: function(){
+      return this.has_fixed_ys;
     },
 
     // Get the Y position of the space above the stave onto which text can

--- a/src/pausemarking.js
+++ b/src/pausemarking.js
@@ -1,0 +1,112 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+//
+// `PauseMarking` implements music notation pause markings. These are marks that
+//  are placed within a voice of notes to indicate the performer to breath or pause.
+Vex.Flow.PauseMarking = (function() {
+  function PauseMarking(type) {
+    if (arguments.length > 0) this.init(type);
+  }
+
+  // Glyph data for each pause marking
+  PauseMarking.GLYPHS = {
+    "tracks_straight": {
+      code: "v34",
+      point:40,
+      x_shift:0,
+      y_shift:2,
+      width: 15
+    },
+    "tracks_curved": {
+      code: "v4b",
+      point:40,
+      x_shift:0,
+      y_shift:2,
+      width: 15
+    },
+    "comma": {
+      code: "v6c",
+      point:40,
+      x_shift:0,
+      y_shift:0,
+      width: 10
+    },
+    "tick": {
+      code: "v6f",
+      point:50,
+      x_shift:0,
+      y_shift:0,
+      width: 10
+    }
+  };
+
+  // ## Prototype Methods
+  Vex.Inherit(PauseMarking, Vex.Flow.Note, {
+    // Initialize the marking with a specific type of mark
+    init: function(type) {
+      PauseMarking.superclass.init.call(this, {duration: "b"});
+
+      this.type = type;
+      this.line = 0;
+      this.glyph_data = PauseMarking.GLYPHS[type];
+      if (!this.glyph_data) throw new Vex.RERR("InvalidArguments",
+        "PauseMarking type" + type + "does not exist");
+
+      this.glyph = new Vex.Flow.Glyph(this.glyph_data.code, this.glyph_data.point);
+
+      this.setWidth(this.glyph_data.width);
+
+      this.ignore_ticks = true;
+    },
+
+    // Get/Set the Stave line on which the note should be placed
+    getLine: function() { return this.line; },
+    setLine: function(line) { this.line = line; return this; },
+
+    // Get the `ModifierContext` category
+    getCategory: function() { return "pausemarkings"; },
+
+    // Pre-render formatting
+    preFormat: function() { this.setPreFormatted(true); },
+
+    // Get the `x` and `y` coordinates for a modifier at a `position`
+    getModifierStartXY: function(position) {
+      if (!this.preFormatted) throw new Vex.RERR("UnformattedNote",
+          "Can't call GetModifierStartXY on an unformatted note");
+
+      var x = 0;
+      if (position == Vex.Flow.Modifier.Position.LEFT) {
+        x = -1 * 2;
+      } else if (position == Vex.Flow.Modifier.Position.RIGHT) {
+        x = this.glyph_data.width + this.x_shift + 2;
+      } else if (position == Vex.Flow.Modifier.Position.BELOW ||
+                 position == Vex.Flow.Modifier.Position.ABOVE) {
+        x = this.glyph_data.width / 2;
+      }
+
+      return { x: this.getAbsoluteX() + x, y: this.stave.getYForLine(this.line) };
+    },
+
+    // Renders the marking on the rendering context
+    draw: function() {
+      if (!this.context) throw new Vex.RERR("NoCanvasContext",
+          "Can't draw without a canvas context.");
+      if (!this.stave) throw new Vex.RERR("NoStave", "Can't draw without a stave.");
+
+      var ctx = this.context;
+      var x = this.getAbsoluteX() + this.glyph_data.x_shift;
+      var y = this.stave.getYForLine(this.line) + this.glyph_data.y_shift;
+
+      this.glyph.render(this.context, x, y);
+
+      for (var i = 0; i < this.modifiers.length; i++) {
+        var mod = this.modifiers[i];
+        mod.setContext(ctx);
+        mod.draw();
+      }
+    }
+  });
+
+  return PauseMarking;
+}());

--- a/src/pausemarking.js
+++ b/src/pausemarking.js
@@ -50,6 +50,8 @@ Vex.Flow.PauseMarking = (function() {
       this.type = type;
       this.line = 0;
       this.glyph_data = PauseMarking.GLYPHS[type];
+      this.has_fixed_ys = true;
+      
       if (!this.glyph_data) throw new Vex.RERR("InvalidArguments",
         "PauseMarking type" + type + "does not exist");
 
@@ -63,6 +65,11 @@ Vex.Flow.PauseMarking = (function() {
     // Get/Set the Stave line on which the note should be placed
     getLine: function() { return this.line; },
     setLine: function(line) { this.line = line; return this; },
+
+    // Get the relative y boundaries on either side of the stave
+    getFixedYs: function(){
+      return {top: 25, bottom: 30};
+    },
 
     // Get the `ModifierContext` category
     getCategory: function() { return "pausemarkings"; },

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -125,6 +125,7 @@
   <script src="../src/pedalmarking.js"></script>
   <script src="../src/textbracket.js"></script>
   <script src="../src/textdynamics.js"></script>
+  <script src="../src/pausemarking.js"></script>
 
   <!-- Compiled Source -->
   <script src="../support/vexflow-min.js"></script>
@@ -182,6 +183,7 @@
   <script src="ornament_tests.js"></script>
   <script src="pedalmarking_tests.js"></script>
   <script src="textbracket_tests.js"></script>
+  <script src="pausemarking_tests.js"></script>
 
   <script>
     $(function() {
@@ -229,6 +231,7 @@
       Vex.Flow.Test.Ornament.Start();
       Vex.Flow.Test.PedalMarking.Start();
       Vex.Flow.Test.TextBracket.Start();
+      Vex.Flow.Test.PauseMarking.Start();
 /*
       Vex.Flow.Test.Table.Start(); // These tests are way too rigid
 */

--- a/tests/pausemarking_tests.js
+++ b/tests/pausemarking_tests.js
@@ -5,6 +5,7 @@ Vex.Flow.Test.PauseMarking.Start = function() {
   Vex.Flow.Test.runTest("All Types", Vex.Flow.Test.PauseMarking.basic);
   Vex.Flow.Test.runTest("Custom Placement", Vex.Flow.Test.PauseMarking.customLinePlacement);
   Vex.Flow.Test.runTest("With Fermata", Vex.Flow.Test.PauseMarking.withFermata);
+  Vex.Flow.Test.runTest("With Fermata Weird Placement", Vex.Flow.Test.PauseMarking.withFermataWeird);
 };
 
 Vex.Flow.Test.PauseMarking.basic = function(options, contextBuilder) {
@@ -88,7 +89,7 @@ Vex.Flow.Test.PauseMarking.customLinePlacement = function(options, contextBuilde
 Vex.Flow.Test.PauseMarking.withFermata = function(options, contextBuilder) {
 	expect(0);
 
-	var ctx = new contextBuilder(options.canvas_sel, 550, 250);
+	var ctx = new contextBuilder(options.canvas_sel, 550, 200);
 	ctx.scale(1, 1);
 	ctx.fillStyle = "#221";
 	ctx.strokeStyle = "#221";
@@ -125,6 +126,61 @@ Vex.Flow.Test.PauseMarking.withFermata = function(options, contextBuilder) {
 		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
 		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
 		new Vex.Flow.PauseMarking("tracks_curved").setLine(5.5).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
+	];
+
+	var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice1.addTickables(notes1);
+
+	var beams1 = Vex.Flow.Beam.generateBeams(notes1);
+	new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+	voice1.draw(ctx, stave1);
+	
+	beams1.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+};
+
+Vex.Flow.Test.PauseMarking.withFermataWeird = function(options, contextBuilder) {
+	expect(0);
+
+	var ctx = new contextBuilder(options.canvas_sel, 550, 200);
+	ctx.scale(1, 1);
+	ctx.fillStyle = "#221";
+	ctx.strokeStyle = "#221";
+	ctx.font = " 10pt Arial";
+	var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
+	stave0.setContext(ctx).draw();
+
+	var stave1 = new Vex.Flow.Stave(260, 40, 250);
+	stave1.setContext(ctx).draw();
+
+	var notes0 = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_straight").setLine(1).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
+	];
+
+	var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice0.addTickables(notes0);
+
+	var beams0 = Vex.Flow.Beam.generateBeams(notes0);
+	new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+
+	voice0.draw(ctx, stave0);
+	
+	beams0.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+
+	var notes1 = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_curved").setLine(3).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
 	];
 
 	var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);

--- a/tests/pausemarking_tests.js
+++ b/tests/pausemarking_tests.js
@@ -9,189 +9,189 @@ Vex.Flow.Test.PauseMarking.Start = function() {
 };
 
 Vex.Flow.Test.PauseMarking.basic = function(options, contextBuilder) {
-	expect(0);
+  expect(0);
 
-	var ctx = new contextBuilder(options.canvas_sel, 600, 140);
-	ctx.scale(1, 1);
-	ctx.fillStyle = "#221";
-	ctx.strokeStyle = "#221";
-	ctx.font = " 10pt Arial";
-	var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
-	stave.setContext(ctx).draw();
+  var ctx = new contextBuilder(options.canvas_sel, 600, 140);
+  ctx.scale(1, 1);
+  ctx.fillStyle = "#221";
+  ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
+  stave.setContext(ctx).draw();
 
-	var notes = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("tracks_straight"),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_curved"),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("comma"),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("tick"),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
-	];
+  var notes = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("tracks_straight"),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_curved"),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("comma"),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("tick"),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
+  ];
 
-	var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice.addTickables(notes);
+  var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice.addTickables(notes);
 
-	var beams = Vex.Flow.Beam.generateBeams(notes);
-	new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+  var beams = Vex.Flow.Beam.generateBeams(notes);
+  new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
-	voice.draw(ctx, stave);
-	
-	beams.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice.draw(ctx, stave);
+  
+  beams.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 };
 
 Vex.Flow.Test.PauseMarking.customLinePlacement = function(options, contextBuilder) {
-	expect(0);
+  expect(0);
 
-	var ctx = new contextBuilder(options.canvas_sel, 600, 140);
-	ctx.scale(1, 1);
-	ctx.fillStyle = "#221";
-	ctx.strokeStyle = "#221";
-	ctx.font = " 10pt Arial";
-	var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
-	stave.setContext(ctx).draw();
+  var ctx = new contextBuilder(options.canvas_sel, 600, 140);
+  ctx.scale(1, 1);
+  ctx.fillStyle = "#221";
+  ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
+  stave.setContext(ctx).draw();
 
-	var notes = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("tracks_straight").setLine(-2),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_curved").setLine(-2),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("comma").setLine(-1),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.PauseMarking("tick").setLine(-1),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
-	];
+  var notes = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("tracks_straight").setLine(-2),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_curved").setLine(-2),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("comma").setLine(-1),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.PauseMarking("tick").setLine(-1),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
+  ];
 
-	var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice.addTickables(notes);
+  var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice.addTickables(notes);
 
-	var beams = Vex.Flow.Beam.generateBeams(notes);
-	new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+  var beams = Vex.Flow.Beam.generateBeams(notes);
+  new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
-	voice.draw(ctx, stave);
-	
-	beams.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice.draw(ctx, stave);
+  
+  beams.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 };
 
 Vex.Flow.Test.PauseMarking.withFermata = function(options, contextBuilder) {
-	expect(0);
+  expect(0);
 
-	var ctx = new contextBuilder(options.canvas_sel, 550, 200);
-	ctx.scale(1, 1);
-	ctx.fillStyle = "#221";
-	ctx.strokeStyle = "#221";
-	ctx.font = " 10pt Arial";
-	var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
-	stave0.setContext(ctx).draw();
+  var ctx = new contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1);
+  ctx.fillStyle = "#221";
+  ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
+  stave0.setContext(ctx).draw();
 
-	var stave1 = new Vex.Flow.Stave(260, 40, 250);
-	stave1.setContext(ctx).draw();
+  var stave1 = new Vex.Flow.Stave(260, 40, 250);
+  stave1.setContext(ctx).draw();
 
-	var notes0 = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_straight").setLine(-1.5).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
-	];
+  var notes0 = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_straight").setLine(-1.5).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
+  ];
 
-	var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice0.addTickables(notes0);
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
 
-	var beams0 = Vex.Flow.Beam.generateBeams(notes0);
-	new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  var beams0 = Vex.Flow.Beam.generateBeams(notes0);
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
 
-	voice0.draw(ctx, stave0);
-	
-	beams0.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice0.draw(ctx, stave0);
+  
+  beams0.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 
-	var notes1 = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_curved").setLine(5.5).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
-	];
+  var notes1 = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_curved").setLine(5.5).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
+  ];
 
-	var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice1.addTickables(notes1);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice1.addTickables(notes1);
 
-	var beams1 = Vex.Flow.Beam.generateBeams(notes1);
-	new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+  var beams1 = Vex.Flow.Beam.generateBeams(notes1);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
 
-	voice1.draw(ctx, stave1);
-	
-	beams1.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice1.draw(ctx, stave1);
+  
+  beams1.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 };
 
 Vex.Flow.Test.PauseMarking.withFermataWeird = function(options, contextBuilder) {
-	expect(0);
+  expect(0);
 
-	var ctx = new contextBuilder(options.canvas_sel, 550, 200);
-	ctx.scale(1, 1);
-	ctx.fillStyle = "#221";
-	ctx.strokeStyle = "#221";
-	ctx.font = " 10pt Arial";
-	var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
-	stave0.setContext(ctx).draw();
+  var ctx = new contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1);
+  ctx.fillStyle = "#221";
+  ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
+  stave0.setContext(ctx).draw();
 
-	var stave1 = new Vex.Flow.Stave(260, 40, 250);
-	stave1.setContext(ctx).draw();
+  var stave1 = new Vex.Flow.Stave(260, 40, 250);
+  stave1.setContext(ctx).draw();
 
-	var notes0 = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_straight").setLine(1).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
-	];
+  var notes0 = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_straight").setLine(1).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
+  ];
 
-	var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice0.addTickables(notes0);
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
 
-	var beams0 = Vex.Flow.Beam.generateBeams(notes0);
-	new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  var beams0 = Vex.Flow.Beam.generateBeams(notes0);
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
 
-	voice0.draw(ctx, stave0);
-	
-	beams0.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice0.draw(ctx, stave0);
+  
+  beams0.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 
-	var notes1 = [
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
-		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
-		new Vex.Flow.PauseMarking("tracks_curved").setLine(3).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
-	];
+  var notes1 = [
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+    new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+    new Vex.Flow.PauseMarking("tracks_curved").setLine(3).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
+  ];
 
-	var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
-	voice1.addTickables(notes1);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice1.addTickables(notes1);
 
-	var beams1 = Vex.Flow.Beam.generateBeams(notes1);
-	new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+  var beams1 = Vex.Flow.Beam.generateBeams(notes1);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
 
-	voice1.draw(ctx, stave1);
-	
-	beams1.forEach(function(beam) {
-		beam.setContext(ctx).draw();
-	});
+  voice1.draw(ctx, stave1);
+  
+  beams1.forEach(function(beam) {
+    beam.setContext(ctx).draw();
+  });
 };

--- a/tests/pausemarking_tests.js
+++ b/tests/pausemarking_tests.js
@@ -1,0 +1,141 @@
+Vex.Flow.Test.PauseMarking = {};
+
+Vex.Flow.Test.PauseMarking.Start = function() {
+  module("PauseMarking");
+  Vex.Flow.Test.runTest("All Types", Vex.Flow.Test.PauseMarking.basic);
+  Vex.Flow.Test.runTest("Custom Placement", Vex.Flow.Test.PauseMarking.customLinePlacement);
+  Vex.Flow.Test.runTest("With Fermata", Vex.Flow.Test.PauseMarking.withFermata);
+};
+
+Vex.Flow.Test.PauseMarking.basic = function(options, contextBuilder) {
+	expect(0);
+
+	var ctx = new contextBuilder(options.canvas_sel, 600, 140);
+	ctx.scale(1, 1);
+	ctx.fillStyle = "#221";
+	ctx.strokeStyle = "#221";
+	ctx.font = " 10pt Arial";
+	var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
+	stave.setContext(ctx).draw();
+
+	var notes = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("tracks_straight"),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_curved"),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("comma"),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("tick"),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
+	];
+
+	var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice.addTickables(notes);
+
+	var beams = Vex.Flow.Beam.generateBeams(notes);
+	new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+	voice.draw(ctx, stave);
+	
+	beams.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+};
+
+Vex.Flow.Test.PauseMarking.customLinePlacement = function(options, contextBuilder) {
+	expect(0);
+
+	var ctx = new contextBuilder(options.canvas_sel, 600, 140);
+	ctx.scale(1, 1);
+	ctx.fillStyle = "#221";
+	ctx.strokeStyle = "#221";
+	ctx.font = " 10pt Arial";
+	var stave = new Vex.Flow.Stave(10, 10, 550).addTrebleGlyph();
+	stave.setContext(ctx).draw();
+
+	var notes = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("tracks_straight").setLine(-2),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_curved").setLine(-2),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("comma").setLine(-1),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.PauseMarking("tick").setLine(-1),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"})
+	];
+
+	var voice = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice.addTickables(notes);
+
+	var beams = Vex.Flow.Beam.generateBeams(notes);
+	new Vex.Flow.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+	voice.draw(ctx, stave);
+	
+	beams.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+};
+
+Vex.Flow.Test.PauseMarking.withFermata = function(options, contextBuilder) {
+	expect(0);
+
+	var ctx = new contextBuilder(options.canvas_sel, 550, 250);
+	ctx.scale(1, 1);
+	ctx.fillStyle = "#221";
+	ctx.strokeStyle = "#221";
+	ctx.font = " 10pt Arial";
+	var stave0 = new Vex.Flow.Stave(10, 40, 250).addTrebleGlyph();
+	stave0.setContext(ctx).draw();
+
+	var stave1 = new Vex.Flow.Stave(260, 40, 250);
+	stave1.setContext(ctx).draw();
+
+	var notes0 = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_straight").setLine(-1.5).addModifier(new Vex.Flow.Articulation('a@a').setPosition(3), 0),
+	];
+
+	var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice0.addTickables(notes0);
+
+	var beams0 = Vex.Flow.Beam.generateBeams(notes0);
+	new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+
+	voice0.draw(ctx, stave0);
+	
+	beams0.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+
+	var notes1 = [
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "4"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "16"}),
+		new Vex.Flow.StaveNote({ keys: ["b/4"], duration: "8"}),
+		new Vex.Flow.PauseMarking("tracks_curved").setLine(5.5).addModifier(new Vex.Flow.Articulation('a@u').setPosition(4), 0),
+	];
+
+	var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+	voice1.addTickables(notes1);
+
+	var beams1 = Vex.Flow.Beam.generateBeams(notes1);
+	new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+	voice1.draw(ctx, stave1);
+	
+	beams1.forEach(function(beam) {
+		beam.setContext(ctx).draw();
+	});
+};


### PR DESCRIPTION
**Multiple Glyph Types**
![image](https://cloud.githubusercontent.com/assets/1631625/3032777/01f90d4e-e05c-11e3-996b-26d9cbab0f51.png)

**Custom Line Placement**
![image](https://cloud.githubusercontent.com/assets/1631625/3032785/1268d8da-e05c-11e3-9fd3-c55c29988416.png)

**With Articulation** *to handle caesura + fermata*
![image](https://cloud.githubusercontent.com/assets/1631625/3032792/2fcc11da-e05c-11e3-9f14-a9913ba3af71.png)

This clutters up `Articulation` a bit, so let me know what you think of the code. We've only dealt with articulations on `StemmableNotes` up to this point and these markings are stemless. So I had to do some checks to make sure to make `Articulation` didn't try and access stem data that didn't exist.