### PR TITLE
Refactor StaveTie tests

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -358,7 +358,9 @@ export class Factory {
       first_indices: [0],
       last_indices: [0],
       text: null,
-      options: {},
+      options: {
+        direction: undefined,
+      },
     });
 
     const tie = new StaveTie({
@@ -366,7 +368,10 @@ export class Factory {
       last_note: params.to,
       first_indices: params.first_indices,
       last_indices: params.last_indices,
-    }, params.text).setContext(this.context);
+    }, params.text);
+
+    if (params.options.direction) tie.setDirection(params.options.direction);
+    tie.setContext(this.context);
     this.renderQ.push(tie);
     return tie;
   }

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -23,107 +23,103 @@ function createTest(notesData, setupTies) {
   };
 }
 
-VF.Test.StaveTie = (function() {
-  var StaveTie = {
-    Start: function() {
-      QUnit.module('StaveTie');
-      VF.Test.runModule(this);
-    },
+VF.Test.StaveTie = {
+  Start: function() {
+    QUnit.module('StaveTie');
+    VF.Test.runModule(this);
+  },
 
-    'Simple StaveTie': createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-        });
-      }
-    ),
+  'Simple StaveTie': createTest(
+    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+    function(vf, notes) {
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
+      });
+    }
+  ),
 
-    'Chord StaveTie': createTest(
-      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1, 2],
-          last_indices: [0, 1, 2],
-        });
-      }
-    ),
+  'Chord StaveTie': createTest(
+    ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
+    function(vf, notes) {
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1, 2],
+        last_indices: [0, 1, 2],
+      });
+    }
+  ),
 
-    'Stem Up StaveTie': createTest(
-      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1, 2],
-          last_indices: [0, 1, 2],
-        });
-      }
-    ),
+  'Stem Up StaveTie': createTest(
+    ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
+    function(vf, notes) {
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1, 2],
+        last_indices: [0, 1, 2],
+      });
+    }
+  ),
 
-    'No End Note': createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes, stave) {
-        stave.addEndClef('treble');
-        vf.StaveTie({
-          from: notes[1],
-          to: null,
-          first_indices: [2],
-          last_indices: [2],
-          text: 'slow.',
-        });
-      }
-    ),
+  'No End Note': createTest(
+    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+    function(vf, notes, stave) {
+      stave.addEndClef('treble');
+      vf.StaveTie({
+        from: notes[1],
+        to: null,
+        first_indices: [2],
+        last_indices: [2],
+        text: 'slow.',
+      });
+    }
+  ),
 
-    'No Start Note': createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes, stave) {
-        stave.addClef('treble');
-        vf.StaveTie({
-          from: null,
-          to: notes[0],
-          first_indices: [2],
-          last_indices: [2],
-          text: 'H',
-        });
-      }
-    ),
+  'No Start Note': createTest(
+    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+    function(vf, notes, stave) {
+      stave.addClef('treble');
+      vf.StaveTie({
+        from: null,
+        to: notes[0],
+        first_indices: [2],
+        last_indices: [2],
+        text: 'H',
+      });
+    }
+  ),
 
-    'Set Direction Down': createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-          options: {
-            direction: VF.Stem.DOWN,
-          },
-        });
-      }
-    ),
+  'Set Direction Down': createTest(
+    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+    function(vf, notes) {
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
+        options: {
+          direction: VF.Stem.DOWN,
+        },
+      });
+    }
+  ),
 
