### PR TITLE
Ignore both "build" and "build/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 build/
 *.lock
 ruby_sess.*


### PR DESCRIPTION
This is helpful because I often bypass the building process by creating a symlink from build/ to releases/ and it is best if git ignores a symlink (which is a file) just like it ignores a directory.