### PR TITLE
fix(stavenote.js): getBoundingBox should not add extra height to chords

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -505,9 +505,9 @@ Vex.Flow.StaveNote = (function() {
             min_y = Vex.Min(yy, min_y);
             max_y = Vex.Max(yy, max_y);
           }
-          min_y -= half_line_spacing;
-          max_y += half_line_spacing;
         }
+        min_y -= half_line_spacing;
+        max_y += half_line_spacing;
       }
 
       return new Vex.Flow.BoundingBox(x, min_y, w, max_y - min_y);


### PR DESCRIPTION
Fixes #346 -- two-lines of code erroneously placed in a for-loop caused an extra half-staff-line of space to be added to `getBoundingBox().height` for every note after the first in a `StaveNote` in stemless rhythms (whole notes & breves).

This PR addresses & corrects that:
![image](https://cloud.githubusercontent.com/assets/8905340/15919165/a6edd4a4-2ddc-11e6-9a79-67e8e052c10e.png)
