### PR TITLE
Add TextBracket to Factory; refactor TextBracket tests

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -32,6 +32,7 @@ import { GraceNoteGroup } from './gracenotegroup';
 import { EasyScore } from './easyscore';
 import { ClefNote } from './clefnote';
 import { PedalMarking } from './pedalmarking';
+import { TextBracket } from './textbracket';
 import { TabNote } from './tabnote';
 import { TabStave } from './tabstave';
 
@@ -357,6 +358,33 @@ export class Factory {
     }, params.text).setContext(this.context);
     this.renderQ.push(tie);
     return tie;
+  }
+
+  TextBracket(params) {
+    params = setDefaults(params, {
+      from: null,
+      to: null,
+      text: '',
+      options: {
+        superscript: '',
+        position: 1,
+      },
+    });
+
+    const textBracket = new TextBracket({
+      start: params.from,
+      stop: params.to,
+      text: params.text,
+      superscript: params.options.superscript,
+      position: params.options.position,
+    });
+
+    if (params.options.line) textBracket.setLine(params.options.line);
+    if (params.options.font) textBracket.setFont(params.options.font);
+
+    textBracket.setContext(this.context);
+    this.renderQ.push(textBracket);
+    return textBracket;
   }
 
   System(params = {}) {

--- a/src/modifier.js
+++ b/src/modifier.js
@@ -85,7 +85,7 @@ export class Modifier extends Element {
   getPosition() { return this.position; }
   setPosition(position) {
     this.position = typeof(position) === 'string'
-     ? Modifier.PositionString[position]
+      ? Modifier.PositionString[position]
       : position;
     return this;
   }

--- a/src/textbracket.js
+++ b/src/textbracket.js
@@ -16,6 +16,7 @@ import { Renderer } from './renderer';
 function L(...args) { if (TextBracket.DEBUG) Vex.L('Vex.Flow.TextBracket', args); }
 
 export class TextBracket extends Element {
+  // FIXME: Modifier.Position is singular while this is plural, make consistent
   static get Positions() {
     return {
       TOP: 1,
@@ -23,17 +24,33 @@ export class TextBracket extends Element {
     };
   }
 
-  constructor(bracket_data) {
+  static get PositionString() {
+    return {
+      top: TextBracket.Positions.TOP,
+      bottom: TextBracket.Positions.BOTTOM,
+    };
+  }
+
+  constructor({
+    start,
+    stop,
+    text = '',
+    superscript = '',
+    position = TextBracket.Positions.TOP,
+  }) {
     super();
     this.setAttribute('type', 'TextBracket');
 
-    this.start = bracket_data.start;
-    this.stop = bracket_data.stop;
+    this.start = start;
+    this.stop = stop;
 
-    this.text = bracket_data.text || '';
-    this.superscript = bracket_data.superscript || '';
+    this.text = text;
+    this.superscript = superscript;
 
-    this.position = bracket_data.position || TextBracket.Positions.TOP;
+    this.position = typeof position === 'string'
+      ? TextBracket.PositionString[position]
+      : position;
+
     this.line = 1;
 
     this.font = {
@@ -76,7 +93,11 @@ export class TextBracket extends Element {
   }
 
   // Set the font for the text
-  setFont(font) { this.font = font; return this; }
+  setFont(font) {
+    // We use Object.assign to support partial updates to the font object
+    this.font = Object.assign({}, this.font, font);
+    return this;
+  }
   // Set the rendering `context` for the octave bracket
   setLine(line) { this.line = line; return this; }
 

--- a/tests/textbracket_tests.js
+++ b/tests/textbracket_tests.js
@@ -3,18 +3,6 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
- /*
- eslint-disable
- no-var,
- no-undef,
- wrap-iife,
- func-names,
- vars-on-top,
- max-len,
- object-shorthand,
- prefer-arrow-callback,
-*/
-
 VF.Test.TextBracket = (function() {
   var TextBracket = {
     Start: function() {

--- a/tests/textbracket_tests.js
+++ b/tests/textbracket_tests.js
@@ -3,145 +3,135 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
-VF.Test.TextBracket = (function(){
+ /*
+ eslint-disable
+ no-var,
+ no-undef,
+ wrap-iife,
+ func-names,
+ vars-on-top,
+ max-len,
+ object-shorthand,
+ prefer-arrow-callback,
+*/
+
+VF.Test.TextBracket = (function() {
   var TextBracket = {
     Start: function() {
-      QUnit.module("TextBracket");
-      VF.Test.runTests("Simple TextBracket", VF.Test.TextBracket.simple0);
-      VF.Test.runTests("TextBracket Styles", VF.Test.TextBracket.simple1);
+      QUnit.module('TextBracket');
+      VF.Test.runTests('Simple TextBracket', VF.Test.TextBracket.simple0);
+      VF.Test.runTests('TextBracket Styles', VF.Test.TextBracket.simple1);
     },
 
-    simple0: function(options, contextBuilder) {
-      expect(0);
+    simple0: function(options) {
+      var vf = VF.Test.makeFactory(options, 550);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      options.contextBuilder = contextBuilder;
-      var ctx = new options.contextBuilder(options.canvas_sel, 650, 200);
-      ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = " 10pt Arial";
-      //ctx.translate(0.5, 0.5);
-      var stave = new VF.Stave(10, 40, 550).addTrebleGlyph();
-      stave.setContext(ctx).draw();
+      var notes = score.notes('c4/4, c4, c4, c4, c4', { stem: 'up' });
+      var voice = score.voice(notes, { time: '5/4' });
 
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-
-      var notes = [
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"}
-      ].map(newNote);
-
-      var voice = new VF.Voice(VF.TIME4_4).setStrict(false);
-      voice.addTickables(notes);
-
-      var octave_top = new VF.TextBracket({
-        start: notes[0],
-        stop: notes[3],
-        text: "15",
-        superscript: "va",
-        position: 1
+      vf.TextBracket({
+        from: notes[0],
+        to: notes[4],
+        text: '15',
+        options: {
+          superscript: 'va',
+          position: 'top',
+        },
       });
 
-      var octave_bottom = new VF.TextBracket({
-        start: notes[0],
-        stop: notes[3],
-        text: "8",
-        superscript: "vb",
-        position: -1
+      vf.TextBracket({
+        from: notes[0],
+        to: notes[4],
+        text: '8',
+        options: {
+          superscript: 'vb',
+          position: 'bottom',
+          line: 3,
+        },
       });
 
-      octave_bottom.setLine(3);
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      vf.draw();
 
-      octave_top.setContext(ctx).draw();
-      octave_bottom.setContext(ctx).draw();
+      ok(true);
     },
 
-    simple1: function(options, contextBuilder) {
-      expect(0);
+    simple1: function(options) {
+      var vf = VF.Test.makeFactory(options, 550);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      options.contextBuilder = contextBuilder;
-      var ctx = new options.contextBuilder(options.canvas_sel, 650, 200);
-      ctx.scale(1, 1); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = " 10pt Arial";
-      //ctx.translate(0.5, 0.5);
-      var stave = new VF.Stave(10, 40, 550).addTrebleGlyph();
-      stave.setContext(ctx).draw();
+      var notes = score.notes('c4/4, c4, c4, c4, c4', { stem: 'up' });
+      var voice = score.voice(notes, { time: '5/4' });
 
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
+      const topOctaves = [
+        vf.TextBracket({
+          from: notes[0],
+          to: notes[1],
+          text: 'Cool notes',
+          options: {
+            superscript: '',
+            position: 'top',
+          },
+        }),
+        vf.TextBracket({
+          from: notes[2],
+          to: notes[4],
+          text: 'Testing',
+          options: {
+            position: 'top',
+            superscript: 'superscript',
+            font: { family: 'Arial', size: 15, weight: '' },
+          },
+        }),
+      ];
 
-      var notes = [
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"},
-        {keys: ["c/4"], duration: "4"}
-      ].map(newNote);
+      const bottomOctaves = [
+        vf.TextBracket({
+          from: notes[0],
+          to: notes[1],
+          text: '8',
+          options: {
+            superscript: 'vb',
+            position: 'bottom',
+            line: 3,
+            font: { size: 30 },
+          },
+        }),
+        vf.TextBracket({
+          from: notes[2],
+          to: notes[4],
+          text: 'Not cool notes',
+          options: {
+            superscript: ' super uncool',
+            position: 'bottom',
+            line: 4,
+          },
+        }),
+      ];
 
-      var voice = new VF.Voice(VF.TIME4_4).setStrict(false);
-      voice.addTickables(notes);
+      topOctaves[1].render_options.line_width = 2;
+      topOctaves[1].render_options.show_bracket = false;
 
-      var octave_top0 = new VF.TextBracket({
-        start: notes[0],
-        stop: notes[1],
-        text: "Cool notes",
-        superscript: "",
-        position: 1
-      });
+      bottomOctaves[0].render_options.underline_superscript = false;
+      bottomOctaves[0].setDashed(false);
 
-      var octave_bottom0 = new VF.TextBracket({
-        start: notes[2],
-        stop: notes[4],
-        text: "Not cool notes",
-        superscript: " super uncool",
-        position: -1
-      });
+      bottomOctaves[1].render_options.bracket_height = 40;
+      bottomOctaves[1].setDashed(true, [2, 2]);
 
-      octave_bottom0.render_options.bracket_height = 40;
-      octave_bottom0.setLine(4);
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      var octave_top1 = new VF.TextBracket({
-        start: notes[2],
-        stop: notes[4],
-        text: "Testing",
-        superscript: "superscript",
-        position: 1
-      });
+      vf.draw();
 
-      var octave_bottom1 = new VF.TextBracket({
-        start: notes[0],
-        stop: notes[1],
-        text: "8",
-        superscript: "vb",
-        position: -1
-      });
-
-      octave_top1.render_options.line_width = 2;
-      octave_top1.render_options.show_bracket = false;
-      octave_bottom1.setDashed(true, [2, 2]);
-      octave_top1.setFont({
-        weight: "",
-        family: "Arial",
-        size: 15
-      });
-
-      octave_bottom1.font.size = 30;
-      octave_bottom1.setDashed(false);
-      octave_bottom1.render_options.underline_superscript = false;
-
-      octave_bottom1.setLine(3);
-
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
-
-      octave_top0.setContext(ctx).draw();
-      octave_bottom0.setContext(ctx).draw();
-
-      octave_top1.setContext(ctx).draw();
-      octave_bottom1.setContext(ctx).draw();
-    }
+      ok(true);
+    },
   };
 
   return TextBracket;


### PR DESCRIPTION
Note the destructured `TextBracket` constructor parameters. I'm personally very fond of this pattern (I use it extensively with my React projects since all React components take a single `props` object). Makes default values really convenient without cluttering up the assignments in the body.