### PR TITLE
Typo-fix

### DIFF
--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -144,12 +144,12 @@
       2D drawing interface, which is modeled on HTML5 Canvas.
       <p/>
       We then create a new <code>Vex.Flow.Stave</code> positioned at
-      <code>0, 0</code> with a width of <code>500</code> pixels.
+      <code>10, 0</code> with a width of <code>500</code> pixels.
       <p/>
       We pass the context to the stave and call <code>draw</code>, which
       renders the stave on the context.
       <p/>
-      Notice that the stave is not exactly drawn in position <code>0, 0</code>.
+      Notice that the stave is not exactly drawn in position <code>10, 0</code>.
       This is because it reserves some head-room for higher notes.
       <p/>
     </div>


### PR DESCRIPTION
Tutorial said (0, 0), code example said (10, 0)
