### PR TITLE
Fix two voice note formatting

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -255,11 +255,11 @@ export class StaveNote extends StemmableNote {
       // See https://github.com/0xfe/vexflow/wiki/Development-Gotchas
       const topNotBottomY = topNote
         .getStave()
-        .getYForLine(Math.abs(5 - topKeys[0].line) + HALF_NOTEHEAD_HEIGHT);
+        .getYForLine(5 - topKeys[0].line + HALF_NOTEHEAD_HEIGHT);
 
       const bottomNoteTopY = bottomNote
         .getStave()
-        .getYForLine(Math.abs(5 - bottomKeys[bottomKeys.length - 1].line) - HALF_NOTEHEAD_HEIGHT);
+        .getYForLine(5 - bottomKeys[bottomKeys.length - 1].line - HALF_NOTEHEAD_HEIGHT);
 
       if (bottomNoteTopY - topNotBottomY <= 0) {
         xShift = topNote.getVoiceShiftWidth();

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -251,8 +251,11 @@ export class StaveNote extends StemmableNote {
       const HALF_NOTEHEAD_HEIGHT = 0.5;
 
       // `keyProps` and `stave.getYForLine` have different notions of a `line`
-      // so we have to convert the keyProps value.
+      // so we have to convert the keyProps value by subtracting 5.
       // See https://github.com/0xfe/vexflow/wiki/Development-Gotchas
+      //
+      // We also extend the y for each note by a half notehead because the
+      // notehead's origin is centered
       const topNotBottomY = topNote
         .getStave()
         .getYForLine(5 - topKeys[0].line + HALF_NOTEHEAD_HEIGHT);

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -264,7 +264,9 @@ export class StaveNote extends StemmableNote {
         .getStave()
         .getYForLine(5 - bottomKeys[bottomKeys.length - 1].line - HALF_NOTEHEAD_HEIGHT);
 
-      if (bottomNoteTopY - topNotBottomY <= 0) {
+      const areNotesColliding = bottomNoteTopY - topNotBottomY < 0;
+
+      if (areNotesColliding) {
         xShift = topNote.getVoiceShiftWidth();
         bottomNote.setXShift(xShift);
       }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -248,11 +248,19 @@ export class StaveNote extends StemmableNote {
       const topKeys = topNote.getKeyProps();
       const bottomKeys = bottomNote.getKeyProps();
 
-      const topY = topNote.getStave().getYForLine(topKeys[0].line);
-      const bottomY = bottomNote.getStave().getYForLine(bottomKeys[bottomKeys.length - 1].line);
+      const HALF_NOTEHEAD_HEIGHT = 0.5;
 
-      const lineSpace = topNote.getStave().options.spacing_between_lines_px;
-      if (Math.abs(topY - bottomY) === lineSpace / 2) {
+      // `keyProps` and `.getYForLine` have different notions of a `line`
+      // so we have to convert the keyProps value
+      const topNotBottomY = topNote
+        .getStave()
+        .getYForLine(Math.abs(5 - topKeys[0].line) + HALF_NOTEHEAD_HEIGHT);
+
+      const bottomNoteTopY = bottomNote
+        .getStave()
+        .getYForLine(Math.abs(5 - bottomKeys[bottomKeys.length - 1].line) - HALF_NOTEHEAD_HEIGHT);
+
+      if (bottomNoteTopY - topNotBottomY <= 0) {
         xShift = topNote.getVoiceShiftWidth();
         bottomNote.setXShift(xShift);
       }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -250,8 +250,9 @@ export class StaveNote extends StemmableNote {
 
       const HALF_NOTEHEAD_HEIGHT = 0.5;
 
-      // `keyProps` and `.getYForLine` have different notions of a `line`
-      // so we have to convert the keyProps value
+      // `keyProps` and `stave.getYForLine` have different notions of a `line`
+      // so we have to convert the keyProps value.
+      // See https://github.com/0xfe/vexflow/wiki/Development-Gotchas
       const topNotBottomY = topNote
         .getStave()
         .getYForLine(Math.abs(5 - topKeys[0].line) + HALF_NOTEHEAD_HEIGHT);

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -331,11 +331,17 @@ VF.Test.Formatter = (function() {
 
       var formatter;
       if (options.params.justify > 0) {
-        formatter = new VF.Formatter().joinVoices( [voice11, voice21, voice31] ).
-          format([voice11, voice21, voice31], options.params.justify);
+        formatter = new VF.Formatter()
+          .joinVoices([voice11])
+          .joinVoices([voice21])
+          .joinVoices([voice31])
+          .format([voice11, voice21, voice31], options.params.justify);
       } else {
-        formatter = new VF.Formatter().joinVoices( [voice11, voice21, voice31] ).
-          format([voice11, voice21, voice31]);
+        formatter = new VF.Formatter()
+          .joinVoices([voice11])
+          .joinVoices([voice21])
+          .joinVoices([voice31])
+          .format([voice11, voice21, voice31]);
       }
 
       for (var i = 0; i < options.params.iterations; i++) {
@@ -395,11 +401,17 @@ VF.Test.Formatter = (function() {
       voice32.addTickables(notes32);
 
       if (options.params.justify > 0) {
-        formatter = new VF.Formatter().joinVoices([voice12, voice22, voice32]).
-          format([voice12, voice22, voice32], 188);
+        formatter = new VF.Formatter()
+          .joinVoices([voice12])
+          .joinVoices([voice22])
+          .joinVoices([voice32])
+          .format([voice12, voice22, voice32], 188);
       } else {
-        formatter = new VF.Formatter().joinVoices([voice12, voice22, voice32]).
-          format([voice12, voice22, voice32]);
+        formatter = new VF.Formatter()
+          .joinVoices([voice12])
+          .joinVoices([voice22])
+          .joinVoices([voice32])
+          .format([voice12, voice22, voice32]);
       }
 
       for (var i = 0; i < options.params.iterations; i++) {
@@ -444,7 +456,7 @@ VF.Test.Formatter = (function() {
       ];
 
       voices.map(newVoice).forEach(newStave);
-      system.addConnector().setType(VF.StaveConnector.type.BRACKET); 
+      system.addConnector().setType(VF.StaveConnector.type.BRACKET);
 
       vf.draw();
       ok(true);

--- a/tests/notesubgroup_tests.js
+++ b/tests/notesubgroup_tests.js
@@ -217,8 +217,10 @@ VF.Test.NoteSubGroup = (function() {
       voice3.addTickables(notes3);
 
       var justifyWidth = stave.getNoteEndX() - stave.getNoteStartX() - 10;
-      var formatter = new VF.Formatter().joinVoices([voice, voice2, voice3]).
-        format([voice, voice2, voice3], justifyWidth);
+      var formatter = new VF.Formatter()
+        .joinVoices([voice, voice2])
+        .joinVoices([voice3])
+        .format([voice, voice2, voice3], justifyWidth);
 
       voice.draw(ctx, stave);
       voice2.draw(ctx, stave);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1631625/17839864/9f474c1c-67ed-11e6-93a7-57e69a07ac9c.png)

The bug is that `keyProps.line` and `stave.getYForLine()` are incompatible -- so we have to convert `keyProps.line`. I wrote about this in the ["Development Gotchas"](https://github.com/0xfe/vexflow/wiki/Development-Gotchas) wiki page.

Worth a look at the diffs.