### PR TITLE
Reset notehead displacements after changing stem direction (Fixes #436)

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -426,6 +426,8 @@ export class StaveNote extends StemmableNote {
 
   // Calculates and stores the properties for each key in the note
   calculateKeyProps() {
+    this.keyProps = [];
+
     let lastLine = null;
     for (let i = 0; i < this.keys.length; ++i) {
       const key = this.keys[i];
@@ -483,6 +485,30 @@ export class StaveNote extends StemmableNote {
       lastLine = key.line;
     });
     this.keyProps.sort((a, b) => a.line - b.line);
+  }
+
+  setStemDirection(direction) {
+    if (!direction) direction = Stem.UP;
+    if (direction !== Stem.UP && direction !== Stem.DOWN) {
+      throw new Vex.RERR('BadArgument', `Invalid stem direction: ${direction}`);
+    }
+
+    this.stem_direction = direction;
+    if (this.stem) {
+      this.stem.setDirection(direction);
+      this.stem.setExtension(this.getStemExtension());
+    }
+
+    this.calculateKeyProps();
+    if (this.flag) this.buildFlag();
+    this.buildNoteHeads();
+
+    this.beam = null;
+    if (this.preFormatted) {
+      this.preFormat();
+    }
+
+    return this;
   }
 
   // Get the `BoundingBox` for the entire note

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -13,6 +13,7 @@ VF.Test.StaveNote = (function() {
       test('Tick - New API', StaveNote.ticksNewApi);
       test('Stem', StaveNote.stem);
       test('Automatic Stem Direction', StaveNote.autoStem);
+      test('Displacement after calling setStemDirection', StaveNote.setStemDirectionDisplacement);
       test('StaveLine', StaveNote.staveLine);
       test('Width', StaveNote.width);
       test('TickContext', StaveNote.tickContext);
@@ -154,6 +155,24 @@ VF.Test.StaveNote = (function() {
         var note = new VF.StaveNote({ keys: keys, auto_stem: true, duration: '8' });
         equal(note.getStemDirection(), expectedStemDirection, 'Stem must be' + (expectedStemDirection === VF.StaveNote.STEM_UP ? 'up' : 'down'));
       });
+    },
+
+    setStemDirectionDisplacement: function() {
+      function getDisplacements(note) {
+        return note.note_heads.map(function(notehead) {
+          return notehead.isDisplaced();
+        })
+      };
+
+      var stemUpDisplacements = [false, true, false];
+      var stemDownDisplacements =  [true, false, false];
+
+      var note = new VF.StaveNote({ keys: ['c/5', 'd/5', 'g/5'], stem_direction: VF.Stem.UP, duration: '4' });
+      deepEqual(getDisplacements(note), stemUpDisplacements);
+      note.setStemDirection(VF.Stem.DOWN);
+      deepEqual(getDisplacements(note), stemDownDisplacements);
+      note.setStemDirection(VF.Stem.UP);
+      deepEqual(getDisplacements(note), stemUpDisplacements);
     },
 
     staveLine: function() {


### PR DESCRIPTION
Related test included. Feel free to close if not necessary.