### PR TITLE
Added PedalMarking class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,8 @@ base_sources = [
   "src/strokes.js",
   "src/curve.js",
   "src/staveline.js",
-  "src/crescendo.js"
+  "src/crescendo.js",
+  "src/pedalmarking.js"
 ]
 
 # Don't minify these files.

--- a/src/pedalmarking.js
+++ b/src/pedalmarking.js
@@ -1,0 +1,261 @@
+// [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+//
+// ## Description
+//
+// This file implements different types of pedal markings. These notation 
+// elements indicate to the performer when to depress and release the a pedal.
+// 
+// In order to create "Sostenuto", and "una corda" markings, you must set
+// custom text for the release/depress pedal markings.  
+Vex.Flow.PedalMarking = (function() {
+  function PedalMarking(type) {
+    if (arguments.length > 0) this.init(type);
+  }
+
+  // To enable logging for this class. Set `Vex.Flow.PedalMarking.DEBUG` to `true`.
+  function L() { if (PedalMarking.DEBUG) Vex.L("Vex.Flow.PedalMarking", arguments); }
+
+  // Glyph data
+  PedalMarking.GLYPHS = {
+    "pedal_depress": {
+      code: "v36",
+      x_shift:-10,
+      y_shift:0
+    },
+    "pedal_release": {
+      code: "v5d",
+      x_shift:-2,
+      y_shift:3
+    },
+  };
+
+  PedalMarking.Styles = {
+    TEXT: 1,
+    BRACKET: 2,
+    MIXED: 3
+  };
+
+  
+  // ## Public helpers
+  // 
+  // Create a sustain pedal marking. Returns the defaults PedalMarking.
+  // Which uses the traditional "Ped" and "*"" markings.
+  PedalMarking.createSustain = function(notes) {
+    var pedal = new PedalMarking(notes);
+    return pedal;
+  };
+
+  // Create a sostenuto pedal marking
+  PedalMarking.createSostenuto = function(notes) {
+    var pedal = new PedalMarking(notes);
+    pedal.setStyle(PedalMarking.Styles.MIXED);
+    pedal.setCustomText("Sost. Ped.");
+    return pedal;
+  };
+
+  // Create an una corda pedal marking
+  PedalMarking.createUnaCorda = function(notes){
+    var pedal = new PedalMarking(notes);
+    pedal.setStyle(PedalMarking.Styles.TEXT);
+    pedal.setCustomText("una corda", "tre corda");
+    return pedal;
+  };
+
+  // ## Prototype Methods
+  PedalMarking.prototype =  {
+    init: function(notes) {
+      this.notes = notes;
+      this.style = Vex.Flow.PedalMarking.TEXT;
+      this.line = 0;
+
+      // Custom text for the release/depress markings
+      this.custom_depress_text = "";
+      this.custom_release_text = "";
+      
+      this.font = {
+        family: "Times New Roman",
+        size: 12,
+        weight: "italic bold"
+      };
+
+      this.render_options = {
+        bracket_height: 10,
+        text_margin_right: 6,
+        bracket_line_width: 1,
+        glyph_point_size: 40,
+        color: "black"
+      };
+    },
+
+    // Set custom text for the `depress`/`release` pedal markings. No text is 
+    // set if the parameter is falsy.
+    setCustomText: function(depress, release) {
+      this.custom_depress_text = depress || "";
+      this.custom_release_text = release || "";
+      return this;
+    },
+
+    // Set the pedal marking style
+    setStyle: function(style){
+      if (style < 1 && style > 3)  {
+        throw new Vex.RERR("InvalidParameter",
+          "The style must be one found in PedalMarking.Styles");
+      }
+
+      this.style = style;
+      return this;
+    },
+
+    // Set the staff line to render the markings on
+    setLine: function(line) { this.line = line; return this; },
+
+    // Set the rendering context
+    setContext: function(context) { this.context = context; return this; },
+
+    // Draw the bracket based pedal markings
+    drawBracketed: function() {
+      var ctx = this.context;
+      var is_pedal_depressed = false;
+      var prev_x;
+      var prev_y;
+      var pedal = this;
+
+      // Iterate through each note
+      this.notes.forEach(function(note, index, notes) {
+        // Each note triggers the opposite pedal action
+        is_pedal_depressed = !is_pedal_depressed;
+
+        // Get the initial coordinates for the note
+        var x = note.getAbsoluteX();
+        var y = note.getStave().getYForBottomText(pedal.line + 3);
+
+        // Throw if current note is positioned before the previous note
+        if (x < prev_x) throw new Vex.RERR('InvalidConfiguration',
+          'The notes provided must be in order of ascending x positions');
+
+        // Determine if the previous or next note are the same 
+        // as the current note. We need to keep track of this for
+        // when adjustments are made for the release+depress action
+        var next_is_same = notes[index+1] === note;
+        var prev_is_same = notes[index-1] === note;
+
+        var x_shift = 0;
+        if (is_pedal_depressed) {
+          // Adjustment for release+depress
+          x_shift =  prev_is_same ? 5 : 0;
+
+          if (pedal.style === PedalMarking.Styles.MIXED && !prev_is_same) {
+            // For MIXED style, start with text instead of bracket
+            if (pedal.custom_depress_text) {
+              // If we have custom text, use instead of the default "Ped" glyph
+              var text_width = ctx.measureText(pedal.custom_depress_text).width;
+              ctx.fillText(pedal.custom_depress_text, x - (text_width/2), y);
+              x_shift = (text_width / 2) + pedal.render_options.text_margin_right;
+            } else {
+              // Render the Ped glyph in position
+              drawPedalGlyph('pedal_depress', ctx, x, y, pedal.render_options.glyph_point_size);
+              x_shift = 20 + pedal.render_options.text_margin_right;
+            }
+          } else {
+            // Draw start bracket
+            ctx.beginPath();
+            ctx.moveTo(x, y - pedal.render_options.bracket_height);
+            ctx.lineTo(x + x_shift, y);
+            ctx.stroke();
+            ctx.closePath();
+          }
+        } else {
+          // Adjustment for release+depress
+          x_shift = next_is_same ? -5 : 0;
+
+          // Draw end bracket
+          ctx.beginPath();
+          ctx.moveTo(prev_x, prev_y);
+          ctx.lineTo(x + x_shift, y);
+          ctx.lineTo(x, y - pedal.render_options.bracket_height);
+          ctx.stroke();
+          ctx.closePath();
+        }
+
+        // Store previous coordinates
+        prev_x = x + x_shift;
+        prev_y = y;
+      });
+    },
+
+    // Draw the text based pedal markings. This defaults to the traditional
+    // "Ped" and "*"" symbols if no custom text has been provided.
+    drawText: function() {
+      var ctx = this.context;
+      var is_pedal_depressed = false;
+      var prev_x;
+      var prev_y;
+      var pedal = this;
+
+      // The glyph point size
+      var point = pedal.render_options.glyph_point_size;
+
+      // Iterate through each note, placing glyphs or custom text accordingly
+      this.notes.forEach(function(note, index, notes) {
+        is_pedal_depressed = !is_pedal_depressed;
+        var stave = note.getStave();
+        var x = note.getAbsoluteX();
+        var y = stave.getYForBottomText(pedal.line + 3);
+
+        var text_width = 0;
+        if (is_pedal_depressed) {
+          if (pedal.custom_depress_text) {
+            text_width = ctx.measureText(pedal.custom_depress_text).width;
+            ctx.fillText(pedal.custom_depress_text, x - (text_width/2), y);
+          } else {
+            drawPedalGlyph("pedal_depress", ctx, x, y, point);
+          }
+        } else {
+          if (pedal.custom_release_text) {
+            text_width = ctx.measureText(pedal.custom_release_text).width;
+            ctx.fillText(pedal.custom_release_text, x - (text_width/2), y);
+          } else {
+            drawPedalGlyph("pedal_release", ctx, x, y, point);
+          }
+        }
+      });
+    },
+
+    // Render the pedal marking in position on the rendering context 
+    draw: function() {
+      if (!this.context) throw new Vex.RERR("NoContext",
+        "Can't draw PedalMarking without a context.");
+      var ctx = this.context;
+
+      ctx.save();
+      ctx.setStrokeStyle(this.render_options.color);
+      ctx.setFillStyle(this.render_options.color);
+      ctx.setFont(this.font.family, this.font.size, this.font.weight);
+
+      L("Rendering Pedal Marking");
+
+      if (this.style === PedalMarking.Styles.BRACKET ||
+          this.style === PedalMarking.Styles.MIXED) {
+        ctx.setLineWidth(this.render_options.bracket_line_width);
+        this.drawBracketed();
+      } else if (this.style === Vex.Flow.PedalMarking.Styles.TEXT) {
+        this.drawText();
+      }
+
+      ctx.restore();
+    }
+  };
+
+  // ## Private Helper
+  // 
+  // Draws a pedal glyph with the provided `name` on a rendering `context` 
+  // at the coordinates `x` and `y. Takes into account the glyph data
+  // coordinate shifts.
+  function drawPedalGlyph(name, context, x, y, point) {
+    var glyph_data = PedalMarking.GLYPHS[name];
+    var glyph = new Vex.Flow.Glyph(glyph_data.code, point);
+    glyph.render(context, x + glyph_data.x_shift, y + glyph_data.y_shift);
+  }
+
+  return PedalMarking;
+}());

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -121,6 +121,7 @@
   <script src="../src/curve.js"></script>
   <script src="../src/staveline.js"></script>
   <script src="../src/crescendo.js"></script>
