### PR TITLE
Wrapped using module line by try-catch to support requirejs compatibilit...

### DIFF
--- a/src/vex.js
+++ b/src/vex.js
@@ -164,7 +164,9 @@ Vex.Inherit = (function () {
 /* global define: false */
 /* global module: false */
 if (typeof require == "function") {
-  module.exports = Vex;
+  try {
+    module.exports = Vex;
+  } catch (e) {}
 } else if (typeof define == "function" && define.amd) {
   define("Vex", [], function(){ return Vex; });
 } else {


### PR DESCRIPTION
Thanks for updates, and I found a tiny issue when I uses current vexflow version with requirejs.

Because when using requirejs, 'require' function exists although it is not the case of using node.js, in vex.js it tries to set module.exports but it makes error because 'module' is not defined.
