### PR TITLE
Refactor stems/beams

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "extends": "airbnb-base",
   "root": true,
+  "env": {
+    "browser": true
+  },
   "rules": {
     "camelcase": [0],
     "yoda": [2, "never", { "exceptRange": true }],

--- a/src/beam.js
+++ b/src/beam.js
@@ -550,7 +550,9 @@ export class Beam {
         currentExtreme = stemTipY;
         extremeY = note.getNoteHeadBounds().y_bottom;
         extremeBeamCount = note.getBeamCount();
-      } else if (stem_direction === Stem.UP && (currentExtreme === 0 || currentExtreme > stemTipY)) {
+      } else if (
+        stem_direction === Stem.UP && (currentExtreme === 0 || currentExtreme > stemTipY)
+      ) {
         currentExtreme = stemTipY;
         extremeY = note.getNoteHeadBounds().y_top;
         extremeBeamCount = note.getBeamCount();

--- a/src/beam.js
+++ b/src/beam.js
@@ -26,6 +26,14 @@ function calculateStemDirection(notes) {
   return Stem.UP;
 }
 
+const getStemSlope = (firstNote, lastNote) => {
+  const firstStemTipY = firstNote.getStemExtents().topY;
+  const firstStemX = firstNote.getStemX();
+  const lastStemTipY = lastNote.getStemExtents().topY;
+  const lastStemX = lastNote.getStemX();
+  return (lastStemTipY - firstStemTipY) / (lastStemX - firstStemX);
+};
+
 export class Beam {
   // Gets the default beam groups for a provided time signature.
   // Attempts to guess if the time signature is not found in table.
@@ -457,117 +465,121 @@ export class Beam {
 
   // Calculate the best possible slope for the provided notes
   calculateSlope() {
-    const first_note = this.notes[0];
-    const first_y_px = first_note.getStemExtents().topY;
-    const first_x_px = first_note.getStemX();
+    const {
+      notes,
+      stem_direction: stemDirection,
+      render_options: { max_slope, min_slope, slope_iterations, slope_cost },
+    } = this;
 
-    const inc = (this.render_options.max_slope - this.render_options.min_slope) /
-        this.render_options.slope_iterations;
-    let min_cost = Number.MAX_VALUE;
-    let best_slope = 0;
-    let y_shift = 0;
+    const firstNote = notes[0];
+    const initialSlope = getStemSlope(firstNote, notes[notes.length - 1]);
+    const increment = (max_slope - min_slope) / slope_iterations;
+    let minCost = Number.MAX_VALUE;
+    let bestSlope = 0;
+    let yShift = 0;
 
     // iterate through slope values to find best weighted fit
-    for (let slope = this.render_options.min_slope;
-         slope <= this.render_options.max_slope;
-         slope += inc) {
-      let total_stem_extension = 0;
-      let y_shift_tmp = 0;
+    for (let slope = min_slope; slope <= max_slope; slope += increment) {
+      let totalStemExtension = 0;
+      let yShiftTemp = 0;
 
       // iterate through notes, calculating y shift and stem extension
-      for (let i = 1; i < this.notes.length; ++i) {
-        const note = this.notes[i];
+      for (let i = 1; i < notes.length; ++i) {
+        const note = notes[i];
+        const adjustedStemTipY = this.getSlopeY(
+          note.getStemX(),
+          firstNote.getStemX(),
+          firstNote.getStemExtents().topY,
+          slope
+        ) + yShiftTemp;
 
-        const x_px = note.getStemX();
-        const y_px = note.getStemExtents().topY;
-        const slope_y_px = this.getSlopeY(x_px, first_x_px, first_y_px, slope) + y_shift_tmp;
-
+        const stemTipY = note.getStemExtents().topY;
         // beam needs to be shifted up to accommodate note
-        if (y_px * this.stem_direction < slope_y_px * this.stem_direction) {
-          const diff =  Math.abs(y_px - slope_y_px);
-          y_shift_tmp += diff * -this.stem_direction;
-          total_stem_extension += (diff * i);
+        if (stemTipY * stemDirection < adjustedStemTipY * stemDirection) {
+          const diff = Math.abs(stemTipY - adjustedStemTipY);
+          yShiftTemp += diff * -stemDirection;
+          totalStemExtension += diff * i;
         } else { // beam overshoots note, account for the difference
-          total_stem_extension += (y_px - slope_y_px) * this.stem_direction;
+          totalStemExtension += (stemTipY - adjustedStemTipY) * stemDirection;
         }
       }
 
-      const last_note = this.notes[this.notes.length - 1];
-      const first_last_slope = ((last_note.getStemExtents().topY - first_y_px) /
-              (last_note.getStemX() - first_x_px));
       // most engraving books suggest aiming for a slope about half the angle of the
       // difference between the first and last notes' stem length;
-      const ideal_slope = first_last_slope / 2;
-      const distance_from_ideal = Math.abs(ideal_slope - slope);
+      const idealSlope = initialSlope / 2;
+      const distanceFromIdeal = Math.abs(idealSlope - slope);
 
-      // This tries to align most beams to something closer to the ideal_slope, but
+      // This tries to align most beams to something closer to the idealSlope, but
       // doesn't go crazy. To disable, set this.render_options.slope_cost = 0
-      const cost = this.render_options.slope_cost * distance_from_ideal +
-          Math.abs(total_stem_extension);
+      const cost = slope_cost * distanceFromIdeal + Math.abs(totalStemExtension);
 
       // update state when a more ideal slope is found
-      if (cost < min_cost) {
-        min_cost = cost;
-        best_slope = slope;
-        y_shift = y_shift_tmp;
+      if (cost < minCost) {
+        minCost = cost;
+        bestSlope = slope;
+        yShift = yShiftTemp;
       }
     }
 
-    this.slope = best_slope;
-    this.y_shift = y_shift;
+    this.slope = bestSlope;
+    this.y_shift = yShift;
   }
 
   // Calculate a slope and y-shift for flat beams
   calculateFlatSlope() {
+    const {
+      notes, stem_direction,
+      render_options: { beam_width, min_flat_beam_offset, flat_beam_offset },
+    } = this;
+
     // If a flat beam offset has not yet been supplied or calculated,
     // generate one based on the notes in this particular note group
     let total = 0;
-    let extreme_y = 0;  // Store the highest or lowest note here
-    let extreme_beam_count = 0;  // The beam count of the extreme note
-    let current_extreme = 0;
-    for (let i = 0; i < this.notes.length; i++) {
+    let extremeY = 0;  // Store the highest or lowest note here
+    let extremeBeamCount = 0;  // The beam count of the extreme note
+    let currentExtreme = 0;
+    for (let i = 0; i < notes.length; i++) {
       // Total up all of the offsets so we can average them out later
-      const note = this.notes[i];
-      const top_y = note.getStemExtents().topY;
-      total += top_y;
+      const note = notes[i];
+      const stemTipY = note.getStemExtents().topY;
+      total += stemTipY;
 
       // Store the highest (stems-up) or lowest (stems-down) note so the
       //  offset can be adjusted in case the average isn't enough
-      if (this.stem_direction === Stem.DOWN && current_extreme < top_y) {
-        current_extreme = top_y;
-        extreme_y = note.getNoteHeadBounds().y_bottom;
-        extreme_beam_count = note.getBeamCount();
-      } else if (this.stem_direction === Stem.UP &&
-          (current_extreme === 0 || current_extreme > top_y)) {
-        current_extreme = top_y;
-        extreme_y = note.getNoteHeadBounds().y_top;
-        extreme_beam_count = note.getBeamCount();
+      if (stem_direction === Stem.DOWN && currentExtreme < stemTipY) {
+        currentExtreme = stemTipY;
+        extremeY = note.getNoteHeadBounds().y_bottom;
+        extremeBeamCount = note.getBeamCount();
+      } else if (stem_direction === Stem.UP && (currentExtreme === 0 || currentExtreme > stemTipY)) {
+        currentExtreme = stemTipY;
+        extremeY = note.getNoteHeadBounds().y_top;
+        extremeBeamCount = note.getBeamCount();
       }
     }
 
     // Average the offsets to try and come up with a reasonable one that
     //  works for all of the notes in the beam group.
-    let offset = total / this.notes.length;
+    let offset = total / notes.length;
 
     // In case the average isn't long enough, add or subtract some more
     //  based on the highest or lowest note (again, based on the stem
     //  direction). This also takes into account the added height due to
     //  the width of the beams.
-    const beam_width = this.render_options.beam_width * 1.5;
-    const extreme_test = this.render_options.min_flat_beam_offset +
-        (extreme_beam_count * beam_width);
-    const new_offset = extreme_y + (extreme_test * -this.stem_direction);
-    if (this.stem_direction === Stem.DOWN && offset < new_offset) {
-      offset = extreme_y + extreme_test;
-    } else if (this.stem_direction === Stem.UP && offset > new_offset) {
-      offset = extreme_y - extreme_test;
+    const beamWidth = beam_width * 1.5;
+    const extremeTest = min_flat_beam_offset + (extremeBeamCount * beamWidth);
+    const newOffset = extremeY + (extremeTest * -stem_direction);
+    if (stem_direction === Stem.DOWN && offset < newOffset) {
+      offset = extremeY + extremeTest;
+    } else if (stem_direction === Stem.UP && offset > newOffset) {
+      offset = extremeY - extremeTest;
     }
-    if (!this.render_options.flat_beam_offset) {
+
+    if (!flat_beam_offset) {
       // Set the offset for the group based on the calculations above.
       this.render_options.flat_beam_offset = offset;
-    } else if (this.stem_direction === Stem.DOWN && offset > this.render_options.flat_beam_offset) {
+    } else if (stem_direction === Stem.DOWN && offset > flat_beam_offset) {
       this.render_options.flat_beam_offset = offset;
-    } else if (this.stem_direction === Stem.UP && offset < this.render_options.flat_beam_offset) {
+    } else if (stem_direction === Stem.UP && offset < flat_beam_offset) {
       this.render_options.flat_beam_offset = offset;
     }
 
@@ -579,78 +591,47 @@ export class Beam {
   // Create new stems for the notes in the beam, so that each stem
   // extends into the beams.
   applyStemExtensions() {
-    const first_note = this.notes[0];
-    let first_y_px = first_note.getStemExtents().topY;
+    const {
+      notes, slope, y_shift, stem_direction, beam_count,
+      render_options: {
+        show_stemlets,
+        flat_beam_offset,
+        flat_beams,
+        stemlet_extension,
+        beam_width,
+      },
+    } = this;
 
-    // If rendering flat beams, and an offset exists, set the y-coordinate to
+    const firstNote = notes[0];
+    let firstStemTipY = firstNote.getStemExtents().topY;
+
+    // If rendering flat beams, and an offset exists, set the y-coordinat`e to
     //  the offset so the stems all end at the beam offset.
-    if (this.render_options.flat_beams && this.render_options.flat_beam_offset) {
-      first_y_px = this.render_options.flat_beam_offset;
+    if (flat_beams && flat_beam_offset) {
+      firstStemTipY = flat_beam_offset;
     }
-    const first_x_px = first_note.getStemX();
+    const firstStemX = firstNote.getStemX();
 
-    for (let i = 0; i < this.notes.length; ++i) {
-      const note = this.notes[i];
+    for (let i = 0; i < notes.length; ++i) {
+      const note = notes[i];
+      const stemX = note.getStemX();
+      const { topY: stemTipY } = note.getStemExtents();
+      const beamedStemTipY = this.getSlopeY(stemX, firstStemX, firstStemTipY, slope) + y_shift;
+      const preBeamExtension = note.getStem().getExtension();
+      const beamExtension = stem_direction === Stem.UP
+        ? stemTipY - beamedStemTipY
+        : beamedStemTipY - stemTipY;
 
-      const x_px = note.getStemX();
-      const y_extents = note.getStemExtents();
-      let base_y_px = y_extents.baseY;
-      let top_y_px = y_extents.topY;
+      note.stem.setExtension(preBeamExtension + beamExtension);
 
-      // If flat beams, set the top of the stem to the offset, rather than
-      //  relying on the topY value from above.
-      if (this.render_options.flat_beams) {
-        top_y_px = first_y_px;
+      if (note.isRest() && show_stemlets) {
+        const beamWidth = beam_width;
+        const totalBeamWidth = ((beam_count - 1) * beamWidth * 1.5) + beamWidth;
+        note.stem
+          .setNoteHeadXBounds(stemX, stemX)
+          .setVisibility(true)
+          .setStemlet(true, totalBeamWidth + stemlet_extension);
       }
-
-      // For harmonic note heads, shorten stem length by 3 pixels
-      base_y_px += this.stem_direction * note.glyph.stem_offset;
-
-      // Don't go all the way to the top (for thicker stems)
-      const y_displacement = Flow.STEM_WIDTH;
-
-      if (!note.hasStem()) {
-        if (note.isRest() && this.render_options.show_stemlets) {
-          const centerGlyphX = note.getCenterGlyphX();
-
-          const width = this.render_options.beam_width;
-          const total_width = ((this.beam_count - 1) * width * 1.5) + width;
-
-          const stemlet_height = (total_width - y_displacement +
-            this.render_options.stemlet_extension);
-
-          const beam_y = this.getSlopeY(centerGlyphX, first_x_px,
-                          first_y_px, this.slope) + this.y_shift;
-          const start_y = beam_y + (Stem.HEIGHT * this.stem_direction);
-          const end_y = beam_y + (stemlet_height * this.stem_direction);
-
-          // Draw Stemlet
-          note.setStem(new Stem({
-            x_begin: centerGlyphX,
-            x_end: centerGlyphX,
-            y_bottom: this.stem_direction === Stem.UP ? end_y : start_y,
-            y_top: this.stem_direction === Stem.UP ? start_y : end_y,
-            y_extend: y_displacement,
-            stem_extension: -1, // To avoid protruding through the beam
-            stem_direction: this.stem_direction,
-          }));
-        }
-
-        continue;
-      }
-
-      const slope_y = this.getSlopeY(x_px, first_x_px, first_y_px,
-                      this.slope) + this.y_shift;
-
-      note.setStem(new Stem({
-        x_begin: x_px - (Flow.STEM_WIDTH / 2),
-        x_end: x_px,
-        y_top: this.stem_direction === Stem.UP ? top_y_px : base_y_px,
-        y_bottom: this.stem_direction === Stem.UP ? base_y_px :  top_y_px,
-        y_extend: y_displacement,
-        stem_extension: Math.abs(top_y_px - slope_y) - Stem.HEIGHT - 1,
-        stem_direction: this.stem_direction,
-      }));
     }
   }
 
@@ -764,45 +745,47 @@ export class Beam {
 
     const valid_beam_durations = ['4', '8', '16', '32', '64'];
 
-    const first_note = this.notes[0];
+    const firstNote = this.notes[0];
 
-    let first_y_px = first_note.getStemExtents().topY;
+    const firstStemTipY = firstNote.getStemExtents().topY;
+    let beamY = firstStemTipY;
 
     // For flat beams, set the first and last Y to the offset, rather than
     //  using the note's stem extents.
     if (this.render_options.flat_beams && this.render_options.flat_beam_offset) {
-      first_y_px = this.render_options.flat_beam_offset;
+      beamY = this.render_options.flat_beam_offset;
     }
 
-    const first_x_px = first_note.getStemX();
-
-    const beam_width = this.render_options.beam_width * this.stem_direction;
+    const firstStemX = firstNote.getStemX();
+    const beamThickness = this.render_options.beam_width * this.stem_direction;
 
     // Draw the beams.
     for (let i = 0; i < valid_beam_durations.length; ++i) {
       const duration = valid_beam_durations[i];
-      const beam_lines = this.getBeamLines(duration);
+      const beamLines = this.getBeamLines(duration);
 
-      for (let j = 0; j < beam_lines.length; ++j) {
-        const beam_line = beam_lines[j];
-        const first_x = beam_line.start -
-          (this.stem_direction === Stem.DOWN ? Flow.STEM_WIDTH / 2 : 0);
-        const first_y = this.getSlopeY(first_x, first_x_px, first_y_px, this.slope);
+      for (let j = 0; j < beamLines.length; ++j) {
+        const beam_line = beamLines[j];
+        const startBeamX = beam_line.start
+          - (this.stem_direction === Stem.DOWN ? Flow.STEM_WIDTH / 2 : 0);
 
-        const last_x = beam_line.end +
-          (this.stem_direction === 1 ? (Flow.STEM_WIDTH / 3) : (-Flow.STEM_WIDTH / 3));
-        const last_y = this.getSlopeY(last_x, first_x_px, first_y_px, this.slope);
+        const startBeamY = this.getSlopeY(startBeamX, firstStemX, beamY, this.slope);
+
+        const lastBeamX = beam_line.end
+          + (this.stem_direction === 1 ? (Flow.STEM_WIDTH / 3) : (-Flow.STEM_WIDTH / 3));
+
+        const lastBeamY = this.getSlopeY(lastBeamX, firstStemX, beamY, this.slope);
 
         this.context.beginPath();
-        this.context.moveTo(first_x, first_y + this.y_shift);
-        this.context.lineTo(first_x, first_y + beam_width + this.y_shift);
-        this.context.lineTo(last_x + 1, last_y + beam_width + this.y_shift);
-        this.context.lineTo(last_x + 1, last_y + this.y_shift);
+        this.context.moveTo(startBeamX, startBeamY);
+        this.context.lineTo(startBeamX, startBeamY + beamThickness);
+        this.context.lineTo(lastBeamX + 1, lastBeamY + beamThickness);
+        this.context.lineTo(lastBeamX + 1, lastBeamY);
         this.context.closePath();
         this.context.fill();
       }
 
-      first_y_px += beam_width * 1.5;
+      beamY += beamThickness * 1.5;
     }
   }
 

--- a/src/beam.js
+++ b/src/beam.js
@@ -625,12 +625,12 @@ export class Beam {
         : beamedStemTipY - stemTipY;
 
       note.stem.setExtension(preBeamExtension + beamExtension);
+      note.stem.renderHeightAdjustment = -Stem.WIDTH / 2;
 
       if (note.isRest() && show_stemlets) {
         const beamWidth = beam_width;
         const totalBeamWidth = ((beam_count - 1) * beamWidth * 1.5) + beamWidth;
         note.stem
-          .setNoteHeadXBounds(stemX, stemX)
           .setVisibility(true)
           .setStemlet(true, totalBeamWidth + stemlet_extension);
       }
@@ -667,7 +667,8 @@ export class Beam {
         }
       }
       const note_gets_beam = ticks < Flow.durationToTicks(duration);
-      const stem_x = note.getStemX();
+
+      const stem_x = note.getStemX() - (Stem.WIDTH / 2);
 
       // Check to see if the next note in the group will get a beam at this
       //  level. This will help to inform the partial beam logic below.
@@ -768,14 +769,10 @@ export class Beam {
 
       for (let j = 0; j < beamLines.length; ++j) {
         const beam_line = beamLines[j];
-        const startBeamX = beam_line.start
-          - (this.stem_direction === Stem.DOWN ? Flow.STEM_WIDTH / 2 : 0);
+        const startBeamX = beam_line.start;
 
         const startBeamY = this.getSlopeY(startBeamX, firstStemX, beamY, this.slope);
-
-        const lastBeamX = beam_line.end
-          + (this.stem_direction === 1 ? (Flow.STEM_WIDTH / 3) : (-Flow.STEM_WIDTH / 3));
-
+        const lastBeamX = beam_line.end;
         const lastBeamY = this.getSlopeY(lastBeamX, firstStemX, beamY, this.slope);
 
         this.context.beginPath();

--- a/src/beam.js
+++ b/src/beam.js
@@ -548,13 +548,13 @@ export class Beam {
       //  offset can be adjusted in case the average isn't enough
       if (stem_direction === Stem.DOWN && currentExtreme < stemTipY) {
         currentExtreme = stemTipY;
-        extremeY = note.getNoteHeadBounds().y_bottom;
+        extremeY = Math.max(...note.getYs());
         extremeBeamCount = note.getBeamCount();
       } else if (
         stem_direction === Stem.UP && (currentExtreme === 0 || currentExtreme > stemTipY)
       ) {
         currentExtreme = stemTipY;
-        extremeY = note.getNoteHeadBounds().y_top;
+        extremeY = Math.min(...note.getYs());
         extremeBeamCount = note.getBeamCount();
       }
     }
@@ -667,7 +667,7 @@ export class Beam {
         }
       }
       const note_gets_beam = ticks < Flow.durationToTicks(duration);
-      const stem_x = note.isRest() ? note.getCenterGlyphX() : note.getStemX();
+      const stem_x = note.getStemX();
 
       // Check to see if the next note in the group will get a beam at this
       //  level. This will help to inform the partial beam logic below.
@@ -801,7 +801,7 @@ export class Beam {
     if (this.postFormatted) return;
 
     // Calculate a smart slope if we're not forcing the beams to be flat.
-    if (this.render_options.flat_beams) {
+    if (this.notes[0].getCategory() === 'tabnotes' || this.render_options.flat_beams) {
       this.calculateFlatSlope();
     } else {
       this.calculateSlope();

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -172,7 +172,7 @@ export class Formatter {
     // Instantiate a `Formatter` and format the notes.
     new Formatter()
       .joinVoices([voice], { align_rests: options.align_rests })
-      .formatToStave([voice], stave, { align_rests: options.align_rests });
+      .formatToStave([voice], stave, { align_rests: options.align_rests, stave });
 
     // Render the voice and beams to the stave.
     voice.setStave(stave).draw(ctx, stave);

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -25,7 +25,7 @@ function L(...args) { if (NoteHead.DEBUG) Vex.L('Vex.Flow.NoteHead', args); }
 // * `y`: the y coordinate to draw at
 // * `stem_direction`: the direction of the stem
 function drawSlashNoteHead(ctx, duration, x, y, stem_direction) {
-  const width = 15 + (Flow.STEM_WIDTH / 2);
+  const width = 15;
   ctx.save();
   ctx.setLineWidth(Flow.STEM_WIDTH);
 

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -10,6 +10,7 @@
 import { Vex } from './vex';
 import { Flow } from './tables';
 import { Note } from './note';
+import { Stem } from './stem';
 import { StaveNote } from './stavenote';
 import { Glyph } from './glyph';
 
@@ -149,7 +150,14 @@ export class NoteHead extends Note {
     // to its tick context
     const x = !this.preFormatted ? this.x : super.getAbsoluteX();
 
-    return x + (this.displaced ? this.width * this.stem_direction : 0);
+    // For a more natural displaced notehead, we adjust the displacement amount
+    // by half the stem width in order to maintain a slight overlap with the stem
+    const displacementStemAdjustment = (Stem.WIDTH / 2);
+
+    return x + (this.displaced
+      ? (this.width - displacementStemAdjustment) * this.stem_direction
+      : 0
+    );
   }
 
   // Get the `BoundingBox` for the `NoteHead`

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -22,6 +22,8 @@ import { Glyph } from './glyph';
 // To enable logging for this class. Set `Vex.Flow.StaveNote.DEBUG` to `true`.
 function L(...args) { if (StaveNote.DEBUG) Vex.L('Vex.Flow.StaveNote', args); }
 
+const getStemAdjustment = (note) => Stem.WIDTH / (2 * -note.getStemDirection());
+
 // Helper methods for rest positioning in ModifierContext.
 function shiftRestVertical(rest, note, dir) {
   const delta = (note.isrest ? 0.0 : 1.0) * dir;
@@ -553,8 +555,7 @@ export class StaveNote extends StemmableNote {
     } else {
       // We adjust the origin of the stem because we want the stem left-aligned
       // with the notehead if stemmed-down, and right-aligned if stemmed-up
-      const stemAdjustment = Stem.WIDTH / (2 * -this.getStemDirection());
-      return super.getStemX() + stemAdjustment;
+      return super.getStemX() + getStemAdjustment(this);
     }
   }
 
@@ -923,22 +924,18 @@ export class StaveNote extends StemmableNote {
     const glyph = this.getGlyph();
 
     if (glyph.flag && shouldRenderFlag) {
-      let flagX;
+      const flagX = this.getStemX();
       let flagY;
       let flagCode;
 
-      const xBegin = this.getNoteHeadBeginX();
-      const xEnd = this.getNoteHeadEndX();
       const { y_top, y_bottom } = this.getNoteHeadBounds();
       const noteStemHeight = stem.getHeight();
       if (this.getStemDirection() === Stem.DOWN) {
         // Down stems have flags on the left.
-        flagX = xBegin + 1;
         flagY = y_top - noteStemHeight + 2;
         flagCode = glyph.code_flag_downstem;
       } else {
         // Up stems have flags on the left.
-        flagX = xEnd + 1;
         flagY = y_bottom - noteStemHeight - 2;
         flagCode = glyph.code_flag_upstem;
       }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -549,6 +549,14 @@ export class StaveNote extends StemmableNote {
   // Determine if the `StaveNote` has a stem
   hasStem() { return this.glyph.stem; }
 
+  getStemX() {
+    if (this.noteType === 'r') {
+      return this.getCenterGlyphX();
+    } else {
+      return super.getStemX();
+    }
+  }
+
   // Get the `y` coordinate for text placed on the top/bottom of a
   // note at a desired `text_line`
   getYForTopText(textLine) {
@@ -578,7 +586,7 @@ export class StaveNote extends StemmableNote {
 
     this.setYs(ys);
 
-    if (this.hasStem()) {
+    if (this.stem) {
       const { y_top, y_bottom } = this.getNoteHeadBounds();
       this.stem.setYBounds(y_top, y_bottom);
     }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -491,8 +491,8 @@ export class StaveNote extends StemmableNote {
     } else if (this.glyph.stem) {
       const ys = this.getStemExtents();
       ys.baseY += halfLineSpacing * this.stem_direction;
-      minY = Vex.Min(ys.topY, ys.baseY);
-      maxY = Vex.Max(ys.topY, ys.baseY);
+      minY = Math.min(ys.topY, ys.baseY);
+      maxY = Math.max(ys.topY, ys.baseY);
     } else {
       minY = null;
       maxY = null;
@@ -503,8 +503,8 @@ export class StaveNote extends StemmableNote {
           minY = yy;
           maxY = yy;
         } else {
-          minY = Vex.Min(yy, minY);
-          maxY = Vex.Max(yy, maxY);
+          minY = Math.min(yy, minY);
+          maxY = Math.max(yy, maxY);
         }
       }
       minY -= halfLineSpacing;
@@ -553,7 +553,7 @@ export class StaveNote extends StemmableNote {
     } else {
       // We adjust the origin of the stem because we want the stem left-aligned
       // with the notehead if stemmed-down, and right-aligned if stemmed-up
-      const stemAdjustment = Stem.WIDTH / (this.getStemDirection() === Stem.UP ? -2 : +2);
+      const stemAdjustment = Stem.WIDTH / (2 * -this.getStemDirection());
       return super.getStemX() + stemAdjustment;
     }
   }
@@ -844,7 +844,7 @@ export class StaveNote extends StemmableNote {
   // Get the ending `x` coordinate for the noteheads
   getNoteHeadEndX() {
     const xBegin = this.getNoteHeadBeginX();
-    return xBegin + this.glyph.head_width - (Flow.STEM_WIDTH / 2);
+    return xBegin + this.glyph.head_width;
   }
 
   // Draw the ledger lines between the stave and the highest/lowest keys
@@ -987,14 +987,14 @@ export class StaveNote extends StemmableNote {
     }
 
     const xBegin = this.getNoteHeadBeginX();
-    const xEnd = this.getNoteHeadEndX();
     const shouldRenderStem = this.hasStem() && !this.beam;
 
     // Format note head x positions
     this.note_heads.forEach(notehead => notehead.setX(xBegin));
 
     // Format stem x positions
-    this.stem.setNoteHeadXBounds(xBegin, xEnd);
+    const stemX = this.getStemX();
+    this.stem.setNoteHeadXBounds(stemX, stemX);
 
     L('Rendering ', this.isChord() ? 'chord :' : 'note :', this.keys);
 

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -324,13 +324,11 @@ export class StaveNote extends StemmableNote {
   buildStem() {
     const glyph = this.getGlyph();
     const yExtend = glyph.code_head === 'v95' || glyph.code_head === 'v3e' ? -4 : 0;
-    const stem = new Stem({ yExtend });
 
-    if (this.isRest()) {
-      stem.hide = true;
-    }
-
-    this.setStem(stem);
+    this.setStem(new Stem({
+      yExtend,
+      hide: !!this.isRest(),
+    }));
   }
 
   // Builds a `NoteHead` for each key in the note

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -551,7 +551,10 @@ export class StaveNote extends StemmableNote {
     if (this.noteType === 'r') {
       return this.getCenterGlyphX();
     } else {
-      return super.getStemX();
+      // We adjust the origin of the stem because we want the stem left-aligned
+      // with the notehead if stemmed-down, and right-aligned if stemmed-up
+      const stemAdjustment = Stem.WIDTH / (this.getStemDirection() === Stem.UP ? -2 : +2);
+      return super.getStemX() + stemAdjustment;
     }
   }
 

--- a/src/stem.js
+++ b/src/stem.js
@@ -142,11 +142,11 @@ export class Stem {
 
     if (stem_direction === Stem.DOWN) {
       // Down stems are rendered to the left of the head.
-      stem_x = this.x_begin + (Stem.WIDTH / 2);
+      stem_x = this.x_begin;
       stem_y = this.y_top;
     } else {
       // Up stems are rendered to the right of the head.
-      stem_x = this.x_end + (Stem.WIDTH / 2);
+      stem_x = this.x_end;
       stem_y = this.y_bottom;
     }
 

--- a/src/stem.js
+++ b/src/stem.js
@@ -159,12 +159,17 @@ export class Stem {
 
     L('Rendering stem - ', 'Top Y: ', this.y_top, 'Bottom Y: ', this.y_bottom);
 
+    // The offset from the stem's base which is required fo satisfy the stemlet height
+    const stemletYOffset = this.isStemlet
+      ? stemHeight - this.stemletHeight * this.stem_direction
+      : 0;
+
     // Draw the stem
     ctx.save();
     this.applyStyle(ctx);
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
-    ctx.moveTo(stem_x, stem_y - (this.isStemlet ? stemHeight - this.stemletHeight * this.stem_direction : 0));
+    ctx.moveTo(stem_x, stem_y - stemletYOffset);
     ctx.lineTo(stem_x, stem_y - stemHeight);
     ctx.stroke();
     ctx.restore();

--- a/src/stem.js
+++ b/src/stem.js
@@ -29,10 +29,7 @@ export class Stem {
     return Flow.STEM_HEIGHT;
   }
 
-  constructor(options = null) {
-    if (options === null) {
-      return;
-    }
+  constructor(options = {}) {
     // Default notehead x bounds
     this.x_begin = options.x_begin || 0;
     this.x_end = options.x_end || 0;

--- a/src/stem.js
+++ b/src/stem.js
@@ -38,8 +38,6 @@ export class Stem {
     this.y_top = options.y_top || 0;
     this.y_bottom = options.y_bottom || 0;
 
-    // Stem base extension
-    this.y_extend = options.y_extend || 0;
     // Stem top extension
     this.stem_extension = options.stem_extension || 0;
 
@@ -51,6 +49,10 @@ export class Stem {
 
     this.isStemlet = options.isStemlet || false;
     this.stemletHeight = options.stemletHeight || 0;
+
+    // Use to adjust the rendered height without affecting
+    // the results of `.getExtents()`
+    this.renderHeightAdjustment = 0;
   }
 
   // Set the x bounds for the default notehead
@@ -150,9 +152,7 @@ export class Stem {
       stem_y = this.y_bottom;
     }
 
-    stem_y += this.y_extend * stem_direction;
-
-    const stemHeight = this.getHeight() + -this.y_extend * -stem_direction;
+    const stemHeight = this.getHeight();
 
     L('Rendering stem - ', 'Top Y: ', this.y_top, 'Bottom Y: ', this.y_bottom);
 
@@ -167,7 +167,7 @@ export class Stem {
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
     ctx.moveTo(stem_x, stem_y - stemletYOffset);
-    ctx.lineTo(stem_x, stem_y - stemHeight);
+    ctx.lineTo(stem_x, stem_y - stemHeight - (this.renderHeightAdjustment * stem_direction));
     ctx.stroke();
     ctx.restore();
   }

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -9,9 +9,6 @@ import { Flow } from './tables';
 import { Stem } from './stem';
 import { Note } from './note';
 
-// To enable logging for this class. Set `Vex.Flow.StemmableNote.DEBUG` to `true`.
-function L(...args) { if (StemmableNote.DEBUG) Vex.L('Vex.Flow.StemmableNote', args); }
-
 export class StemmableNote extends Note {
   constructor(note_struct) {
     super(note_struct);

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -97,10 +97,7 @@ export class StemmableNote extends Note {
   getStemX() {
     const x_begin = this.getAbsoluteX() + this.x_shift;
     const x_end = this.getAbsoluteX() + this.x_shift + this.glyph.head_width;
-
-    let stem_x = this.stem_direction === Stem.DOWN ? x_begin : x_end;
-    stem_x -= (Stem.WIDTH / 2) * this.stem_direction;
-
+    const stem_x = this.stem_direction === Stem.DOWN ? x_begin : x_end;
     return stem_x;
   }
 

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -138,33 +138,7 @@ export class StemmableNote extends Note {
 
   // Get the top and bottom `y` values of the stem.
   getStemExtents() {
-    if (!this.ys || this.ys.length === 0) {
-      throw new Vex.RERR('NoYValues', "Can't get top stem Y when note has no Y values.");
-    }
-
-    let topY = this.ys[0];
-    let baseY = this.ys[0];
-    const stemHeight = Stem.HEIGHT + this.getStemExtension();
-
-    for (let i = 0; i < this.ys.length; ++i) {
-      const stemTop = this.ys[i] + (stemHeight * -this.stem_direction);
-
-      if (this.stem_direction === Stem.DOWN) {
-        topY = Math.max(topY, stemTop);
-        baseY = Math.min(baseY, this.ys[i]);
-      } else {
-        topY = Math.min(topY, stemTop);
-        baseY = Math.max(baseY, this.ys[i]);
-      }
-
-      if (this.noteType === 's' || this.noteType === 'x') {
-        topY -= this.stem_direction * 7;
-        baseY -= this.stem_direction * 7;
-      }
-    }
-
-    L('Stem extents: ', topY, baseY);
-    return { topY, baseY };
+    return this.stem.getExtents();
   }
 
   // Sets the current note's beam
@@ -213,7 +187,6 @@ export class StemmableNote extends Note {
     if (!this.context) {
       throw new Vex.RERR('NoCanvasContext', "Can't draw without a canvas context.");
     }
-
     this.setStem(new Stem(stem_struct));
     this.stem.setContext(this.context).draw();
   }

--- a/src/tables.js
+++ b/src/tables.js
@@ -2,6 +2,7 @@
 
 import { Vex } from './vex';
 import { Fraction } from './fraction';
+import { Glyph } from './glyph';
 
 const Flow = {
   STEM_WIDTH: 1.5,
@@ -801,7 +802,9 @@ Flow.durationToGlyph = (duration, type) => {
 Flow.durationToGlyph.duration_codes = {
   '1/2': {
     common: {
-      head_width: 22,
+      get head_width() {
+        return new Glyph(this.code_head || 'v53', 35).getMetrics().width;
+      },
       stem: false,
       stem_offset: 0,
       flag: false,
@@ -828,7 +831,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Breve rest
         code_head: 'v31',
-        head_width: 24,
         rest: true,
         position: 'B/5',
         dot_shiftY: 0.5,
@@ -842,7 +844,9 @@ Flow.durationToGlyph.duration_codes = {
   },
   '1': {
     common: {
-      head_width: 16,
+      get head_width() {
+        return new Glyph(this.code_head || 'v1d', 35).getMetrics().width;
+      },
       stem: false,
       stem_offset: 0,
       flag: false,
@@ -869,7 +873,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Whole rest
         code_head: 'v5c',
-        head_width: 12,
         rest: true,
         position: 'D/5',
         dot_shiftY: 0.5,
@@ -883,7 +886,9 @@ Flow.durationToGlyph.duration_codes = {
   },
   '2': {
     common: {
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'v81', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: false,
@@ -910,7 +915,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Half rest
         code_head: 'vc',
-        head_width: 12,
         stem: false,
         rest: true,
         position: 'B/4',
@@ -925,7 +929,9 @@ Flow.durationToGlyph.duration_codes = {
   },
   '4': {
     common: {
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: false,
@@ -952,7 +958,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Quarter rest
         code_head: 'v7c',
-        head_width: 8,
         stem: false,
         rest: true,
         position: 'B/4',
@@ -969,7 +974,9 @@ Flow.durationToGlyph.duration_codes = {
   },
   '8': {
     common: {
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: true,
@@ -1016,7 +1023,9 @@ Flow.durationToGlyph.duration_codes = {
   '16': {
     common: {
       beam_count: 2,
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: true,
@@ -1044,7 +1053,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Sixteenth rest
         code_head: 'v3c',
-        head_width: 13,
         stem: false,
         flag: false,
         rest: true,
@@ -1063,7 +1071,9 @@ Flow.durationToGlyph.duration_codes = {
   '32': {
     common: {
       beam_count: 3,
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: true,
@@ -1091,7 +1101,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Thirty-second rest
         code_head: 'v55',
-        head_width: 16,
         stem: false,
         flag: false,
         rest: true,
@@ -1110,7 +1119,9 @@ Flow.durationToGlyph.duration_codes = {
   '64': {
     common: {
       beam_count: 4,
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: true,
@@ -1138,7 +1149,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': { // Sixty-fourth rest
         code_head: 'v38',
-        head_width: 18,
         stem: false,
         flag: false,
         rest: true,
@@ -1157,7 +1167,9 @@ Flow.durationToGlyph.duration_codes = {
   '128': {
     common: {
       beam_count: 5,
-      head_width: 10,
+      get head_width() {
+        return new Glyph(this.code_head || 'vb', 35).getMetrics().width;
+      },
       stem: true,
       stem_offset: 0,
       flag: true,
@@ -1185,7 +1197,6 @@ Flow.durationToGlyph.duration_codes = {
       },
       'r': {  // Hundred-twenty-eight rest
         code_head: 'vaa',
-        head_width: 20,
         stem: false,
         flag: false,
         rest: true,

--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -388,11 +388,6 @@ export class TabNote extends StemmableNote {
         this.getStemDirection()
       );
 
-      // Fine tune x position to match default stem
-      if (!this.beam || this.getStemDirection() === 1) {
-        stem_x += (Stem.WIDTH / 2);
-      }
-
       ctx.save();
       ctx.setLineWidth(Stem.WIDTH);
       stem_lines.forEach(bounds => {

--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -370,7 +370,7 @@ export class TabNote extends StemmableNote {
 
   // Render the stem extension through the fret positions
   drawStemThrough() {
-    let stem_x = this.getStemX();
+    const stem_x = this.getStemX();
     const stem_y = this.getStemY();
     const ctx = this.context;
 

--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -453,7 +453,6 @@ export class TabNote extends StemmableNote {
     this.drawStemThrough();
 
     const stem_x = this.getStemX();
-    const stem_y = this.getStemY();
 
     this.stem.setNoteHeadXBounds(stem_x, stem_x);
 

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -373,7 +373,7 @@ VF.Test.StaveNote = (function() {
       tickContext.setX(10);
       tickContext.setPadding(0);
 
-      equal(tickContext.getWidth(), 15.5988);
+      VF.Test.almostEqual(tickContext.getWidth(), 15.5988, 0.0001);
     },
 
     showNote: function(note_struct, stave, ctx, x, drawBoundingBox) {

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -373,7 +373,7 @@ VF.Test.StaveNote = (function() {
       tickContext.setX(10);
       tickContext.setPadding(0);
 
-      equal(tickContext.getWidth(), 16);
+      equal(tickContext.getWidth(), 15.5988);
     },
 
     showNote: function(note_struct, stave, ctx, x, drawBoundingBox) {

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -215,8 +215,8 @@ VF.Test = (function() {
       ctx.restore();
     },
 
-    almostEqual: function(value, expected, precision) {
-      return equal(Math.abs(value - expected) < precision, true);
+    almostEqual: function(value, expectedValue, errorMargin) {
+      return equal(Math.abs(value - expectedValue) < errorMargin, true);
     }
   };
 

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -213,6 +213,10 @@ VF.Test = (function() {
       legend("#DDD", "Formatter Shift")
 
       ctx.restore();
+    },
+
+    almostEqual: function(value, expected, precision) {
+      return QUnit.equal(Math.abs(value - expected) < precision, true);
     }
   };
 

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -216,7 +216,7 @@ VF.Test = (function() {
     },
 
     almostEqual: function(value, expected, precision) {
-      return QUnit.equal(Math.abs(value - expected) < precision, true);
+      return equal(Math.abs(value - expected) < precision, true);
     }
   };
 


### PR DESCRIPTION
Still  a WIP, tab is broken.

Important things to note:

* The logic `StaveNote.getStemExtents()` has been removed and now delegates to `Stem.getExtents()`
* Went through `Beam` and did a lot of renaming, most variable names were really vague and I think it's a lot easier to understand now.
* A lot of logic in `beam.applyStemExtensions` was just plain wrong mainly due to incorrect assumptions around stem coordinates because it's a [very confusing part of the codebase](https://github.com/0xfe/vexflow/wiki/Development-Gotchas) -- that method has been greatly simplified
* `Formatter.FormatAndDraw` now passes `options.stave` to `formatter.formatToStave` which is required to trigger the `postFormat`  lifecycle (this also explains why the stem extents were wrong in the articulation PR)