+  <script src="../src/pedalmarking.js"></script>
 
   <!-- Compiled Source -->
   <script src="../support/vexflow-min.js"></script>
@@ -175,6 +176,7 @@
   <script src="curve_tests.js"></script>
   <script src="notehead_tests.js"></script>
   <script src="staveline_tests.js"></script>
+  <script src="pedalmarking_tests.js"></script>
 
   <script>
     $(function() {
@@ -219,6 +221,7 @@
       Vex.Flow.Test.Curve.Start();
       Vex.Flow.Test.TextNote.Start();
       Vex.Flow.Test.StaveLine.Start();
+      Vex.Flow.Test.PedalMarking.Start();
 /*
       Vex.Flow.Test.Table.Start(); // These tests are way too rigid
 */

--- a/tests/pedalmarking_tests.js
+++ b/tests/pedalmarking_tests.js
@@ -1,0 +1,362 @@
+/**
+ * VexFlow - PedalMarking Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ */
+
+Vex.Flow.Test.PedalMarking = {};
+
+Vex.Flow.Test.PedalMarking.Start = function() {
+  module("PedalMarking");
+  Vex.Flow.Test.runTest("Simple Pedal", Vex.Flow.Test.PedalMarking.simpleText);
+  Vex.Flow.Test.runTest("Simple Pedal", Vex.Flow.Test.PedalMarking.simpleBracket);
+  Vex.Flow.Test.runTest("Simple Pedal", Vex.Flow.Test.PedalMarking.simpleMixed);
+  Vex.Flow.Test.runTest("Release and Depress on Same Note", Vex.Flow.Test.PedalMarking.releaseDepressOnSameNoteBracketed);
+  Vex.Flow.Test.runTest("Release and Depress on Same Note", Vex.Flow.Test.PedalMarking.releaseDepressOnSameNoteMixed);
+  Vex.Flow.Test.runTest("Custom Text", Vex.Flow.Test.PedalMarking.customText);
+  Vex.Flow.Test.runTest("Custom Text", Vex.Flow.Test.PedalMarking.customTextMixed);
+};
+
+
+Vex.Flow.Test.PedalMarking.simpleText = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes0[2], notes0[3], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.TEXT);
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+
+};
+
+Vex.Flow.Test.PedalMarking.simpleBracket = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes0[2], notes0[3], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.BRACKET);
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+
+};
+
+Vex.Flow.Test.PedalMarking.simpleMixed = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes0[2], notes0[3], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.MIXED);
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+
+};
+
+Vex.Flow.Test.PedalMarking.releaseDepressOnSameNoteBracketed = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes0[3], notes0[3], notes1[1], notes1[1], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.BRACKET);
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+
+};
+
+Vex.Flow.Test.PedalMarking.releaseDepressOnSameNoteMixed = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes0[3], notes0[3], notes1[1], notes1[1],  notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.MIXED);
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+
+};
+
+Vex.Flow.Test.PedalMarking.customText = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.TEXT);
+
+  pedal.setCustomText("una corda", "tre corda");
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+};
+
+Vex.Flow.Test.PedalMarking.customTextMixed = function(options, contextBuilder) {
+  expect(0);
+
+  options.contextBuilder = contextBuilder;
+  var ctx = new options.contextBuilder(options.canvas_sel, 550, 200);
+  ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
+  ctx.font = " 10pt Arial";
+  //ctx.translate(0.5, 0.5);
+  var stave0 = new Vex.Flow.Stave(10, 10, 250).addTrebleGlyph();
+  var stave1 = new Vex.Flow.Stave(260, 10, 250);
+  stave0.setContext(ctx).draw();
+  stave1.setContext(ctx).draw();
+
+  function newNote(note_struct) { return new Vex.Flow.StaveNote(note_struct); }
+  function newAcc(type) { return new Vex.Flow.Accidental(type); }
+
+
+  var notes0 = [
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: 1},
+    {keys: ["b/4"], duration: "4", stem_direction: -1}
+  ].map(newNote);
+
+  var notes1 = [
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"},
+    {keys: ["c/4"], duration: "4"}
+  ].map(newNote);
+
+  var voice0 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  var voice1 = new Vex.Flow.Voice(Vex.Flow.TIME4_4).setStrict(false);
+  voice0.addTickables(notes0);
+  voice1.addTickables(notes1);
+
+  new Vex.Flow.Formatter().joinVoices([voice0]).formatToStave([voice0], stave0);
+  new Vex.Flow.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  var pedal = new Vex.Flow.PedalMarking([notes0[0], notes1[3]]);
+
+  pedal.setStyle(Vex.Flow.PedalMarking.Styles.MIXED);
+  pedal.setCustomText("Sost. Ped.");
+
+  voice0.draw(ctx, stave0);
+  voice1.draw(ctx, stave1);
+  pedal.setContext(ctx).draw();
+};