-    'Set Direction Up': createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-          options: {
-            direction: VF.Stem.UP,
-          },
-        });
-      }
-    ),
-  };
-
-  return StaveTie;
-})();
+  'Set Direction Up': createTest(
+    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+    function(vf, notes) {
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
+        options: {
+          direction: VF.Stem.UP,
+        },
+      });
+    }
+  ),
+};

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -3,124 +3,126 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
-function createTest(notesData, setupTies) {
-  return function(options) {
-    var vf = VF.Test.makeFactory(options, 300);
-    var stave = vf.Stave();
-    var score = vf.EasyScore();
-    var voice = score.voice(score.notes.apply(score, notesData));
-    var notes = voice.getTickables();
+VF.Test.StaveTie = (function() {
+  function createTest(notesData, setupTies) {
+    return function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
+      var voice = score.voice(score.notes.apply(score, notesData));
+      var notes = voice.getTickables();
 
-    setupTies(vf, notes, stave);
+      setupTies(vf, notes, stave);
 
-    vf.Formatter()
-      .joinVoices([voice])
-      .formatToStave([voice], stave);
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-    vf.draw();
+      vf.draw();
 
-    ok(true);
+      ok(true);
+    };
+  }
+
+  return {
+    Start: function() {
+      var run = VF.Test.runTests;
+
+      QUnit.module('StaveTie');
+
+      run('Simple StaveTie', createTest(
+        ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+        function(vf, notes) {
+          vf.StaveTie({
+            from: notes[0],
+            to: notes[1],
+            first_indices: [0, 1],
+            last_indices: [0, 1],
+          });
+        }
+      ));
+
+      run('Chord StaveTie', createTest(
+        ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
+        function(vf, notes) {
+          vf.StaveTie({
+            from: notes[0],
+            to: notes[1],
+            first_indices: [0, 1, 2],
+            last_indices: [0, 1, 2],
+          });
+        }
+      ));
+
+      run('Stem Up StaveTie', createTest(
+        ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
+        function(vf, notes) {
+          vf.StaveTie({
+            from: notes[0],
+            to: notes[1],
+            first_indices: [0, 1, 2],
+            last_indices: [0, 1, 2],
+          });
+        }
+      ));
+
+      run('No End Note', createTest(
+        ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+        function(vf, notes, stave) {
+          stave.addEndClef('treble');
+          vf.StaveTie({
+            from: notes[1],
+            to: null,
+            first_indices: [2],
+            last_indices: [2],
+            text: 'slow.',
+          });
+        }
+      ));
+
+      run('No Start Note', createTest(
+        ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+        function(vf, notes, stave) {
+          stave.addClef('treble');
+          vf.StaveTie({
+            from: null,
+            to: notes[0],
+            first_indices: [2],
+            last_indices: [2],
+            text: 'H',
+          })
+        }
+      ));
+
+      run('Set Direction Down', createTest(
+        ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+        function(vf, notes) {
+          vf.StaveTie({
+            from: notes[0],
+            to: notes[1],
+            first_indices: [0, 1],
+            last_indices: [0, 1],
+            options: {
+              direction: VF.Stem.DOWN,
+            },
+          });
+        }
+      ));
+
+      run('Set Direction Up', createTest(
+        ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+        function(vf, notes) {
+          vf.StaveTie({
+            from: notes[0],
+            to: notes[1],
+            first_indices: [0, 1],
+            last_indices: [0, 1],
+            options: {
+              direction: VF.Stem.UP,
+            },
+          });
+        }
+      ));
+    },
   };
-}
-
-VF.Test.StaveTie = {
-  Start: function() {
-    var run = VF.Test.runTests;
-
-    QUnit.module('StaveTie');
-
-    run('Simple StaveTie', createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-        });
-      }
-    ));
-
-    run('Chord StaveTie', createTest(
-      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1, 2],
-          last_indices: [0, 1, 2],
-        });
-      }
-    ));
-
-    run('Stem Up StaveTie', createTest(
-      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1, 2],
-          last_indices: [0, 1, 2],
-        });
-      }
-    ));
-
-    run('No End Note', createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes, stave) {
-        stave.addEndClef('treble');
-        vf.StaveTie({
-          from: notes[1],
-          to: null,
-          first_indices: [2],
-          last_indices: [2],
-          text: 'slow.',
-        });
-      }
-    ));
-
-    run('No Start Note', createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes, stave) {
-        stave.addClef('treble');
-        vf.StaveTie({
-          from: null,
-          to: notes[0],
-          first_indices: [2],
-          last_indices: [2],
-          text: 'H',
-        })
-      }
-    ));
-
-    run('Set Direction Down', createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-          options: {
-            direction: VF.Stem.DOWN,
-          },
-        });
-      }
-    ));
-
-    run('Set Direction Up', createTest(
-      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-      function(vf, notes) {
-        vf.StaveTie({
-          from: notes[0],
-          to: notes[1],
-          first_indices: [0, 1],
-          last_indices: [0, 1],
-          options: {
-            direction: VF.Stem.UP,
-          },
-        });
-      }
-    ));
-  },
-};
+}());

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -8,189 +8,212 @@ VF.Test.StaveTie = (function() {
     Start: function() {
       var runTests = VF.Test.runTests;
 
-      QUnit.module("StaveTie");
-      runTests("Simple StaveTie", StaveTie.simple);
-      runTests("Chord StaveTie", StaveTie.chord);
-      runTests("Stem Up StaveTie", StaveTie.stemUp);
-      runTests("No End Note", StaveTie.noEndNote);
-      runTests("No Start Note", StaveTie.noStartNote);
-      runTests("Set Direction Down", StaveTie.setDirectionDown);
-      runTests("Set Direction Up", StaveTie.setDirectionUp);
-
+      QUnit.module('StaveTie');
+      runTests('Simple StaveTie', StaveTie.simple);
+      runTests('Chord StaveTie', StaveTie.chord);
+      runTests('Stem Up StaveTie', StaveTie.stemUp);
+      runTests('No End Note', StaveTie.noEndNote);
+      runTests('No Start Note', StaveTie.noStartNote);
+      runTests('Set Direction Down', StaveTie.setDirectionDown);
+      runTests('Set Direction Up', StaveTie.setDirectionUp);
     },
 
-    tieNotes: function(notes, indices, stave, ctx, direction) {
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
+    simple: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      var formatter = new VF.Formatter().joinVoices([voice]).
-        format([voice], 250);
-      voice.draw(ctx, stave);
+      var voice = score.voice(score.notes(
+        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
+      ));
 
-      var tie = new VF.StaveTie({
-        first_note: notes[0],
-        last_note: notes[1],
-        first_indices: indices,
-        last_indices: indices,
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
       });
 
-      tie.setContext(ctx);
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      if(direction !== undefined && direction !== null){
-        tie.setDirection(direction);
-      }
+      vf.draw();
 
-      tie.draw();
+      ok(true, 'Simple Test');
     },
 
-    drawTie: function(notes, indices, options) {
-      var ctx = new options.contextBuilder(options.canvas_sel, 350, 140);
+    chord: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      var stave = new VF.Stave(10, 10, 350).setContext(ctx).draw();
+      var voice = score.voice(score.notes(
+        '(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' })
+      );
 
-      VF.Test.StaveTie.tieNotes(notes, indices, stave, ctx, options['direction']);
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1, 2],
+        last_indices: [0, 1, 2],
+      });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'Chord test');
     },
 
