### PR TITLE
adds context to glyphs for clefnote and stave glyphs

### DIFF
--- a/src/clefnote.js
+++ b/src/clefnote.js
@@ -29,6 +29,12 @@ Vex.Flow.ClefNote = (function() {
       return this.clef;
     },
 
+    setContext: function(context){
+      this.context = context;
+      this.glyph.setContext(this.context);
+      return this;
+    },
+
     setStave: function(stave) {
       var superclass = Vex.Flow.ClefNote.superclass;
       superclass.setStave.call(this, stave);

--- a/src/stave.js
+++ b/src/stave.js
@@ -80,7 +80,15 @@ Vex.Flow.Stave = (function() {
     getNoteEndX: function() { return this.end_x; },
     getTieStartX: function() { return this.start_x; },
     getTieEndX: function() { return this.x + this.width; },
-    setContext: function(context) { this.context = context; return this; },
+    setContext: function(context) {
+      this.context = context; 
+	for(var i=0; i<this.glyphs.length; i++){
+          if(typeof(this.glyphs[i].setContext) === "function"){
+	    this.glyphs[i].setContext(context);
+          }
+	}
+      return this; 
+    },
     getContext: function() { return this.context; },
     getX: function() { return this.x; },
     getNumLines: function() { return this.options.num_lines; },


### PR DESCRIPTION
Small problem I ran into when I tried to draw something on a new context. The glyphs associated with staves and clefnotes never got the setContext message passed to them since they already had a context. This fixes the problem by having stave and clefnote set their glyph's context as part of their setContext function.