### PR TITLE
Removed unnecessary Array.prototype.slice() call

### DIFF
--- a/src/vex.js
+++ b/src/vex.js
@@ -156,7 +156,7 @@ Vex.StackTrace = () => {
 
 // Dump warning to console.
 Vex.W = (...args) => {
-  const line = Array.prototype.slice.call(args).join(' ');
+  const line = args.join(' ');
   window.console.log('Warning: ', line, Vex.StackTrace());
 };
 


### PR DESCRIPTION
ES6 rest parameter (`...args` in this case) returns a true array, not an "arguments" object, so no need for this indirection
