### PR TITLE
stops beam stems from being messed up the second time you draw them

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -333,7 +333,9 @@ Vex.Flow.StaveNote = (function() {
       this.setYs(ys);
 
       var bounds = this.getNoteHeadBounds();
-      this.stem.setYBounds(bounds.y_top, bounds.y_bottom);
+      if(!this.beam){
+	this.stem.setYBounds(bounds.y_top, bounds.y_bottom);
+      }
 
       return this;
     },


### PR DESCRIPTION
When a note with a beam is drawn for the second time (and after), the stem will become far too short (not even appearing most of the time). To see why this is important, take a look at the site I'm building, which is still a bit rough, but working, http://computingmusic.cs.mcgill.ca/ It allows users to upload an midi or abc file and see it as sheet music and then perform analyses on it. Since pieces are often far too long to fit on a canvas, I solved the problem by having the canvas fit to the screen and update when click-dragged or otherwise moved to show only the part of the piece in view. This means that on each movement I have to redraw all of the notes, and if beam stems only work on the first draw things look very ugly. This pull request fixes this problem.