-    simple: function(options, contextBuilder) {
-      options.contextBuilder = contextBuilder;
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    stemUp: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      VF.Test.StaveTie.drawTie([
-        newNote({ keys: ["c/4", "e/4", "a/4"], stem_direction: -1, duration: "h"}).
-          addAccidental(0, newAcc("b")).
-          addAccidental(1, newAcc("#")),
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"})
-      ], [0, 1], options);
-      ok(true, "Simple Test");
+      var voice = score.voice(score.notes(
+        '(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' })
+      );
+
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1, 2],
+        last_indices: [0, 1, 2],
+      });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'Stem up test');
     },
 
-    chord: function(options, contextBuilder) {
-      options.contextBuilder = contextBuilder;
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    noEndNote: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave().addEndClef('treble');
+      var score = vf.EasyScore();
 
-      VF.Test.StaveTie.drawTie([
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"}),
-        newNote({ keys: ["c/4", "f/4", "a/4"], stem_direction: -1, duration: "h"}).
-          addAccidental(0, newAcc("n")).
-          addAccidental(1, newAcc("#")),
-      ], [0, 1, 2], options);
-      ok(true, "Chord test");
-    },
+      var voice = score.voice(score.notes(
+        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
+      ));
 
-    stemUp: function(options, contextBuilder) {
-      options.contextBuilder = contextBuilder;
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+      var notes = voice.getTickables();
 
-      VF.Test.StaveTie.drawTie([
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: 1, duration: "h"}),
-        newNote({ keys: ["c/4", "f/4", "a/4"], stem_direction: 1, duration: "h"}).
-          addAccidental(0, newAcc("n")).
-          addAccidental(1, newAcc("#")),
-      ], [0, 1, 2], options);
-      ok(true, "Stem up test");
-    },
-
-    noEndNote: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 350, 140);
-      ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = "10pt Arial";
-      var stave = new VF.Stave(10, 10, 350).setContext(ctx).draw();
-
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-
-      var notes = [
-        newNote({ keys: ["c/4", "e/4", "a/4"], stem_direction: -1, duration: "h"}).
-          addAccidental(0, newAcc("b")).
-          addAccidental(1, newAcc("#")),
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"})
-      ];
-
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-
-      var formatter = new VF.Formatter().joinVoices([voice]).
-        format([voice], 250);
-      voice.draw(ctx, stave);
-
-      var tie = new VF.StaveTie({
-        first_note: notes[1],
-        last_note: null,
-        first_indices: [2],
-        last_indices: [2]
-      }, "slow.").setContext(ctx).draw();
-
-      ok(true, "No end note");
-    },
-
-    noStartNote: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 350, 140);
-      ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = "10pt Arial";
-      var stave = new VF.Stave(10, 10, 350).addTrebleGlyph().
-        setContext(ctx).draw();
-
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-
-      var notes = [
-        newNote({ keys: ["c/4", "e/4", "a/4"], stem_direction: -1, duration: "h"}).
-          addAccidental(0, newAcc("b")).
-          addAccidental(1, newAcc("#")),
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"})
-      ];
-
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-
-      var formatter = new VF.Formatter().joinVoices([voice]).
-        format([voice], 250);
-      voice.draw(ctx, stave);
-
-      var tie = new VF.StaveTie({
-        first_note: null,
-        last_note: notes[0],
+      vf.StaveTie({
+        from: notes[1],
+        to: null,
         first_indices: [2],
         last_indices: [2],
-      }, "H").setContext(ctx).draw();
+        text: 'slow.',
+      });
 
