### PR TITLE
Remove rollup in favor of webpack for super-fast incremental rebuilds. 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "extends": "airbnb-base",
   "root": true,
+  "env": {
+    "browser": true
+  },
   "rules": {
     "camelcase": [0],
     "yoda": [2, "never", { "exceptRange": true }],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,3 @@
-const babel = require('rollup-plugin-babel');
 const path = require('path');
 
 module.exports = (grunt) => {
@@ -27,6 +26,29 @@ module.exports = (grunt) => {
     'tests/run.js',
   ];
 
+  const webpackCommon = {
+    entry: MODULE_ENTRY,
+    output: {
+      path: BUILD_DIR,
+      filename: 'vexflow-debug.js',
+      library: 'Vex',
+    },
+    devtool: 'source-map',
+    module: {
+      loaders: [
+        {
+          test: /\.js?$/,
+          exclude: /(node_modules|bower_components)/,
+          loader: 'babel',
+          query: {
+            presets: ['es2015'],
+            'plugins': ['add-module-exports'],
+          },
+        },
+      ],
+    },
+  };
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     concat: {
@@ -39,25 +61,13 @@ module.exports = (grunt) => {
         dest: TARGET_TESTS,
       },
     },
-    rollup: {
-      options: {
-        banner: BANNER,
-        format: 'umd',
-        moduleName: 'Vex',
-        sourceMap: true,
-        sourceMapFile: TARGET_RAW,
-        plugins() {
-          return [
-            babel({
-              exclude: './node_modules/**',
-            }),
-          ];
-        },
-      },
-      files: {
-        src: MODULE_ENTRY,
-        dest: TARGET_RAW,
-      },
+    webpack: {
+      build: webpackCommon,
+      watch: Object.assign({}, webpackCommon, {
+        watch: true,
+        keepalive: true,
+        watchDelay: 0,
+      }),
     },
     uglify: {
       options: {
@@ -79,13 +89,6 @@ module.exports = (grunt) => {
       files: ['tests/flow.html'],
     },
     watch: {
-      scripts: {
-        files: ['src/*', 'Gruntfile.js'],
-        tasks: ['rollup'],
-        options: {
-          interrupt: true,
-        },
-      },
       tests: {
         files: ['tests/*'],
         tasks: ['concat:tests'],
@@ -146,7 +149,6 @@ module.exports = (grunt) => {
   });
 
   // Load the plugin that provides the "uglify" task.
-  grunt.loadNpmTasks('grunt-rollup');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -158,10 +160,11 @@ module.exports = (grunt) => {
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-git');
   grunt.loadNpmTasks('grunt-eslint');
+  grunt.loadNpmTasks('grunt-webpack');
 
   // Default task(s).
-  grunt.registerTask('default', ['eslint', 'rollup', 'concat', 'uglify', 'docco']);
-  grunt.registerTask('test', 'Run qunit tests.', ['rollup', 'concat', 'qunit']);
+  grunt.registerTask('default', ['eslint', 'webpack:build', 'concat', 'uglify', 'docco']);
+  grunt.registerTask('test', 'Run qunit tests.', ['webpack:build', 'concat', 'qunit']);
 
   // Release current build.
   grunt.registerTask('stage', 'Stage current binaries to releases/.', () => {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = (grunt) => {
       path: BUILD_DIR,
       filename: 'vexflow-debug.js',
       library: 'Vex',
+      libraryTarget: 'umd',
     },
     devtool: 'source-map',
     module: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "url": "https://github.com/0xfe/vexflow/issues"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-es2015": "^6.9.0",
     "browserify": "^13.0.1",
     "docco": "^0.7.0",
     "eslint": "^3.0.1",
@@ -37,13 +39,13 @@
     "grunt-eslint": "^19.0.0",
     "grunt-git": "^1.0.0",
     "grunt-release": "^0.14.0",
-    "grunt-rollup": "^0.7.1",
+    "grunt-webpack": "^1.0.11",
     "jquery": "^3.1.0",
     "jscs": "^3.0.6",
     "qunit": "^0.9.1",
     "raphael": "^2.1.0",
-    "rollup-plugin-babel": "^2.5.1",
-    "slimerjs": "^0.906.2"
+    "slimerjs": "^0.906.2",
+    "webpack": "^1.13.1"
   },
   "scripts": {
     "start": "grunt stage",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["es2015-rollup"]
-}


### PR DESCRIPTION
Throwing this out there... I was unable to get fast incremental rebuilds working with rollup (@aaronmars do you know how?). If it's possible I'm happy to stick with it. But I couldn't figure it out, so I replaced rollup with webpack (using `grunt-webpack`).

See the rebuilds in action by running: `grunt webpack:watch`. On my machine, the initial build takes `~8s`, and a rebuild takes `~800ms`. Makes for a much nicer dev experience.

The `watch:scripts` task has been removed in favor of `webpack:watch` (in order to take advantage of webpack's built-in file watching). The task for building _without_ watching is `webpack:build`.
