### PR TITLE
Fix offset beat group beaming

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -572,11 +572,9 @@ Vex.Flow.Beam = (function() {
         var totalTicks = getTotalTicks(currentGroup);
 
         // Double the amount of ticks in a group, if it's an unbeamable tuplet
-        var unbeamable = false;
-        if (Vex.Flow.durationToNumber(unprocessedNote.duration) < 8
-            && unprocessedNote.tuplet) {
+        var unbeamable = Vex.Flow.durationToNumber(unprocessedNote.duration) < 8;
+        if (unbeamable && unprocessedNote.tuplet) {
           ticksPerGroup.numerator *= 2;
-          unbeamable = true;
         }
 
         // If the note that was just added overflows the group tick total


### PR DESCRIPTION
Fixes a beaming case that got broken during the massive amounts of PR merging/rebasing :) At some point the following case got broken, and the last two 8th notes weren't being beamed. Now fixed.

![image](https://cloud.githubusercontent.com/assets/1631625/3892892/24ce1a0a-2236-11e4-9eab-a4d534d0a145.png)