### PR DESCRIPTION
# Features
- You can provide custom text through the `.setCustomText(depress, release)`. Where `depress` and `release` is the custom text for each pedal action.
- Three Different Styles - based off of lilypond
  - `TEXT` style defaults to the traditional _Ped_ and _asterix_ glyphs, unless custom text has been provided. This style only supports **depress** and **release** actions on separate notes. Trying to do both on the same note will simply draw overlapping text.
  - `BRACKET` draws bracket based marking and supports **release and depress** on the same note. Which will draw the little tooth.
  - `MIXED` draws the depress text (either the default _Ped_ glyph, or the custom text), followed by the brackets. This also supports **release and depress** action. But will not render the release text, only a release bracket.
- Helper functions to draw common pedal markings `.createSustain(notes)`, `.createSostenuto(notes)`, `.createUnaCorda(notes)`
# Code Examples

``` javascript
  // Create a new pedal marking. Each note in the array toggle back and forth 
  // between a depress/release action
  var pedal = new Vex.Flow.PedalMarking([note0, note10]);

  // Set the style of the pedal marking
  pedal.setStyle(Vex.Flow.PedalMarking.Styles.TEXT);

  // Set the custom text for the pedal marking
  pedal.setCustomText("una corda", "tre corda");

  // Set the line the marking should render on
  pedal.setLine(1);

  // Draw elements, must draw pedal marking after its notes have a stave
  voice.draw(ctx, stave);
  pedal.setContext(ctx).draw();
```
# Tests

![image](https://cloud.githubusercontent.com/assets/1631625/3125138/b0d9b1da-e785-11e3-9995-0614b5ae1b55.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125141/b517f8b0-e785-11e3-8c3a-a4ded65c7dac.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125143/b91d26e2-e785-11e3-8340-04c5f1597601.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125145/be84d562-e785-11e3-9a0b-68970d8a535b.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125146/c2eaee3e-e785-11e3-9a33-24ce21facd99.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125148/c978e3b4-e785-11e3-88df-006937b40e18.png)
![image](https://cloud.githubusercontent.com/assets/1631625/3125149/cd4c45b2-e785-11e3-803b-fc035c98c6f4.png)
