### PR TITLE
All clefs keys

### DIFF
--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -124,36 +124,45 @@ Vex.Flow.KeySignature = (function() {
     // the  accidental `type` for the key signature ('# or 'b').
     convertAccLines: function(clef, type) {
       var offset = 0.0; // if clef === "treble"
-      var tenorSharps;
-      var isTenorSharps = ((clef === "tenor") && (type === "#")) ? true : false;
+      var customLines; // when clef doesn't follow treble key sig shape
 
       switch (clef) {
-        case "bass":
-          offset = 1;
+        // Treble & Subbass both have offsets of 0, so are not included.
+        case "soprano":
+          if(type === "#") customLines = [2.5,0.5,2,0,1.5,-0.5,1];
+          else offset = -1;
+          break;
+        case "mezzo-soprano":
+          if(type === "b") customLines = [0,2,0.5,2.5,1,3,1.5];
+          else offset = 1.5;
           break;
         case "alto":
           offset = 0.5;
           break;
         case "tenor":
-          if (!isTenorSharps) {
-            offset = -0.5;
-          }
+          if(type === "#") customLines = [3, 1, 2.5, 0.5, 2, 0, 1.5];
+          else offset = -0.5;
+          break;
+        case "baritone-f":
+        case "baritone-c":
+          if(type === "b") customLines = [0.5,2.5,1,3,1.5,3.5,2];
+          else offset = 2;
+          break;
+        case "bass":
+        case "french":
+          offset = 1;
           break;
       }
 
-      // Special-case for TenorSharps
+      // If there's a special case, assign those lines/spaces:
       var i;
-      if (isTenorSharps) {
-        tenorSharps = [3, 1, 2.5, 0.5, 2, 0, 1.5];
+      if (typeof customLines !== "undefined") {
         for (i = 0; i < this.accList.length; ++i) {
-          this.accList[i].line = tenorSharps[i];
+          this.accList[i].line = customLines[i];
         }
-      }
-      else {
-        if (clef != "treble") {
-          for (i = 0; i < this.accList.length; ++i) {
-            this.accList[i].line += offset;
-          }
+      } else if (offset !== 0) {
+        for (i = 0; i < this.accList.length; ++i) {
+          this.accList[i].line += offset;
         }
       }
     }

--- a/tests/key_clef_tests.js
+++ b/tests/key_clef_tests.js
@@ -41,14 +41,15 @@ Vex.Flow.Test.ClefKeySignature.Start = function() {
   module("KeySignature");
   test("Key Parser Test", Vex.Flow.Test.ClefKeySignature.parser);
   Vex.Flow.Test.runTests("Major Key Clef Test", 
-    Vex.Flow.Test.ClefKeySignature.majorKeys);
+    Vex.Flow.Test.ClefKeySignature.keys,
+    {majorKeys: true});
   
   Vex.Flow.Test.runTests("Minor Key Clef Test", 
-    Vex.Flow.Test.ClefKeySignature.minorKeys);
+    Vex.Flow.Test.ClefKeySignature.keys,
+    {majorKeys: false});
   
   Vex.Flow.Test.runTests("Stave Helper", 
     Vex.Flow.Test.ClefKeySignature.staveHelper);
-
 }
 
 Vex.Flow.Test.ClefKeySignature.catchError = function(spec) {
@@ -84,83 +85,57 @@ Vex.Flow.Test.ClefKeySignature.parser = function() {
   ok(true, "all pass");
 }
  
-Vex.Flow.Test.ClefKeySignature.majorKeys = function(options, contextBuilder) {
-  var ctx = new contextBuilder(options.canvas_sel, 400, 400);
-  var stave = new Vex.Flow.Stave(10, 10, 370);
-  var stave2 = new Vex.Flow.Stave(10, 90, 370);
-  var stave3 = new Vex.Flow.Stave(10, 170, 370);
-  var stave4 = new Vex.Flow.Stave(10, 260, 370);
-  stave.addClef("treble");
-  stave2.addClef("bass");
-  stave3.addClef("alto");
-  stave4.addClef("tenor");
-  var keys = Vex.Flow.Test.ClefKeySignature.MAJOR_KEYS;
+Vex.Flow.Test.ClefKeySignature.keys = function(options, contextBuilder) {
 
-  for (var n = 0; n < 8; ++n) {
-    var keySig = new Vex.Flow.KeySignature(keys[n]);
-    var keySig2 = new Vex.Flow.KeySignature(keys[n]);
-    keySig.addToStave(stave);
-    keySig2.addToStave(stave2);
+  var clefs = 
+    ["treble",
+    "soprano",
+    "mezzo-soprano",
+    "alto",
+    "tenor",
+    "baritone-f",
+    "baritone-c",
+    "bass",
+    "french",
+    "subbass",
+    "percussion"];
+
+  var ctx = new contextBuilder(options.canvas_sel, 400, 20 + 80 * 2 * clefs.length);
+
+
+  var staves = [];
+  var keys = (options.params.majorKeys) ? 
+    Vex.Flow.Test.ClefKeySignature.MAJOR_KEYS :
+    Vex.Flow.Test.ClefKeySignature.MINOR_KEYS;
+
+  var i, flat, sharp, keySig;
+
+  var yOffsetForFlatStaves = 10 + 80 * clefs.length;
+  for(i = 0; i<clefs.length; i++) {
+    // Render all the sharps first, then all the flats:
+    staves[i] = new Vex.Flow.Stave(10, 10 + 80*i, 390);
+    staves[i].addClef(clefs[i]);
+    staves[i+clefs.length] = new Vex.Flow.Stave(10, yOffsetForFlatStaves + 10 + 80*i, 390);
+    staves[i+clefs.length].addClef(clefs[i]);
+
+    for(flat = 0; flat < 8; flat++) {
+      keySig = new Vex.Flow.KeySignature(keys[flat]);
+      keySig.addToStave(staves[i]);
+    }
+
+    for(sharp = 8; sharp < keys.length; sharp++) {
+      keySig = new Vex.Flow.KeySignature(keys[sharp]);
+      keySig.addToStave(staves[i+clefs.length]);
+    }
+
+    staves[i].setContext(ctx);
+    staves[i].draw();
+    staves[i + clefs.length].setContext(ctx);
+    staves[i + clefs.length].draw();
   }
-
-  for (var i = 8; i < keys.length; ++i) {
-    var keySig3 = new Vex.Flow.KeySignature(keys[i]);
-    var keySig4 = new Vex.Flow.KeySignature(keys[i]);
-    keySig3.addToStave(stave3);
-    keySig4.addToStave(stave4);
-  }
-
-
-  stave.setContext(ctx);
-  stave.draw();
-  stave2.setContext(ctx);
-  stave2.draw();
-  stave3.setContext(ctx);
-  stave3.draw();
-  stave4.setContext(ctx);
-  stave4.draw();
 
   ok(true, "all pass");
-}
-
-Vex.Flow.Test.ClefKeySignature.minorKeys = function(options, contextBuilder) {
-  var ctx = new contextBuilder(options.canvas_sel, 400, 400);
-  var stave = new Vex.Flow.Stave(10, 10, 370);
-  var stave2 = new Vex.Flow.Stave(10, 90, 370);
-  var stave3 = new Vex.Flow.Stave(10, 170, 370);
-  var stave4 = new Vex.Flow.Stave(10, 260, 370);
-  stave.addClef("treble");
-  stave2.addClef("bass");
-  stave3.addClef("alto");
-  stave4.addClef("tenor");
-  var keys = Vex.Flow.Test.ClefKeySignature.MINOR_KEYS;
-
-  for (var n = 0; n < 8; ++n) {
-    var keySig3 = new Vex.Flow.KeySignature(keys[n]);
-    var keySig4 = new Vex.Flow.KeySignature(keys[n]);
-    keySig3.addToStave(stave3);
-    keySig4.addToStave(stave4);
-  }
-
-  for (var i = 8; i < keys.length; ++i) {
-    var keySig = new Vex.Flow.KeySignature(keys[i]);
-    var keySig2 = new Vex.Flow.KeySignature(keys[i]);
-    keySig.addToStave(stave);
-    keySig2.addToStave(stave2);
-  }
-
-
-  stave.setContext(ctx);
-  stave.draw();
-  stave2.setContext(ctx);
-  stave2.draw();
-  stave3.setContext(ctx);
-  stave3.draw();
-  stave4.setContext(ctx);
-  stave4.draw();
-
-  ok(true, "all pass");
-}
+};
 
 Vex.Flow.Test.ClefKeySignature.staveHelper = function(options, contextBuilder) {
   var ctx = new contextBuilder(options.canvas_sel, 400, 400);


### PR DESCRIPTION
## Support for Keys in all Clefs

Fixes #295 

Previously, key signatures only rendered on the correct lines in treble, alto, tenor, and bass clefs. This PR provides support for key signatures in all of the clefs supported by VexFlow (treble, soprano, mezzo-soprano, alto, tenor, baritone-f, baritone-c, bass, french, subbass, percussion).

Previously, for instance, mezzo-soprano would show flats on the wrong lines/spaces:
![image](https://cloud.githubusercontent.com/assets/8905340/8145251/6b25139a-11ce-11e5-94d4-f63628eeb878.png)

This, and others, have been corrected:
![image](https://cloud.githubusercontent.com/assets/8905340/8145260/bfb64eb0-11ce-11e5-98b3-11000d623da2.png)

With testing revised for all keys in all clefs.