### PR TITLE
Expose Vex.Flow.Font to fix glyphs.html

### DIFF
--- a/src/glyphs.html
+++ b/src/glyphs.html
@@ -39,10 +39,7 @@
     }
   </style>
 
-  <script src="vex.js"></script>
-  <script src="flow.js"></script>
-  <script src="fonts/gonville_all.js"></script>
-  <script src="glyph.js"></script>
+  <script src="../build/vexflow-debug.js"></script>
   <script>
     $(function() {
       var canvas = document.getElementById("glyphs");

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ import { Tremolo } from './tremolo';
 import { StringNumber } from './stringnumber';
 import { Crescendo } from './crescendo';
 import { Volta } from './stavevolta';
+import { Font } from './fonts/vexflow_font';
 
 Vex.Flow = Flow;
 Vex.Flow.Fraction = Fraction;
@@ -112,5 +113,6 @@ Vex.Flow.Tremolo = Tremolo;
 Vex.Flow.StringNumber = StringNumber;
 Vex.Flow.Crescendo = Crescendo;
 Vex.Flow.Volta = Volta;
+Vex.Flow.Font = Font;
 
 export default Vex;


### PR DESCRIPTION
The file glyphs.html uses `Vex.Flow.Font` to display the glyphs, but that object was no longer being exposed after the ES6 rewrite. Fixed this by adding `Vex.Flow.Font` to index.js.