-      ok(true, "No end note");
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'No end note');
     },
 
-    setDirectionDown: function(options, contextBuilder){
-      options.contextBuilder = contextBuilder;
-      options.direction = Vex.Flow.Stem.DOWN;
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    noStartNote: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave().addClef('treble');
+      var score = vf.EasyScore();
 
-      VF.Test.StaveTie.drawTie([
-        newNote({ keys: ["c/4", "e/4", "a/4"], stem_direction: -1, duration: "h"}).
-            addAccidental(0, newAcc("b")).
-            addAccidental(1, newAcc("#")),
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"})
-      ], [0, 1], options);
-      ok(true, "Set Direction Down");
+      var voice = score.voice(score.notes(
+        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
+      ));
+
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: null,
+        to: notes[0],
+        first_indices: [2],
+        last_indices: [2],
+        text: 'H',
+      });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'No end note');
     },
 
-    setDirectionUp: function(options, contextBuilder){
-      options.contextBuilder = contextBuilder;
-      options.direction = Vex.Flow.Stem.UP;
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    setDirectionDown: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
 
-      VF.Test.StaveTie.drawTie([
-        newNote({ keys: ["c/4", "e/4", "a/4"], stem_direction: -1, duration: "h"}).
-            addAccidental(0, newAcc("b")).
-            addAccidental(1, newAcc("#")),
-        newNote({ keys: ["d/4", "e/4", "f/4"], stem_direction: -1, duration: "h"})
-      ], [0, 1], options);
-      ok(true, "Set Direction Down");
-    }
+      var voice = score.voice(score.notes(
+        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
+      ));
 
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
+        options: {
+          direction: Vex.Flow.Stem.DOWN,
+        },
+      });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'Set Direction Down');
+    },
+
+    setDirectionUp: function(options) {
+      var vf = VF.Test.makeFactory(options, 300);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
+
+      var voice = score.voice(score.notes(
+        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
+      ));
+
+      var notes = voice.getTickables();
+
+      vf.StaveTie({
+        from: notes[0],
+        to: notes[1],
+        first_indices: [0, 1],
+        last_indices: [0, 1],
+        options: {
+          direction: Vex.Flow.Stem.UP,
+        },
+      });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'Set Direction Down');
+    },
   };
 
   return StaveTie;

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -3,6 +3,26 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
+function createTest(notesData, setupTies) {
+  return function(options) {
+    var vf = VF.Test.makeFactory(options, 300);
+    var stave = vf.Stave();
+    var score = vf.EasyScore();
+    var voice = score.voice(score.notes.apply(score, notesData));
+    var notes = voice.getTickables();
+
+    setupTies(vf, notes, stave);
+
+    vf.Formatter()
+      .joinVoices([voice])
+      .formatToStave([voice], stave);
+
+    vf.draw();
+
+    ok(true);
+  };
+}
+
 VF.Test.StaveTie = (function() {
   var StaveTie = {
     Start: function() {
@@ -18,202 +38,99 @@ VF.Test.StaveTie = (function() {
       runTests('Set Direction Up', StaveTie.setDirectionUp);
     },
 
-    simple: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave();
-      var score = vf.EasyScore();
+    simple: createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+        });
+      }
+    ),
 
-      var voice = score.voice(score.notes(
-        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
-      ));
+    chord: createTest(
+      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1, 2],
+          last_indices: [0, 1, 2],
+        });
+      }
+    ),
 
