### PR TITLE
Calmer beams with new cost algorithm

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -89,7 +89,7 @@ Vex.Flow.Beam = (function() {
         max_slope: 0.25,
         min_slope: -0.25,
         slope_iterations: 20,
-        slope_cost: 25,
+        slope_cost: 100,
         show_stemlets: false,
         stemlet_extension: 7,
         partial_beam_length: 10
@@ -163,15 +163,19 @@ Vex.Flow.Beam = (function() {
           }
 
         }
-        /*
-          // This causes too many zero-slope beams.
+        
+        var last_note = this.notes[this.notes.length - 1];
+        var first_last_slope = ((last_note.getStemExtents().topY - first_y_px) / 
+                (last_note.getStemX() - first_x_px));
+        // most engraving books suggest aiming for a slope about half the angle of the
+        // difference between the first and last notes' stem length;
+        var ideal_slope = first_last_slope / 2; 
+        var distance_from_ideal = Math.abs(ideal_slope - slope);
 
-          var cost = this.render_options.slope_cost * Math.abs(slope) +
-            Math.abs(total_stem_extension);
-        */
-
-        // Pick a beam that minimizes stem extension.
-        var cost = Math.abs(total_stem_extension);
+        // This tries to align most beams to something closer to the ideal_slope, but
+        // doesn't go crazy. To disable, set this.render_options.slope_cost = 0
+        var cost = this.render_options.slope_cost * distance_from_ideal +
+            Math.abs(total_stem_extension);     
 
         // update state when a more ideal slope is found
         if (cost < min_cost) {


### PR DESCRIPTION
This patch applies the (previously unused) slope_cost option in Vex.Flow.Beam to not penalize the slope itself but to penalize the difference between the test slope and a slope which examines the stem height of the first and last notes only and aims for a slope that is half the angle of their difference. This is the algorithm that a number of books on notation suggest aiming for. It still will chose other slopes in cases where intervening notes make getting this slope impossible. But the examples below (Left: new algorithm; Right: old algorithm) give much more gentle slopes than before and more often convey the overall angle from first to last note. Only some tests included, but all other tests leave the original beam slopes largely alone.

![vexflow_beam_improvements](https://cloud.githubusercontent.com/assets/3521479/3212364/12dcf64c-ef58-11e3-9425-03a5e9d034dd.jpg)
