### PR TITLE
Accurate glyph metrics using a Glyph's Bounding Box

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-qunit": "^0.5.2",
+    "grunt-contrib-qunit": "^1.2.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-docco": "^0.3.3",

--- a/src/boundingboxcomputation.js
+++ b/src/boundingboxcomputation.js
@@ -1,4 +1,12 @@
-// from https://github.com/gabelerner/canvg/blob/860e418aca67b9a41e858a223d74d375793ec364/canvg.js#L449
+// ## Description
+//
+// Object which computes metrics for a bounding box by continuously
+// taking canvas path commands
+
+// Warning: This file is merely a crutch to get bounding box information without
+// explicit metadata. This is likely to get deprecated following SMuFL support.
+//
+// taken from: https://github.com/gabelerner/canvg/blob/860e418aca67b9a41e858a223d74d375793ec364/canvg.js#L449
 
 Vex.Flow.BoundingBoxComputation = (function() {
   function BoundingBoxComputation(x1, y1, x2, y2) { // pass in initial points if you want

--- a/src/boundingboxcomputation.js
+++ b/src/boundingboxcomputation.js
@@ -1,0 +1,110 @@
+// from https://github.com/gabelerner/canvg/blob/860e418aca67b9a41e858a223d74d375793ec364/canvg.js#L449
+
+Vex.Flow.BoundingBoxComputation = (function() {
+  function BoundingBoxComputation(x1, y1, x2, y2) { // pass in initial points if you want
+    this.x1 = Number.NaN;
+    this.y1 = Number.NaN;
+    this.x2 = Number.NaN;
+    this.y2 = Number.NaN;
+
+    this.addPoint(x1, y1);
+    this.addPoint(x2, y2);
+  }
+
+  BoundingBoxComputation.prototype = {
+    width: function () {
+      return this.x2 - this.x1;
+    },
+
+    height: function () {
+      return this.y2 - this.y1;
+    },
+
+    addPoint: function (x, y) {
+      if (x != null) {
+        if (isNaN(this.x1) || isNaN(this.x2)) {
+          this.x1 = x;
+          this.x2 = x;
+        }
+        if (x < this.x1) this.x1 = x;
+        if (x > this.x2) this.x2 = x;
+      }
+
+      if (y != null) {
+        if (isNaN(this.y1) || isNaN(this.y2)) {
+          this.y1 = y;
+          this.y2 = y;
+        }
+        if (y < this.y1) this.y1 = y;
+        if (y > this.y2) this.y2 = y;
+      }
+    },
+
+    addX: function (x) {
+      this.addPoint(x, null);
+    },
+
+    addY: function (y) {
+      this.addPoint(null, y);
+    },
+
+    addQuadraticCurve: function (p0x, p0y, p1x, p1y, p2x, p2y) {
+      var cp1x = p0x + 2 / 3 * (p1x - p0x); // CP1 = QP0 + 2/3 *(QP1-QP0)
+      var cp1y = p0y + 2 / 3 * (p1y - p0y); // CP1 = QP0 + 2/3 *(QP1-QP0)
+      var cp2x = cp1x + 1 / 3 * (p2x - p0x); // CP2 = CP1 + 1/3 *(QP2-QP0)
+      var cp2y = cp1y + 1 / 3 * (p2y - p0y); // CP2 = CP1 + 1/3 *(QP2-QP0)
+      this.addBezierCurve(p0x, p0y, cp1x, cp1y, cp2x, cp2y, p2x, p2y);
+    },
+
+    addBezierCurve: function (p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y) {
+      // from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
+      var
+        i,
+        p0 = [p0x, p0y],
+        p1 = [p1x, p1y],
+        p2 = [p2x, p2y],
+        p3 = [p3x, p3y];
+
+      this.addPoint(p0[0], p0[1]);
+      this.addPoint(p3[0], p3[1]);
+
+      for (i = 0; i <= 1; i++) {
+        var f = function (t) {
+          return Math.pow(1 - t, 3) * p0[i]
+            + 3 * Math.pow(1 - t, 2) * t * p1[i]
+            + 3 * (1 - t) * Math.pow(t, 2) * p2[i]
+            + Math.pow(t, 3) * p3[i];
+        };
+
+        var b = 6 * p0[i] - 12 * p1[i] + 6 * p2[i];
+        var a = -3 * p0[i] + 9 * p1[i] - 9 * p2[i] + 3 * p3[i];
+        var c = 3 * p1[i] - 3 * p0[i];
+
+        if (a == 0) {
+          if (b == 0) continue;
+          var t = -c / b;
+          if (0 < t && t < 1) {
+            if (i == 0) this.addX(f(t));
+            if (i == 1) this.addY(f(t));
+          }
+          continue;
+        }
+
+        var b2ac = Math.pow(b, 2) - 4 * c * a;
+        if (b2ac < 0) continue;
+        var t1 = (-b + Math.sqrt(b2ac)) / (2 * a);
+        if (0 < t1 && t1 < 1) {
+          if (i == 0) this.addX(f(t1));
+          if (i == 1) this.addY(f(t1));
+        }
+        var t2 = (-b - Math.sqrt(b2ac)) / (2 * a);
+        if (0 < t2 && t2 < 1) {
+          if (i == 0) this.addX(f(t2));
+          if (i == 1) this.addY(f(t2));
+        }
+      }
+    }
+  };
+
+  return BoundingBoxComputation;
+}());

--- a/src/boundingboxcomputation.js
+++ b/src/boundingboxcomputation.js
@@ -58,34 +58,33 @@ Vex.Flow.BoundingBoxComputation = (function() {
 
     addBezierCurve: function (p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y) {
       // from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
-      var
-        i,
-        p0 = [p0x, p0y],
-        p1 = [p1x, p1y],
-        p2 = [p2x, p2y],
-        p3 = [p3x, p3y];
+      var p0 = [p0x, p0y];
+      var p1 = [p1x, p1y];
+      var p2 = [p2x, p2y];
+      var p3 = [p3x, p3y];
+      var i;
 
       this.addPoint(p0[0], p0[1]);
       this.addPoint(p3[0], p3[1]);
 
-      for (i = 0; i <= 1; i++) {
-        var f = function (t) {
-          return Math.pow(1 - t, 3) * p0[i]
-            + 3 * Math.pow(1 - t, 2) * t * p1[i]
-            + 3 * (1 - t) * Math.pow(t, 2) * p2[i]
-            + Math.pow(t, 3) * p3[i];
-        };
+      var f = function (t, i) {
+        return Math.pow(1 - t, 3) * p0[i] +
+          3 * Math.pow(1 - t, 2) * t * p1[i] +
+          3 * (1 - t) * Math.pow(t, 2) * p2[i] +
+          Math.pow(t, 3) * p3[i];
+      };
 
+      for (i = 0; i <= 1; i++) {
         var b = 6 * p0[i] - 12 * p1[i] + 6 * p2[i];
         var a = -3 * p0[i] + 9 * p1[i] - 9 * p2[i] + 3 * p3[i];
         var c = 3 * p1[i] - 3 * p0[i];
 
-        if (a == 0) {
-          if (b == 0) continue;
+        if (a === 0) {
+          if (b === 0) continue;
           var t = -c / b;
           if (0 < t && t < 1) {
-            if (i == 0) this.addX(f(t));
-            if (i == 1) this.addY(f(t));
+            if (i === 0) this.addX(f(t, i));
+            if (i === 1) this.addY(f(t, i));
           }
           continue;
         }
@@ -94,13 +93,13 @@ Vex.Flow.BoundingBoxComputation = (function() {
         if (b2ac < 0) continue;
         var t1 = (-b + Math.sqrt(b2ac)) / (2 * a);
         if (0 < t1 && t1 < 1) {
-          if (i == 0) this.addX(f(t1));
-          if (i == 1) this.addY(f(t1));
+          if (i === 0) this.addX(f(t1, i));
+          if (i === 1) this.addY(f(t1, i));
         }
         var t2 = (-b - Math.sqrt(b2ac)) / (2 * a);
         if (0 < t2 && t2 < 1) {
-          if (i == 0) this.addX(f(t2));
-          if (i == 1) this.addY(f(t2));
+          if (i === 0) this.addX(f(t2, i));
+          if (i === 1) this.addY(f(t2, i));
         }
       }
     }

--- a/src/boundingboxcomputation.js
+++ b/src/boundingboxcomputation.js
@@ -8,7 +8,7 @@
 //
 // taken from: https://github.com/gabelerner/canvg/blob/860e418aca67b9a41e858a223d74d375793ec364/canvg.js#L449
 
-Vex.Flow.BoundingBoxComputation = (function() {
+export var BoundingBoxComputation = (function() {
   function BoundingBoxComputation(x1, y1, x2, y2) { // pass in initial points if you want
     this.x1 = Number.NaN;
     this.y1 = Number.NaN;

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -17,12 +17,15 @@ export var Glyph = (function() {
       font: Font
     };
 
-    this.width = null;
     this.metrics = null;
     this.x_shift = 0;
     this.y_shift = 0;
 
-    if (options) this.setOptions(options); else this.reset();
+    if (options) {
+      this.setOptions(options);
+    } else {
+      this.reset();
+    }
   }
 
   Glyph.prototype = {
@@ -39,24 +42,29 @@ export var Glyph = (function() {
     getContext: function() { return this.context; },
 
     reset: function() {
-      this.metrics = Glyph.loadMetrics(this.options.font, this.code,
-          this.options.cache);
       this.scale = this.point * 72 / (this.options.font.resolution * 100);
-    },
-
-    setWidth: function(width) {
-      this.width =  width;
-      return this;
+      this.metrics = Glyph.loadMetrics(
+        this.options.font,
+        this.code,
+        this.options.cache
+      );
+      this.bbox = Glyph.getOutlineBoundingBox(
+        this.metrics.outline,
+        this.scale,
+        0,
+        0
+      );
     },
 
     getMetrics: function() {
       if (!this.metrics) throw new Vex.RuntimeError("BadGlyph", "Glyph " +
-          this.code + " is not initialized.");
+        this.code + " is not initialized.");
+
       return {
         x_min: this.metrics.x_min * this.scale,
         x_max: this.metrics.x_max * this.scale,
-        width: this.width || (this.metrics.x_max - this.metrics.x_min) * this.scale,
-        height: this.metrics.ha * this.scale
+        width: this.bbox.getW(),
+        height: this.bbox.getH()
       };
     },
 
@@ -116,52 +124,9 @@ export var Glyph = (function() {
         outline: outline
       };
     } else {
-      throw new Vex.RuntimeError("BadGlyph", "Glyph " + this.code +
+      throw new Vex.RuntimeError("BadGlyph", "Glyph " + code +
           " has no outline defined.");
     }
-  };
-
-  Glyph.renderOutline = function(ctx, outline, scale, x_pos, y_pos) {
-    var outlineLength = outline.length;
-
-    ctx.beginPath();
-
-    ctx.moveTo(x_pos, y_pos);
-
-    for (var i = 0; i < outlineLength; ) {
-      var action = outline[i++];
-
-      switch(action) {
-        case 'm':
-          ctx.moveTo(x_pos + outline[i++] * scale,
-                     y_pos + outline[i++] * -scale);
-          break;
-        case 'l':
-          ctx.lineTo(x_pos + outline[i++] * scale,
-                     y_pos + outline[i++] * -scale);
-          break;
-
-        case 'q':
-          var cpx = x_pos + outline[i++] * scale;
-          var cpy = y_pos + outline[i++] * -scale;
-
-          ctx.quadraticCurveTo(
-              x_pos + outline[i++] * scale,
-              y_pos + outline[i++] * -scale, cpx, cpy);
-          break;
-
-        case 'b':
-          var x = x_pos + outline[i++] * scale;
-          var y = y_pos + outline[i++] * -scale;
-
-          ctx.bezierCurveTo(
-              x_pos + outline[i++] * scale, y_pos + outline[i++] * -scale,
-              x_pos + outline[i++] * scale, y_pos + outline[i++] * -scale,
-              x, y);
-          break;
-      }
-    }
-    ctx.fill();
   };
 
   /**
@@ -180,6 +145,66 @@ export var Glyph = (function() {
     var metrics = Glyph.loadMetrics(Font, val, !nocache);
     Glyph.renderOutline(ctx, metrics.outline, scale, x_pos, y_pos);
   };
+
+  Glyph.renderOutline = function(ctx, outline, scale, x_pos, y_pos) {
+    ctx.beginPath();
+    ctx.moveTo(x_pos, y_pos);
+    processOutline(outline, x_pos, y_pos, scale, -scale, {
+      m: ctx.moveTo.bind(ctx),
+      l: ctx.lineTo.bind(ctx),
+      q: ctx.quadraticCurveTo.bind(ctx),
+      b: ctx.bezierCurveTo.bind(ctx)
+    });
+    ctx.fill();
+  };
+
+  Glyph.getOutlineBoundingBox = function(outline, scale, x_pos, y_pos) {
+    var bboxComp = new Vex.Flow.BoundingBoxComputation(x_pos, y_pos);
+
+    processOutline(outline, x_pos, y_pos, scale, -scale, {
+      m: bboxComp.addPoint.bind(bboxComp),
+      l: bboxComp.addPoint.bind(bboxComp),
+      q: bboxComp.addQuadraticCurve.bind(bboxComp),
+      b: bboxComp.addBezierCurve.bind(bboxComp)
+    });
+
+    return new Vex.Flow.BoundingBox(
+      bboxComp.x1,
+      bboxComp.y1,
+      bboxComp.width(),
+      bboxComp.height()
+    );
+  };
+
+  function processOutline(outline, originX, originY, scaleX, scaleY, outlineFns) {
+    var command;
+    var x;
+    var y;
+    var i = 0;
+
+    function nextX() { return originX + outline[i++] * scaleX; }
+    function nextY() { return originY + outline[i++] * scaleY; }
+
+    while (i < outline.length) {
+      command = outline[i++];
+      switch (command) {
+        case 'm':
+        case 'l':
+          outlineFns[command](nextX(), nextY());
+          break;
+        case 'q':
+          x = nextX();
+          y = nextY();
+          outlineFns.q(nextX(), nextY(), x, y);
+          break;
+        case 'b':
+          x = nextX();
+          y = nextY();
+          outlineFns.b(nextX(), nextY(), nextX(), nextY(), x, y);
+          break;
+      }
+    }
+  }
 
   return Glyph;
 }());

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -1,7 +1,7 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 
 import { Vex } from './vex';
-import { Flow } from './tables';
+import { BoundingBoxComputation } from './boundingboxcomputation';
 import { Font } from './fonts/vexflow_font';
 
 /**
@@ -159,7 +159,7 @@ export var Glyph = (function() {
   };
 
   Glyph.getOutlineBoundingBox = function(outline, scale, x_pos, y_pos) {
-    var bboxComp = new Vex.Flow.BoundingBoxComputation(x_pos, y_pos);
+    var bboxComp = new BoundingBoxComputation(x_pos, y_pos);
 
     processOutline(outline, x_pos, y_pos, scale, -scale, {
       m: bboxComp.addPoint.bind(bboxComp),

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -89,7 +89,7 @@ export var KeySignature = (function() {
       this.setPosition(StaveModifier.Position.BEGIN);
       this.glyphFontScale = 38; // TODO(0xFE): Should this match StaveNote?
       this.glyphs = [];
-      this.xPositions = [];
+      this.xPositions = []; // relative to this.x
       this.paddingForced = false;
     },
 

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -96,30 +96,32 @@ export var KeySignature = (function() {
     getCategory: function() { return KeySignature.category; },
 
     // Add an accidental glyph to the `KeySignature` instance which represents
-    // the provided `accid`. If a `nextAccid` is also provided, the appropriate
+    // the provided `acc`. If `nextAcc` is also provided, the appropriate
     // spacing will be included in the glyph's position
-    convertToGlyph: function(accid, nextAccid) {
-      var accidGlyphData = Flow.accidentalCodes(accid.type);
-      var glyph = new Glyph(accidGlyphData.code, this.glyphFontScale);
+    convertToGlyph: function(acc, nextAcc) {
+      var accGlyphData = Flow.accidentalCodes(acc.type);
+      var glyph = new Glyph(accGlyphData.code, this.glyphFontScale);
 
       // Determine spacing between current accidental and the next accidental
       var extraWidth = 0;
-      if (accid.type === "n" && nextAccid) {
-        var isAbove = nextAccid.line >= accid.line;
-        var spacing = KeySignature.accidentalSpacing[nextAccid.type];
+      if (acc.type === "n" && nextAcc) {
+        var isAbove = nextAcc.line >= acc.line;
+        var spacing = KeySignature.accidentalSpacing[nextAcc.type];
         if (spacing) {
           extraWidth = isAbove ? spacing.above : spacing.below;
         }
       }
 
-      var glyphWidth = accidGlyphData.width + extraWidth;
-      var prevXPosition = this.xPositions[this.xPositions.length - 1];
-      this.width += glyphWidth;
       // Place the glyph on the stave
-      this.placeGlyphOnLine(glyph, this.stave, accid.line);
+      this.placeGlyphOnLine(glyph, this.stave, acc.line);
       this.glyphs.push(glyph);
+
+      var xPosition = this.xPositions[this.xPositions.length - 1];
+      var glyphWidth = accGlyphData.width + extraWidth;
       // Store the next accidental's x position
-      this.xPositions.push(prevXPosition + glyphWidth);
+      this.xPositions.push(xPosition + glyphWidth);
+      // Expand size of key signature
+      this.width += glyphWidth;
     },
 
     // Cancel out a key signature provided in the `spec` parameter. This will

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -114,7 +114,6 @@ export var KeySignature = (function() {
       var glyph_width = glyph_data.width + extra_width;
       this.width += glyph_width;
       // Set the width and place the glyph on the stave
-      glyph.setWidth(glyph_width);
       this.placeGlyphOnLine(glyph, this.stave, acc.line);
       this.glyphs.push(glyph);
     },

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -105,9 +105,9 @@ export var KeySignature = (function() {
       // Determine spacing between current accidental and the next accidental
       var extraWidth = 0;
       if (acc.type === "n" && nextAcc) {
-        var isAbove = nextAcc.line >= acc.line;
         var spacing = KeySignature.accidentalSpacing[nextAcc.type];
         if (spacing) {
+          var isAbove = nextAcc.line >= acc.line;
           extraWidth = isAbove ? spacing.above : spacing.below;
         }
       }

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -95,9 +95,9 @@ export var KeySignature = (function() {
 
     getCategory: function() { return KeySignature.category; },
 
-    // Add an accidental glyph to the `stave`. `acc` is the data of the
-    // accidental to add. If the `next` accidental is also provided, extra
-    // width will be added to the initial accidental for optimal spacing.
+    // Add an accidental glyph to the `KeySignature` instance which represents
+    // the provided `accid`. If a `nextAccid` is also provided, the appropriate
+    // spacing will be included in the glyph's position
     convertToGlyph: function(accid, nextAccid) {
       var accidGlyphData = Flow.accidentalCodes(accid.type);
       var glyph = new Glyph(accidGlyphData.code, this.glyphFontScale);
@@ -118,6 +118,7 @@ export var KeySignature = (function() {
       // Place the glyph on the stave
       this.placeGlyphOnLine(glyph, this.stave, accid.line);
       this.glyphs.push(glyph);
+      // Store the next accidental's x position
       this.xPositions.push(prevXPosition + glyphWidth);
     },
 

--- a/src/keysignature.js
+++ b/src/keysignature.js
@@ -113,7 +113,7 @@ export var KeySignature = (function() {
 
       var glyph_width = glyph_data.width + extra_width;
       this.width += glyph_width;
-      // Set the width and place the glyph on the stave
+      // Place the glyph on the stave
       this.placeGlyphOnLine(glyph, this.stave, acc.line);
       this.glyphs.push(glyph);
     },


### PR DESCRIPTION
This is a WIP.

Note that this is one of the changes outlined in https://github.com/0xfe/vexflow/issues/349

* Add a `BoundingBoxComputation` class -- [which was completely taken from here](https://github.com/icons8/svg-path-bounding-box/blob/master/lib/Path/BoundingBox.js)
  * This is only needed for a temporary amount of time. With SMuFL metadata we would no longer need a utilitiy to determine glyph bounding boxes.
* Add static method `Glyph.getOutlineBoundingBox`
  * Did a bit of refactoring to share logic between this and `Glyph.renderOutline`
* Every time `glyph.reset()` is called, the `bbox` property is set
* `Glyph.getMetrics()` will now return the `width` and `height` of the `bbox`
* Removed `Glyph.setWidth()` since there should be no reason to manually set the width of a glyph
  * This was only used in `Vex.Flow.KeySignature` -- that call has been removed

@0xfe The regression tests don't run on Windows. Any other options?