### PR TITLE
Remove float comparisons where Fraction comparisons would be better

### DIFF
--- a/src/accidental.js
+++ b/src/accidental.js
@@ -128,19 +128,19 @@ Vex.Flow.Accidental = (function(){
 
     // Sort the tickables in each voice by their tick position in the voice
     voices.forEach(function(voice) {
-      var tickPosition = 0;
+      var tickPosition = new Vex.Flow.Fraction(0, 1);
       var notes = voice.getTickables();
       notes.forEach(function(note) {
-        var notesAtPosition = tickNoteMap[tickPosition];
+        var notesAtPosition = tickNoteMap[tickPosition.value()];
 
         if (!notesAtPosition) {
-          tickPositions.push(tickPosition);
-          tickNoteMap[tickPosition] = [note];
+          tickPositions.push(tickPosition.value());
+          tickNoteMap[tickPosition.value()] = [note];
         } else {
           notesAtPosition.push(note);
         }
 
-        tickPosition += note.getTicks().value();
+        tickPosition.add(note.getTicks());
       });
     });
     

--- a/src/beam.js
+++ b/src/beam.js
@@ -568,19 +568,19 @@ Vex.Flow.Beam = (function() {
         }
 
         currentGroup.push(unprocessedNote);
-        var ticksPerGroup = tickGroups[currentTickGroup].value();
-        var totalTicks = getTotalTicks(currentGroup).value();
+        var ticksPerGroup = tickGroups[currentTickGroup].clone();
+        var totalTicks = getTotalTicks(currentGroup);
 
         // Double the amount of ticks in a group, if it's an unbeamable tuplet
         var unbeamable = false;
         if (Vex.Flow.durationToInteger(unprocessedNote.duration) < 8
             && unprocessedNote.tuplet) {
-          ticksPerGroup *= 2;
+          ticksPerGroup.numerator *= 2;
           unbeamable = true;
         }
 
         // If the note that was just added overflows the group tick total
-        if (totalTicks > ticksPerGroup) {
+        if (totalTicks.greaterThan(ticksPerGroup)) {
           // If the overflow note can be beamed, start the next group
           // with it. Unbeamable notes leave the group overflowed.
           if (!unbeamable) {
@@ -589,7 +589,7 @@ Vex.Flow.Beam = (function() {
           noteGroups.push(currentGroup);
           currentGroup = nextGroup;
           nextTickGroup();
-        } else if (totalTicks == ticksPerGroup) {
+        } else if (totalTicks.equals(ticksPerGroup)) {
           noteGroups.push(currentGroup);
           currentGroup = nextGroup;
           nextTickGroup();

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -94,9 +94,9 @@ Vex.Flow.Formatter = (function() {
     var voice;
     for (i = 0; i < voices.length; ++i) {
       voice = voices[i];
-      if (voice.getTotalTicks().value() != totalTicks.value()) {
+      if (!(voice.getTotalTicks().equals(totalTicks))) {
         throw new Vex.RERR("TickMismatch",
-            "Voices should have same time signature.");
+            "Voices should have same total note duration in ticks.");
       }
 
       if (voice.getMode() == Vex.Flow.Voice.Mode.STRICT && !voice.isComplete())

--- a/src/fraction.js
+++ b/src/fraction.js
@@ -183,20 +183,44 @@ Vex.Flow.Fraction = (function() {
     },
 
 
-    // Simplifies both sides and checks if they are equal
+    // Simplifies both sides and checks if they are equal.
     equals: function(compare) {
       var a = Vex.Flow.Fraction.__compareA.copy(compare).simplify();
       var b = Vex.Flow.Fraction.__compareB.copy(this).simplify();
 
       return (a.numerator === b.numerator) && (a.denominator === b.denominator);
     },
+    
+    // Greater than operator.
+    greaterThan: function(compare) {
+      var a = Vex.Flow.Fraction.__compareB.copy(this);
+      a.subtract(compare);
+      return (a.numerator > 0);
+    },
+    
+    // Greater than or equals operator.
+    greaterThanEquals: function(compare) {
+      var a = Vex.Flow.Fraction.__compareB.copy(this);
+      a.subtract(compare);
+      return (a.numerator >= 0);
+    },
 
-    // Creates a new copy with this current values
+    // Less than operator.
+    lessThan: function(compare) {
+      return !(this.greaterThanEquals(compare));  
+    },
+
+    // Less than or equals operator.
+    lessThanEquals: function(compare) {
+      return !(this.greaterThan(compare));  
+    },
+
+    // Creates a new copy with this current values.
     clone: function() {
       return new Vex.Flow.Fraction(this.numerator, this.denominator);
     },
 
-    // Copies value of another Fraction into itself
+    // Copies value of another Fraction into itself.
     copy: function(copy) {
       return this.set(copy.numerator, copy.denominator);
     },

--- a/src/tickcontext.js
+++ b/src/tickcontext.js
@@ -87,13 +87,13 @@ Vex.Flow.TickContext = (function() {
 
         var ticks = tickable.getTicks();
 
-        if (ticks.value() > this.maxTicks.value()) {
+        if (ticks.greaterThan(this.maxTicks)) {
           this.maxTicks = ticks.clone();
         }
 
         if (this.minTicks == null) {
           this.minTicks = ticks.clone();
-        } else if (ticks.value() < this.minTicks.value()) {
+        } else if (ticks.lessThan(this.minTicks)) {
           this.minTicks = ticks.clone();
         }
       }

--- a/src/voice.js
+++ b/src/voice.js
@@ -139,34 +139,34 @@ Vex.Flow.Voice = (function() {
       if (!tickable.shouldIgnoreTicks()) {
         var ticks = tickable.getTicks();
 
-        // Update the total ticks for this line
+        // Update the total ticks for this line.
         this.ticksUsed.add(ticks);
 
         if ((this.mode == Vex.Flow.Voice.Mode.STRICT ||
              this.mode == Vex.Flow.Voice.Mode.FULL) &&
-             this.ticksUsed.value() > this.totalTicks.value()) {
+             this.ticksUsed.greaterThan(this.totalTicks)) {
           this.totalTicks.subtract(ticks);
           throw new Vex.RERR("BadArgument", "Too many ticks.");
         }
 
-        // Track the smallest tickable for formatting
-        if (ticks.value() < this.smallestTickCount.value()) {
+        // Track the smallest tickable for formatting.
+        if (ticks.lessThan(this.smallestTickCount)) {
           this.smallestTickCount = ticks.clone();
         }
 
         this.resolutionMultiplier = this.ticksUsed.denominator;
 
-        // Expand total ticks using denominator from ticks used
+        // Expand total ticks using denominator from ticks used.
         this.totalTicks.add(0, this.ticksUsed.denominator);
       }
 
-      // Add the tickable to the line
+      // Add the tickable to the line.
       this.tickables.push(tickable);
       tickable.setVoice(this);
       return this;
     },
 
-    // Add an array of tickables to the voice
+    // Add an array of tickables to the voice.
     addTickables: function(tickables) {
       for (var i = 0; i < tickables.length; ++i) {
         this.addTickable(tickables[i]);
@@ -175,7 +175,7 @@ Vex.Flow.Voice = (function() {
       return this;
     },
 
-    // Preformats the voice by applying the voice's stave to each note
+    // Preformats the voice by applying the voice's stave to each note.
     preFormat: function(){
       if (this.preFormatted) return;
 


### PR DESCRIPTION
Fixes https://github.com/0xfe/vexflow/issues/234 -- multiple non-power-of-two ticks added together sometimes cause floating point comparison problems. Replaces all comparisons of FractionA.value() == FractionB.value() with FractionA.equals(FractionB) and adds Fraction.lessThan, Fraction.greaterThan, etc. 
