### PR TITLE
Reference the correct position of vexflow-debug.js

### DIFF
--- a/src/glyphs.html
+++ b/src/glyphs.html
@@ -39,7 +39,7 @@
     }
   </style>
 
-  <script src="../build/vexflow-debug.js"></script>
+  <script src="../releases/vexflow-debug.js"></script>
   <script>
     $(function() {
       var canvas = document.getElementById("glyphs");


### PR DESCRIPTION
The reference needs to be updated for glyphs.html to work out of the box.