### PR TITLE
Fixed align_rests option of Formatter to work correctly

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -295,6 +295,7 @@ Vex.Flow.Formatter = (function() {
           var props = note.getKeyProps()[0];
           if (i === 0) {
             props.line = lookAhead(notes, props.line, i, false);
+            note.setKeyLine(0, props.line);
           } else if (i > 0 && i < notes.length) {
             // If previous note is a rest, use its line number.
             var rest_line;
@@ -306,6 +307,7 @@ Vex.Flow.Formatter = (function() {
               // Get the rest line for next valid non-rest note group.
               props.line = lookAhead(notes, rest_line, i, true);
             }
+            note.setKeyLine(0, props.line);
           }
         }
       }

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -127,8 +127,9 @@ Vex.Flow.NoteHead = (function() {
     getY: function() { return this.y; },
     setY: function(y) { this.y = y;  return this; },
 
-    // Get the stave line the notehead is placed on 
-    getLine: function(){ return this.line; },
+    // Get/set the stave line the notehead is placed on
+    getLine: function() { return this.line; },
+    setLine: function(line) { this.line = line; return this; },
 
     // Get the canvas `x` coordinate position of the notehead.
     getAbsoluteX: function() {

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -409,6 +409,11 @@ Vex.Flow.StaveNote = (function() {
       return this;
     },
 
+    setKeyLine: function(index, line) {
+      this.note_heads[index].setLine(line);
+      return this;
+    },
+
     // Add self to modifier context. `mContext` is the `ModifierContext`
     // to be added to.
     addToModifierContext: function(mContext) {

--- a/tests/threevoice_tests.js
+++ b/tests/threevoice_tests.js
@@ -330,7 +330,7 @@ Vex.Flow.Test.ThreeVoices.autoresttwovoices = function(options, contextBuilder) 
   Vex.Debug = false;
   var formatter = new Vex.Flow.Formatter().
     joinVoices([voice, voice1, voice2]).
-    format([voice, voice1, voice2], 350, {align_rests: true});
+    format([voice, voice1, voice2], 350, {align_rests: false});
 
   voice.draw(c, stave);
   voice1.draw(c, stave);
@@ -446,7 +446,7 @@ Vex.Flow.Test.ThreeVoices.autorestthreevoices = function(options, contextBuilder
   Vex.Debug = false;
   var formatter = new Vex.Flow.Formatter().
     joinVoices([voice, voice1, voice2, voice3]).
-    format([voice, voice1, voice2, voice3], 350, {align_rests: true});
+    format([voice, voice1, voice2, voice3], 350, {align_rests: false});
 
   voice.draw(c, stave);
   voice1.draw(c, stave);
@@ -558,7 +558,7 @@ Vex.Flow.Test.ThreeVoices.autorestthreevoices2 = function(options, contextBuilde
   Vex.Debug = false;
   var formatter = new Vex.Flow.Formatter().
     joinVoices([voice, voice1, voice2, voice3]).
-    format([voice, voice1, voice2, voice3], 400, {align_rests: true});
+    format([voice, voice1, voice2, voice3], 400, {align_rests: false});
 
   voice.draw(c, stave);
   voice1.draw(c, stave);


### PR DESCRIPTION
align_rests option was not working because line of note_head is not updated when formatting rests
Formatter only updated keyProps, so fixed
and also fixed tests to make it possible to compare between align_rests option on and off

Previous:
![33](https://cloud.githubusercontent.com/assets/2025065/3747875/2ffa8de4-17d4-11e4-9b33-61745f04316c.png)
Updated:
![34](https://cloud.githubusercontent.com/assets/2025065/3747876/30069cd8-17d4-11e4-912f-06531d30d7a7.png)
