### PR TITLE
Fix BoundingBox mergeWith function

### DIFF
--- a/src/boundingbox.js
+++ b/src/boundingbox.js
@@ -34,12 +34,8 @@ export class BoundingBox {
 
     const new_x = this.x < that.x ? this.x : that.x;
     const new_y = this.y < that.y ? this.y : that.y;
-    const new_w = (this.x + this.w) < (that.x + that.w)
-      ? (that.x + that.w) - this.x
-      : (this.x + this.w) - Math.min(this.x, that.x);
-    const new_h = (this.y + this.h) < (that.y + that.h)
-      ? (that.y + that.h) - this.y
-      : (this.y + this.h) - Math.min(this.y, that.y);
+    const new_w = Math.max(this.x + this.w, that.x + that.w) - new_x;
+    const new_h = Math.max(this.y + this.h, that.y + that.h) - new_y;
 
     this.x = new_x;
     this.y = new_y;

--- a/tests/boundingbox_tests.js
+++ b/tests/boundingbox_tests.js
@@ -23,17 +23,39 @@ VF.Test.BoundingBox = (function() {
     },
 
     merging: function() {
-      var bb1 = new VF.BoundingBox(10, 10, 10, 10);
-      var bb2 = new VF.BoundingBox(15, 20, 10, 10);
+      var tests = [
+        {
+          type: 'Intersection',
+          bb1: new VF.BoundingBox(10, 10, 10, 10),
+          bb2: new VF.BoundingBox(15, 20, 10, 10),
+          merged: new VF.BoundingBox(10, 10, 15, 20)
+        },
+        {
+          type: '1 contains 2',
+          bb1: new VF.BoundingBox(10, 10, 30, 30),
+          bb2: new VF.BoundingBox(15, 15, 10, 10),
+          merged: new VF.BoundingBox(10, 10, 30, 30)
+        },
+        {
+          type: '2 contains 1',
+          bb1: new VF.BoundingBox(15, 15, 10, 10),
+          bb2: new VF.BoundingBox(10, 10, 30, 30),
+          merged: new VF.BoundingBox(10, 10, 30, 30)
+        }
+      ];
 
-      equal(bb1.getX(), 10, "Bad X for bb1");
-      equal(bb2.getX(), 15, "Bad X for bb2");
+      tests.forEach(function(test) {
+        const type = test.type;
+        const bb1 = test.bb1;
+        const bb2 = test.bb2;
+        const merged = test.merged;
 
-      bb1.mergeWith(bb2);
-      equal(bb1.getX(), 10);
-      equal(bb1.getY(), 10);
-      equal(bb1.getW(), 15);
-      equal(bb1.getH(), 20);
+        bb1.mergeWith(bb2);
+        equal(bb1.getX(), merged.getX(), type + " - Bad X");
+        equal(bb1.getY(), merged.getY(), type + " - Bad Y");
+        equal(bb1.getW(), merged.getW(), type + " - Bad W");
+        equal(bb1.getH(), merged.getH(), type + " - Bad H");
+      });
     }
   };
 


### PR DESCRIPTION
Hi Mohit,

I found a bug which is very simple but obvious, so I fixed and here is the PR.
Current BoundingBox mergeWith function was not working properly for some cases;
Box1 contains Box2 -> error calculating new_w or new_h

Thanks!
Taehoon
