### PR TITLE
Enable Flat beams in Beam.generateBeams()

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -176,6 +176,24 @@ Vex.Flow.Beam = (function() {
       this.y_shift = y_shift;
     },
 
+    // Calculate a slope and y-shift for flat beams
+    calculateFlatSlope: function() {
+      var highest_note = 0;
+      var lowest_note = 0;
+      for (var n = 0; n < this.notes.length; ++n) {
+        var stem = this.notes[n].getStemExtents();
+        var top = stem.topY;
+        if (top > highest_note) {
+          highest_note = top;
+        }
+        if (lowest_note === 0 || top < lowest_note) {
+          lowest_note = top;
+        }
+      }
+      this.slope = 0;
+      this.y_shift = (highest_note - lowest_note) * -this.stem_direction;
+    },
+
     // Create new stems for the notes in the beam, so that each stem
     // extends into the beams.
     applyStemExtensions: function(){
@@ -234,7 +252,7 @@ Vex.Flow.Beam = (function() {
           x_begin: x_px - (Vex.Flow.STEM_WIDTH/2),
           x_end: x_px,
           y_top: this.stem_direction === 1 ? top_y_px : base_y_px,
-          y_bottom: this.stem_direction === 1 ? base_y_px :  top_y_px ,
+          y_bottom: this.stem_direction === 1 ? base_y_px :  top_y_px,
           y_extend: y_displacement,
           stem_extension: Math.abs(top_y_px - slope_y) - Stem.HEIGHT - 1,
           stem_direction: this.stem_direction
@@ -384,12 +402,16 @@ Vex.Flow.Beam = (function() {
     preFormat: function() { return this; },
 
     // Post-format the beam. This can only be called after
-    // the notes in the beam have both `x` and `y` values. ie: they've 
+    // the notes in the beam have both `x` and `y` values. ie: they've
     // been formatted and have staves
     postFormat: function() {
       if (this.postFormatted) return;
 
-      this.calculateSlope();
+      if(this.render_options.flat_beams) {
+        this.calculateFlatSlope();
+      } else {
+        this.calculateSlope();
+      }
       this.applyStemExtensions();
 
       this.postFormatted = true;
@@ -730,7 +752,7 @@ Vex.Flow.Beam = (function() {
       if (config.show_stemlets) {
         beam.render_options.show_stemlets = true;
       }
-
+      beam.render_options.flat_beams = config.flat_beams;
       beams.push(beam);
     });
 

--- a/src/beam.js
+++ b/src/beam.js
@@ -199,6 +199,9 @@ Vex.Flow.Beam = (function() {
           if (this.stem_direction === Stem.DOWN && extreme_y < top_y) {
             extreme_y = note.getNoteHeadBounds().y_bottom;
             extreme_beam_count = note.getBeamCount();
+          } else if (this.stem_direction === Stem.UP && (extreme_y === 0 || extreme_y > top_y)) {
+            extreme_y = note.getNoteHeadBounds().y_top;
+            extreme_beam_count = note.getBeamCount();
           }
         }
 
@@ -212,8 +215,11 @@ Vex.Flow.Beam = (function() {
         //  the width of the beams.
         var beam_width = this.render_options.beam_width * 1.5;
         var extreme_test = this.min_flat_beam_offset + (extreme_beam_count * beam_width);
-        if (offset < (extreme_y + extreme_test)) {
+        var new_offset = extreme_y + (extreme_test * -this.stem_direction);
+        if (this.stem_direction === Stem.DOWN && offset < new_offset) {
           offset = extreme_y + extreme_test;
+        } else if (this.stem_direction === Stem.UP && offset > new_offset) {
+          offset = extreme_y - extreme_test;
         }
 
         // Set the offset for the group based on the calculations above.

--- a/src/beam.js
+++ b/src/beam.js
@@ -187,6 +187,7 @@ Vex.Flow.Beam = (function() {
         var total = 0;
         var extreme_y = 0;  // Store the highest or lowest note here
         var extreme_beam_count = 0;  // The beam count of the extreme note
+        var current_extreme = 0;
         for (var i = 0; i < this.notes.length; i++) {
 
           // Total up all of the offsets so we can average them out later
@@ -196,10 +197,12 @@ Vex.Flow.Beam = (function() {
 
           // Store the highest (stems-up) or lowest (stems-down) note so the
           //  offset can be adjusted in case the average isn't enough
-          if (this.stem_direction === Stem.DOWN && extreme_y < top_y) {
+          if (this.stem_direction === Stem.DOWN && current_extreme < top_y) {
+            current_extreme = top_y;
             extreme_y = note.getNoteHeadBounds().y_bottom;
             extreme_beam_count = note.getBeamCount();
-          } else if (this.stem_direction === Stem.UP && (extreme_y === 0 || extreme_y > top_y)) {
+          } else if (this.stem_direction === Stem.UP && (current_extreme === 0 || current_extreme > top_y)) {
+            current_extreme = top_y;
             extreme_y = note.getNoteHeadBounds().y_top;
             extreme_beam_count = note.getBeamCount();
           }

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -40,6 +40,10 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.moreSimpleTuplets);
   Vex.Flow.Test.runTests("More Automatic Beaming",
                         Vex.Flow.Test.AutoBeamFormatting.moreBeaming);
+  Vex.Flow.Test.runTests("Flat beams Up Direction",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp);
+  Vex.Flow.Test.runTests("Flat beams Down Direction",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown);
 }
 
 Vex.Flow.Test.AutoBeamFormatting.setupContext = function(options, x, y) {
@@ -216,8 +220,8 @@ Vex.Flow.Test.AutoBeamFormatting.oddBeamGroups = function(options, contextBuilde
   var Fraction = Vex.Flow.Fraction;
 
   var groups = [
-    new Fraction(2, 8), 
-    new Fraction(3, 8), 
+    new Fraction(2, 8),
+    new Fraction(3, 8),
     new Fraction(1, 8)
   ];
 
@@ -1017,4 +1021,83 @@ Vex.Flow.Test.AutoBeamFormatting.moreBeaming = function(options, contextBuilder)
   });
 
   ok(true, "Auto Beam Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["f/5"], duration: "8"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["a/5"], duration: "32"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: false,
+    flat_beams: true,
+    stem_direction: 1
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Auto Beaming Applicator Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["f/5"], duration: "8"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["a/5"], duration: "32"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    beam_rests: false,
+    flat_beams: true
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Flat Beams Up Direction Test");
 }

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -1030,12 +1030,13 @@ Vex.Flow.Test.AutoBeamFormatting.moreBeaming = function(options, contextBuilder)
 Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
   var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
-
   var notes = [
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["g/4"], duration: "8"}),
     newNote({ keys: ["f/5"], duration: "8"}),
-    newNote({ keys: ["a/5"], duration: "8"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["f/4"], duration: "16"}),
     newNote({ keys: ["f/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
@@ -1045,24 +1046,23 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder)
     newNote({ keys: ["f/5"], duration: "32"}),
     newNote({ keys: ["f/5"], duration: "32"})
   ];
-
+  var triplet1 = new Vex.Flow.Tuplet(notes.slice(0, 3));
+  var triplet2 = new Vex.Flow.Tuplet(notes.slice(4, 7));
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
     .setMode(Vex.Flow.Voice.Mode.SOFT);
   voice.addTickables(notes);
-
   var beams = Vex.Flow.Beam.generateBeams(notes, {
     flat_beams: true,
     stem_direction: 1
   });
-
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
-
   voice.draw(c.context, c.stave);
-
   beams.forEach(function(beam){
     beam.setContext(c.context).draw();
   });
+  triplet1.setContext(c.context).draw();
+  triplet2.setContext(c.context).draw();
   ok(true, "Flat Beams Up Test");
 }
 
@@ -1115,10 +1115,10 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
 Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform = function(options, contextBuilder) {
   options.contextBuilder = contextBuilder;
   var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
-
   var notes = [
-    newNote({ keys: ["f/5"], duration: "8"}),
-    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["g/4"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["c/5"], duration: "16"}),
     newNote({ keys: ["f/4"], duration: "16"}),
@@ -1130,25 +1130,22 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform = function(options, contextB
     newNote({ keys: ["f/5"], duration: "32"}),
     newNote({ keys: ["f/5"], duration: "32"})
   ];
-
+  var triplet1 = new Vex.Flow.Tuplet(notes.slice(0, 3));
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
     .setMode(Vex.Flow.Voice.Mode.SOFT);
   voice.addTickables(notes);
-
   var beams = Vex.Flow.Beam.generateBeams(notes, {
     flat_beams: true,
-    flat_beam_offset: 30,
+    flat_beam_offset: 50,
     stem_direction: 1
   });
-
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
     formatToStave([voice], c.stave);
-
   voice.draw(c.context, c.stave);
-
   beams.forEach(function(beam){
     beam.setContext(c.context).draw();
   });
+  triplet1.setContext(c.context).draw();
   ok(true, "Flat Beams Up (uniform) Test");
 }
 

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -40,10 +40,14 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.moreSimpleTuplets);
   Vex.Flow.Test.runTests("More Automatic Beaming",
                         Vex.Flow.Test.AutoBeamFormatting.moreBeaming);
-  Vex.Flow.Test.runTests("Flat beams Up Direction",
+  Vex.Flow.Test.runTests("Flat Beams Up",
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp);
-  Vex.Flow.Test.runTests("Flat beams Down Direction",
+  Vex.Flow.Test.runTests("Flat Beams Down",
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown);
+  Vex.Flow.Test.runTests("Flat Beams Up (uniform)",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform);
+  Vex.Flow.Test.runTests("Flat Beams Down (uniform)",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform);
 }
 
 Vex.Flow.Test.AutoBeamFormatting.setupContext = function(options, x, y) {
@@ -220,8 +224,8 @@ Vex.Flow.Test.AutoBeamFormatting.oddBeamGroups = function(options, contextBuilde
   var Fraction = Vex.Flow.Fraction;
 
   var groups = [
-    new Fraction(2, 8),
-    new Fraction(3, 8),
+    new Fraction(2, 8), 
+    new Fraction(3, 8), 
     new Fraction(1, 8)
   ];
 
@@ -1035,11 +1039,11 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder)
     newNote({ keys: ["f/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
-    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["c/4"], duration: "8"}),
     newNote({ keys: ["f/5"], duration: "32"}),
     newNote({ keys: ["f/5"], duration: "32"}),
     newNote({ keys: ["f/5"], duration: "32"}),
-    newNote({ keys: ["a/5"], duration: "32"})
+    newNote({ keys: ["f/5"], duration: "32"})
   ];
 
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
@@ -1047,7 +1051,6 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder)
   voice.addTickables(notes);
 
   var beams = Vex.Flow.Beam.generateBeams(notes, {
-    beam_rests: false,
     flat_beams: true,
     stem_direction: 1
   });
@@ -1060,7 +1063,7 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder)
   beams.forEach(function(beam){
     beam.setContext(c.context).draw();
   });
-  ok(true, "Auto Beaming Applicator Test");
+  ok(true, "Flat Beams Up Test");
 }
 
 Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilder) {
@@ -1068,18 +1071,26 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
   var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
 
   var notes = [
-    newNote({ keys: ["f/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
     newNote({ keys: ["a/5"], duration: "8"}),
-    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
     newNote({ keys: ["c/5"], duration: "16"}),
-    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
-    newNote({ keys: ["e/5"], duration: "8"}),
-    newNote({ keys: ["f/5"], duration: "32"}),
-    newNote({ keys: ["f/5"], duration: "32"}),
-    newNote({ keys: ["f/5"], duration: "32"}),
-    newNote({ keys: ["a/5"], duration: "32"})
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["g/4"], duration: "64"}),
+    newNote({ keys: ["g/4"], duration: "64"})
   ];
 
   var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
@@ -1087,7 +1098,6 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
   voice.addTickables(notes);
 
   var beams = Vex.Flow.Beam.generateBeams(notes, {
-    beam_rests: false,
     flat_beams: true
   });
 
@@ -1099,5 +1109,92 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
   beams.forEach(function(beam){
     beam.setContext(c.context).draw();
   });
-  ok(true, "Flat Beams Up Direction Test");
+  ok(true, "Flat Beams Down Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["f/5"], duration: "8"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    flat_beams: true,
+    flat_beam_offset: 30,
+    stem_direction: 1
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Flat Beams Up (uniform) Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["g/4"], duration: "64"}),
+    newNote({ keys: ["g/4"], duration: "64"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    flat_beams: true,
+    flat_beam_offset: 150
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Flat Beams Down (uniform) Test");
 }

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -44,6 +44,8 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp);
   Vex.Flow.Test.runTests("Flat Beams Down",
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown);
+  Vex.Flow.Test.runTests("Flat Beams Mixed Direction",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsMixed);
   Vex.Flow.Test.runTests("Flat Beams Up (uniform)",
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform);
   Vex.Flow.Test.runTests("Flat Beams Down (uniform)",
@@ -1036,7 +1038,7 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUp = function(options, contextBuilder)
     newNote({ keys: ["f/5"], duration: "8"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["c/5"], duration: "16"}),
-    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
     newNote({ keys: ["f/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
@@ -1081,7 +1083,7 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
     newNote({ keys: ["c/5"], duration: "64"}),
     newNote({ keys: ["a/5"], duration: "8"}),
     newNote({ keys: ["g/5"], duration: "8"}),
-    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["d/4", "f/4", "a/4"], duration: "16"}),
     newNote({ keys: ["d/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
@@ -1089,6 +1091,53 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
     newNote({ keys: ["a/6"], duration: "32"}),
     newNote({ keys: ["a/6"], duration: "32"}),
     newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["g/4"], duration: "64"}),
+    newNote({ keys: ["g/4"], duration: "64"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    flat_beams: true,
+    stem_direction: -1
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Flat Beams Down Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsMixed = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+
+  var notes = [
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["d/5"], duration: "64"}),
+    newNote({ keys: ["e/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["f/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["a/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["d/4", "f/4", "a/4"], duration: "16"}),
+    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
+    newNote({ keys: ["a/4"], duration: "32"}),
     newNote({ keys: ["g/4"], duration: "64"}),
     newNote({ keys: ["g/4"], duration: "64"})
   ];
@@ -1109,7 +1158,7 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDown = function(options, contextBuilde
   beams.forEach(function(beam){
     beam.setContext(c.context).draw();
   });
-  ok(true, "Flat Beams Down Test");
+  ok(true, "Flat Beams Mixed Direction Test");
 }
 
 Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform = function(options, contextBuilder) {
@@ -1121,7 +1170,7 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform = function(options, contextB
     newNote({ keys: ["g/5"], duration: "8"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["c/5"], duration: "16"}),
-    newNote({ keys: ["f/4"], duration: "16"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
     newNote({ keys: ["c/4"], duration: "8"}),
@@ -1164,8 +1213,8 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform = function(options, contex
     newNote({ keys: ["c/5"], duration: "64"}),
     newNote({ keys: ["a/5"], duration: "8"}),
     newNote({ keys: ["g/5"], duration: "8"}),
-    newNote({ keys: ["c/5"], duration: "16"}),
-    newNote({ keys: ["d/4"], duration: "16"}),
+    newNote({ keys: ["e/4", "g/4", "b/4"], duration: "16"}),
+    newNote({ keys: ["e/5"], duration: "16"}),
     newNote({ keys: ["d/5"], duration: "8"}),
     newNote({ keys: ["e/5"], duration: "8"}),
     newNote({ keys: ["g/5"], duration: "8"}),
@@ -1182,7 +1231,8 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform = function(options, contex
 
   var beams = Vex.Flow.Beam.generateBeams(notes, {
     flat_beams: true,
-    flat_beam_offset: 150
+    flat_beam_offset: 150,
+    stem_direction: -1
   });
 
   var formatter = new Vex.Flow.Formatter().joinVoices([voice]).

--- a/tests/auto_beam_formatting_tests.js
+++ b/tests/auto_beam_formatting_tests.js
@@ -50,6 +50,10 @@ Vex.Flow.Test.AutoBeamFormatting.Start = function() {
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpUniform);
   Vex.Flow.Test.runTests("Flat Beams Down (uniform)",
                         Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform);
+  Vex.Flow.Test.runTests("Flat Beams Up Bounds",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpBounds);
+  Vex.Flow.Test.runTests("Flat Beams Down Bounds",
+                        Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownBounds);
 }
 
 Vex.Flow.Test.AutoBeamFormatting.setupContext = function(options, x, y) {
@@ -1231,7 +1235,94 @@ Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownUniform = function(options, contex
 
   var beams = Vex.Flow.Beam.generateBeams(notes, {
     flat_beams: true,
-    flat_beam_offset: 150,
+    flat_beam_offset: 155,
+    stem_direction: -1
+  });
+
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+
+  voice.draw(c.context, c.stave);
+
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  ok(true, "Flat Beams Down (uniform) Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsUpBounds = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+  var notes = [
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["g/4"], duration: "8"}),
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["c/5"], duration: "16"}),
+    newNote({ keys: ["c/4", "e/4", "g/4"], duration: "16"}),
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"}),
+    newNote({ keys: ["c/4"], duration: "8"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"}),
+    newNote({ keys: ["f/5"], duration: "32"})
+  ];
+  var triplet1 = new Vex.Flow.Tuplet(notes.slice(0, 3));
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    flat_beams: true,
+    flat_beam_offset: 60,
+    stem_direction: 1
+  });
+  var formatter = new Vex.Flow.Formatter().joinVoices([voice]).
+    formatToStave([voice], c.stave);
+  voice.draw(c.context, c.stave);
+  beams.forEach(function(beam){
+    beam.setContext(c.context).draw();
+  });
+  triplet1.setContext(c.context).draw();
+  ok(true, "Flat Beams Up (uniform) Test");
+}
+
+Vex.Flow.Test.AutoBeamFormatting.flatBeamsDownBounds = function(options, contextBuilder) {
+  options.contextBuilder = contextBuilder;
+  var c = Vex.Flow.Test.AutoBeamFormatting.setupContext(options);
+  var notes = [
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["a/6"], duration: "32"}),
+    newNote({ keys: ["g/4"], duration: "64"}),
+    newNote({ keys: ["g/4"], duration: "64"}),
+
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["c/5"], duration: "64"}),
+    newNote({ keys: ["a/5"], duration: "8"}),
+
+    newNote({ keys: ["g/5"], duration: "8"}),
+    newNote({ keys: ["e/4", "g/4", "b/4"], duration: "16"}),
+    newNote({ keys: ["e/5"], duration: "16"}),
+
+    newNote({ keys: ["d/5"], duration: "8"}),
+    newNote({ keys: ["e/5"], duration: "8"})
+  ];
+
+  var voice = new Vex.Flow.Voice(Vex.Flow.Test.TIME4_4)
+    .setMode(Vex.Flow.Voice.Mode.SOFT);
+  voice.addTickables(notes);
+
+  var beams = Vex.Flow.Beam.generateBeams(notes, {
+    flat_beams: true,
+    flat_beam_offset: 145,
     stem_direction: -1
   });
 


### PR DESCRIPTION
This change allows beam slope calculations to be bypassed in the beam generation logic, and allows for a flat beam.  The current, default behavior of generateBeams() is unchanged.

The offset for the flat beam can be universally applied for all of the notes sent to generateBeams(), or it can be automatically calculated per beam group.

To enable flat beams with different heights per beam group, send in `flat_beams: true` to the generateBeams() options.

If the same height is desired for all of the beams in the set of notes sent to generateBeams(), a 2nd parameter, `flat_beam_offset`, can be passed along with `flat_beams: true`.  This parameter is ignored if `flat_beams` is `false` (the default).

I added 5 tests for the 2 modes described above with both up-stems and down-stems (and mixed, up and down).  I tried to put in as many edge cases as I could think of.