-      var notes = voice.getTickables();
+    stemUp: createTest(
+      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1, 2],
+          last_indices: [0, 1, 2],
+        });
+      }
+    ),
 
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-      });
+    noEndNote: createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes, stave) {
+        stave.addEndClef('treble');
+        vf.StaveTie({
+          from: notes[1],
+          to: null,
+          first_indices: [2],
+          last_indices: [2],
+          text: 'slow.',
+        });
+      }
+    ),
 
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
+    noStartNote: createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes, stave) {
+        stave.addClef('treble');
+        vf.StaveTie({
+          from: null,
+          to: notes[0],
+          first_indices: [2],
+          last_indices: [2],
+          text: 'H',
+        });
+      }
+    ),
 
-      vf.draw();
+    setDirectionDown: createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+          options: {
+            direction: Vex.Flow.Stem.DOWN,
+          },
+        });
+      }
+    ),
 
-      ok(true, 'Simple Test');
-    },
-
-    chord: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave();
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' })
-      );
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1, 2],
-        last_indices: [0, 1, 2],
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'Chord test');
-    },
-
-    stemUp: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave();
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' })
-      );
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1, 2],
-        last_indices: [0, 1, 2],
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'Stem up test');
-    },
-
-    noEndNote: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave().addEndClef('treble');
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
-      ));
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: notes[1],
-        to: null,
-        first_indices: [2],
-        last_indices: [2],
-        text: 'slow.',
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'No end note');
-    },
-
-    noStartNote: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave().addClef('treble');
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
-      ));
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: null,
-        to: notes[0],
-        first_indices: [2],
-        last_indices: [2],
-        text: 'H',
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'No end note');
-    },
-
-    setDirectionDown: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave();
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
-      ));
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-        options: {
-          direction: Vex.Flow.Stem.DOWN,
-        },
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'Set Direction Down');
-    },
-
-    setDirectionUp: function(options) {
-      var vf = VF.Test.makeFactory(options, 300);
-      var stave = vf.Stave();
-      var score = vf.EasyScore();
-
-      var voice = score.voice(score.notes(
-        '(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }
-      ));
-
-      var notes = voice.getTickables();
-
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-        options: {
-          direction: Vex.Flow.Stem.UP,
-        },
-      });
-
-      vf.Formatter()
-        .joinVoices([voice])
-        .formatToStave([voice], stave);
-
-      vf.draw();
-
-      ok(true, 'Set Direction Down');
-    },
+    setDirectionUp: createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+          options: {
+            direction: Vex.Flow.Stem.UP,
+          },
+        });
+      }
+    ),
   };
 
   return StaveTie;

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -26,19 +26,11 @@ function createTest(notesData, setupTies) {
 VF.Test.StaveTie = (function() {
   var StaveTie = {
     Start: function() {
-      var runTests = VF.Test.runTests;
-
       QUnit.module('StaveTie');
-      runTests('Simple StaveTie', StaveTie.simple);
-      runTests('Chord StaveTie', StaveTie.chord);
-      runTests('Stem Up StaveTie', StaveTie.stemUp);
-      runTests('No End Note', StaveTie.noEndNote);
-      runTests('No Start Note', StaveTie.noStartNote);
-      runTests('Set Direction Down', StaveTie.setDirectionDown);
-      runTests('Set Direction Up', StaveTie.setDirectionUp);
+      VF.Test.runModule(this);
     },
 
-    simple: createTest(
+    'Simple StaveTie': createTest(
       ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
       function(vf, notes) {
         vf.StaveTie({
@@ -50,7 +42,7 @@ VF.Test.StaveTie = (function() {
       }
     ),
 
-    chord: createTest(
+    'Chord StaveTie': createTest(
       ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
       function(vf, notes) {
         vf.StaveTie({
@@ -62,7 +54,7 @@ VF.Test.StaveTie = (function() {
       }
     ),
 
-    stemUp: createTest(
+    'Stem Up StaveTie': createTest(
       ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
       function(vf, notes) {
         vf.StaveTie({
@@ -74,7 +66,7 @@ VF.Test.StaveTie = (function() {
       }
     ),
 
-    noEndNote: createTest(
+    'No End Note': createTest(
       ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
       function(vf, notes, stave) {
         stave.addEndClef('treble');
@@ -88,7 +80,7 @@ VF.Test.StaveTie = (function() {
       }
     ),
 
-    noStartNote: createTest(
+    'No Start Note': createTest(
       ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
       function(vf, notes, stave) {
         stave.addClef('treble');
@@ -102,7 +94,7 @@ VF.Test.StaveTie = (function() {
       }
     ),
 
-    setDirectionDown: createTest(
+    'Set Direction Down': createTest(
       ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
       function(vf, notes) {
         vf.StaveTie({
@@ -111,13 +103,13 @@ VF.Test.StaveTie = (function() {
           first_indices: [0, 1],
           last_indices: [0, 1],
           options: {
-            direction: Vex.Flow.Stem.DOWN,
+            direction: VF.Stem.DOWN,
           },
         });
       }
     ),
 
-    setDirectionUp: createTest(
+    'Set Direction Up': createTest(
       ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
       function(vf, notes) {
         vf.StaveTie({
@@ -126,7 +118,7 @@ VF.Test.StaveTie = (function() {
           first_indices: [0, 1],
           last_indices: [0, 1],
           options: {
-            direction: Vex.Flow.Stem.UP,
+            direction: VF.Stem.UP,
           },
         });
       }

--- a/tests/stavetie_tests.js
+++ b/tests/stavetie_tests.js
@@ -25,101 +25,102 @@ function createTest(notesData, setupTies) {
 
 VF.Test.StaveTie = {
   Start: function() {
+    var run = VF.Test.runTests;
+
     QUnit.module('StaveTie');
-    VF.Test.runModule(this);
+
+    run('Simple StaveTie', createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+        });
+      }
+    ));
+
+    run('Chord StaveTie', createTest(
+      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1, 2],
+          last_indices: [0, 1, 2],
+        });
+      }
+    ));
+
+    run('Stem Up StaveTie', createTest(
+      ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1, 2],
+          last_indices: [0, 1, 2],
+        });
+      }
+    ));
+
+    run('No End Note', createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes, stave) {
+        stave.addEndClef('treble');
+        vf.StaveTie({
+          from: notes[1],
+          to: null,
+          first_indices: [2],
+          last_indices: [2],
+          text: 'slow.',
+        });
+      }
+    ));
+
+    run('No Start Note', createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes, stave) {
+        stave.addClef('treble');
+        vf.StaveTie({
+          from: null,
+          to: notes[0],
+          first_indices: [2],
+          last_indices: [2],
+          text: 'H',
+        })
+      }
+    ));
+
+    run('Set Direction Down', createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+          options: {
+            direction: VF.Stem.DOWN,
+          },
+        });
+      }
+    ));
+
+    run('Set Direction Up', createTest(
+      ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
+      function(vf, notes) {
+        vf.StaveTie({
+          from: notes[0],
+          to: notes[1],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+          options: {
+            direction: VF.Stem.UP,
+          },
+        });
+      }
+    ));
   },
-
-  'Simple StaveTie': createTest(
-    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-    function(vf, notes) {
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-      });
-    }
-  ),
-
-  'Chord StaveTie': createTest(
-    ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'down' }],
-    function(vf, notes) {
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1, 2],
-        last_indices: [0, 1, 2],
-      });
-    }
-  ),
-
-  'Stem Up StaveTie': createTest(
-    ['(d4 e4 f4)/2, (cn4 f#4 a4)', { stem: 'up' }],
-    function(vf, notes) {
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1, 2],
-        last_indices: [0, 1, 2],
-      });
-    }
-  ),
-
-  'No End Note': createTest(
-    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-    function(vf, notes, stave) {
-      stave.addEndClef('treble');
-      vf.StaveTie({
-        from: notes[1],
-        to: null,
-        first_indices: [2],
-        last_indices: [2],
-        text: 'slow.',
-      });
-    }
-  ),
-
-  'No Start Note': createTest(
-    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-    function(vf, notes, stave) {
-      stave.addClef('treble');
-      vf.StaveTie({
-        from: null,
-        to: notes[0],
-        first_indices: [2],
-        last_indices: [2],
-        text: 'H',
-      });
-    }
-  ),
-
-  'Set Direction Down': createTest(
-    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-    function(vf, notes) {
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-        options: {
-          direction: VF.Stem.DOWN,
-        },
-      });
-    }
-  ),
-
-  'Set Direction Up': createTest(
-    ['(cb4 e#4 a4)/2, (d4 e4 f4)', { stem: 'down' }],
-    function(vf, notes) {
-      vf.StaveTie({
-        from: notes[0],
-        to: notes[1],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-        options: {
-          direction: VF.Stem.UP,
-        },
-      });
-    }
-  ),
 };

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -244,7 +244,10 @@ VF.Test = (function() {
     runModule: function(module) {
       for (var testName in module) {
         if (testName !== 'Start' && {}.hasOwnProperty.call(module, testName)) {
-          VF.Test.runTests(testName, module[testName]);
+          var test = module[testName];
+          if (typeof test === 'function') {
+            VF.Test.runTests(testName, test);
+          }
         }
       }
     }

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -240,17 +240,6 @@ VF.Test = (function() {
     almostEqual: function(value, expectedValue, errorMargin) {
       return equal(Math.abs(value - expectedValue) < errorMargin, true);
     },
-
-    runModule: function(module) {
-      for (var testName in module) {
-        if (testName !== 'Start' && {}.hasOwnProperty.call(module, testName)) {
-          var test = module[testName];
-          if (typeof test === 'function') {
-            VF.Test.runTests(testName, test);
-          }
-        }
-      }
-    }
   };
 
   Test.genID.ID = 0;

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -239,6 +239,14 @@ VF.Test = (function() {
 
     almostEqual: function(value, expectedValue, errorMargin) {
       return equal(Math.abs(value - expectedValue) < errorMargin, true);
+    },
+
+    runModule: function(module) {
+      for (var testName in module) {
+        if (testName !== 'Start' && {}.hasOwnProperty.call(module, testName)) {
+          VF.Test.runTests(testName, module[testName]);
+        }
+      }
     }
   };
 


### PR DESCRIPTION
~So I really got a little more experimental... but I think this managed to reduce boilerplate really clearly and isolates the parts being tested.~

~I've always found the string+test mapping in each `Start` function to be pretty annoying. So I got rid of it and rely on iteration through the keys using a `runModule` test helper.~

~Definitely looking for feedback on this!~

Also bug https://github.com/0xfe/vexflow/issues/489 was found during the course of this refactor.