### PR TITLE
Fix call to Formatter.AlignRestsToNotes() to remove  keyword

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -328,7 +328,7 @@ export class Formatter {
     if (!voices || !voices.length) throw new Vex.RERR("BadArgument",
         "No voices to format rests");
     for (var i = 0; i < voices.length; i++) {
-      new Formatter.AlignRestsToNotes(voices[i].tickables, align_all_notes);
+      Formatter.AlignRestsToNotes(voices[i].tickables, align_all_notes);
     }
   }
 


### PR DESCRIPTION
Apparently, this worked with the old call style, but it's not necessary to use `new` to call the static function.