### PR TITLE
Fixed default rest positioning

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -188,6 +188,15 @@ Vex.Flow.StaveNote = (function() {
               "Invalid key for note properties: " + key);
         }
 
+        // Override line placement for default rests
+        if (props.key === "R") {
+          if (this.duration === "1" || this.duration === "w") {
+            props.line = 4;
+          } else {
+            props.line = 3;
+          }
+        }
+
         // Calculate displacement of this note
         var line = props.line;
         if (last_line === null) {

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -16,35 +16,35 @@ Vex.Flow.Test.StaveNote.Start = function() {
   test("TickContext", Vex.Flow.Test.StaveNote.tickContext);
 
   Vex.Flow.Test.runTest("StaveNote Draw - Treble", Vex.Flow.Test.StaveNote.draw,
-      { clef: "treble", octaveShift: 0, restKey: "b/4" });
+      { clef: "treble", octaveShift: 0, restKey: "r/4" });
   Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Treble (Raphael)",
       Vex.Flow.Test.StaveNote.draw,
-      { clef: "treble", octaveShift: 0, restKey: "b/4" });
+      { clef: "treble", octaveShift: 0, restKey: "r/4" });
 
   Vex.Flow.Test.runTest("StaveNote BoundingBoxes - Treble", Vex.Flow.Test.StaveNote.drawBoundingBoxes,
-      { clef: "treble", octaveShift: 0, restKey: "b/4" });
+      { clef: "treble", octaveShift: 0, restKey: "r/4" });
   Vex.Flow.Test.runRaphaelTest("StaveNote BoundingBoxes - Treble (Raphael)",
       Vex.Flow.Test.StaveNote.drawBoundingBoxes,
-      { clef: "treble", octaveShift: 0, restKey: "b/4" });
+      { clef: "treble", octaveShift: 0, restKey: "r/4" });
 
 
   Vex.Flow.Test.runTest("StaveNote Draw - Alto", Vex.Flow.Test.StaveNote.draw,
-      { clef: "alto", octaveShift: -1, restKey: "c/4" });
+      { clef: "alto", octaveShift: -1, restKey: "r/4" });
   Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Alto (Raphael)",
       Vex.Flow.Test.StaveNote.draw,
-      { clef: "alto", octaveShift: -1, restKey: "c/4" });
+      { clef: "alto", octaveShift: -1, restKey: "r/4" });
 
   Vex.Flow.Test.runTest("StaveNote Draw - Tenor", Vex.Flow.Test.StaveNote.draw,
-      { clef: "tenor", octaveShift: -1, restKey: "a/3" });
+      { clef: "tenor", octaveShift: -1, restKey: "r/3" });
   Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Tenor (Raphael)",
       Vex.Flow.Test.StaveNote.draw,
-      { clef: "tenor", octaveShift: -1, restKey: "a/3" });
+      { clef: "tenor", octaveShift: -1, restKey: "r/3" });
 
   Vex.Flow.Test.runTest("StaveNote Draw - Bass", Vex.Flow.Test.StaveNote.draw,
-      { clef: "bass", octaveShift: -2, restKey: "d/3" });
+      { clef: "bass", octaveShift: -2, restKey: "r/3" });
   Vex.Flow.Test.runRaphaelTest("StaveNote Draw - Bass (Raphael)",
       Vex.Flow.Test.StaveNote.draw,
-      { clef: "bass", octaveShift: -2, restKey: "d/3" });
+      { clef: "bass", octaveShift: -2, restKey: "r/3" });
 
   Vex.Flow.Test.runTest("StaveNote Draw - Harmonic And Muted",
                         Vex.Flow.Test.StaveNote.drawHarmonicAndMuted);
@@ -567,12 +567,12 @@ Vex.Flow.Test.StaveNote.drawBass = function(options, contextBuilder) {
     { clef: 'bass', keys: ["c/2", "e/2", "a/2"], duration: "16", stem_direction: -1},
     { clef: 'bass', keys: ["c/2", "e/2", "a/2"], duration: "32", stem_direction: -1},
 
-    { keys: ["b/4"], duration: "wr"},
-    { keys: ["b/4"], duration: "hr"},
-    { keys: ["b/4"], duration: "qr"},
-    { keys: ["b/4"], duration: "8r"},
-    { keys: ["b/4"], duration: "16r"},
-    { keys: ["b/4"], duration: "32r"},
+    { keys: ["r/4"], duration: "wr"},
+    { keys: ["r/4"], duration: "hr"},
+    { keys: ["r/4"], duration: "qr"},
+    { keys: ["r/4"], duration: "8r"},
+    { keys: ["r/4"], duration: "16r"},
+    { keys: ["r/4"], duration: "32r"},
     { keys: ["x/4"], duration: "h"}
   ];
 


### PR DESCRIPTION
This PR does two things:
1. Fixes positioning of Whole Rest
2. Normalizes rest positioning across all clefs while using the key type `R`, ie: `keys: ["r/4"]`. _(But really the octave is irrelevant, we just need it to not break key parsing)_

Basically, in `StaveNote.calculateKeyProps()` I simply override the `line` value if the `props.key` is `"R"`. Let me know if you'd prefer a different way of fixing this.

I also modified the `stavenote_tests.js`, so all rests simply take `r/n`. 

**Treble**
![image](https://cloud.githubusercontent.com/assets/1631625/3235773/383ffc0c-f0d6-11e3-8dbf-708df325aa4b.png)
**Bass**
![image](https://cloud.githubusercontent.com/assets/1631625/3235774/48b80912-f0d6-11e3-9e4b-d9477071a4b1.png)
