### PR TITLE
Reset noteheads when `StaveNote#setKeyLine` is called; Refactor threevoice_tests.js;

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -57,7 +57,21 @@ export class StaveNote extends StemmableNote {
   static format(notes, state) {
     if (!notes || notes.length < 2) return false;
 
-    if (notes[0].getStave() != null) return StaveNote.formatByY(notes, state);
+    // FIXME: VexFlow will soon require that a stave be set before formatting.
+    // Which, according to the below condition, means that following branch will
+    // always be taken and the rest of this function is dead code.
+    //
+    // Problematically, `Formatter#formatByY` was not designed to work for more
+    // than 2 voices (although, doesn't throw on this condition, just tries
+    // to power through).
+    //
+    // Based on the above:
+    //   * 2 voices can be formatted *with or without* a stave being set but
+    //     the output will be different
+    //   * 3 voices can only be formatted *without* a stave
+    if (notes[0].getStave()) {
+      return StaveNote.formatByY(notes, state);
+    }
 
     const notesList = [];
 
@@ -725,6 +739,7 @@ export class StaveNote extends StemmableNote {
   setKeyLine(index, line) {
     this.keyProps[index].line = line;
     this.note_heads[index].setLine(line);
+    this.reset();
     return this;
   }
 

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -281,7 +281,7 @@ export class StaveNote extends StemmableNote {
       const areNotesColliding = bottomNoteTopY - topNotBottomY < 0;
 
       if (areNotesColliding) {
-        xShift = topNote.getVoiceShiftWidth();
+        xShift = topNote.getVoiceShiftWidth() + 2;
         bottomNote.setXShift(xShift);
       }
     }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -738,7 +738,6 @@ export class StaveNote extends StemmableNote {
 
   setKeyLine(index, line) {
     this.keyProps[index].line = line;
-    this.note_heads[index].setLine(line);
     this.reset();
     return this;
   }

--- a/tests/threevoice_tests.js
+++ b/tests/threevoice_tests.js
@@ -3,594 +3,241 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
+ /*
+ eslint-disable
+ no-var,
+ no-undef,
+ wrap-iife,
+ func-names,
+ vars-on-top,
+ max-len,
+ object-shorthand,
+ prefer-arrow-callback,
+  */
+
 VF.Test.ThreeVoices = (function() {
+  function concat(a, b) { return a.concat(b); }
+
+  function createThreeVoicesTest(noteGroup1, noteGroup2, noteGroup3, setup) {
+    return function(options) {
+      var vf = VF.Test.makeFactory(options, 600, 200);
+      var stave = vf.Stave().addTrebleGlyph().addTimeSignature('4/4');
+      var score = vf.EasyScore();
+
+      var noteGroups = [noteGroup1, noteGroup2, noteGroup3].map(function(noteGroup) {
+        return score.notes.apply(score, noteGroup);
+      });
+
+      var voices = noteGroups.map(score.voice.bind(score));
+
+      setup(vf, voices);
+
+      var beams = [
+        VF.Beam.applyAndGetBeams(voices[0], 1),
+        VF.Beam.applyAndGetBeams(voices[1], -1),
+        VF.Beam.applyAndGetBeams(voices[2], -1),
+      ].reduce(concat);
+
+      // Set option to position rests near the notes in each voice
+      vf.Formatter()
+        .joinVoices(voices)
+        .formatToStave(voices, stave);
+
+      vf.draw();
+
+      for (var i = 0; i < beams.length; i++) {
+        beams[i].setContext(vf.getContext()).draw();
+      }
+
+      ok(true, 'Three Voices - Test #2 Complex');
+    };
+  }
+
   var ThreeVoices = {
     Start: function() {
-      var runTests = VF.Test.runTests;
-      QUnit.module("Three Voice Rests");
-      runTests("Three Voices - #1", ThreeVoices.threevoices);
-      runTests("Three Voices - #2 Complex", ThreeVoices.threevoices2);
-      runTests("Three Voices - #3", ThreeVoices.threevoices3);
-      runTests("Auto Adjust Rest Positions - Two Voices", ThreeVoices.autoresttwovoices);
-      runTests("Auto Adjust Rest Positions - Three Voices #1", ThreeVoices.autorestthreevoices);
-      runTests("Auto Adjust Rest Positions - Three Voices #2", ThreeVoices.autorestthreevoices2);
+      var run = VF.Test.runTests;
+
+      QUnit.module('Multiple Voices');
+
+      run('Three Voices - #1', createThreeVoicesTest(
+        ['e5/2, e5', { stem: 'up' }],
+        ['(d4 a4 d#5)/8, b4, (d4 a4 c5), b4, (d4 a4 c5), b4, (d4 a4 c5), b4', { stem: 'down' }],
+        ['b3/4, e3, f3, a3', { stem: 'down' }],
+        function(vf, voices) {
+          voices[0]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '0', position: 'left' }));
+
+          voices[1]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '0', position: 'left' }))
+            .addModifier(1, vf.Fingering({ number: '4', position: 'left' }));
+        }
+      ));
+
+      run('Three Voices - #2 Complex', createThreeVoicesTest(
+        ['(a4 e5)/16, e5, e5, e5, e5/8, e5, e5/2', { stem: 'up' }],
+        ['(d4 d#5)/16, (b4 c5), d5, e5, (d4 a4 c5)/8, b4, (d4 a4 c5), b4, (d4 a4 c5), b4', { stem: 'down' }],
+        ['b3/8, b3, e3/4, f3, a3', { stem: 'down' }],
+        function(vf, voices) {
+          voices[0]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '2', position: 'left' }))
+            .addModifier(1, vf.Fingering({ number: '0', position: 'above' }));
+
+          voices[1]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '0', position: 'left' }))
+            .addModifier(1, vf.Fingering({ number: '4', position: 'left' }));
+        }
+      ));
+
+      run('Three Voices - #3', createThreeVoicesTest(
+        ['(g4 e5)/4, e5, (g4 e5)/2', { stem: 'up' }],
+        ['c#5/4, b4/8, b4/8/r, a4/4., g4/8', { stem: 'down' }],
+        ['c4/4, b3, a3, g3', { stem: 'down' }],
+        function(vf, voices) {
+          voices[0]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '0', position: 'left' }))
+            .addModifier(1, vf.Fingering({ number: '0', position: 'left' }));
+
+          voices[1]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '1', position: 'left' }));
+
+          voices[2]
+            .getTickables()[0]
+            .addModifier(0, vf.Fingering({ number: '3', position: 'left' }));
+        }
+      ));
+
+      run('Auto Adjust Rest Positions - Two Voices', ThreeVoices.autoRestTwoVoices);
+      run('Auto Adjust Rest Positions - Three Voices #1', ThreeVoices.autorestthreevoices);
+      run('Auto Adjust Rest Positions - Three Voices #2', ThreeVoices.autorestthreevoices2);
     },
 
-    setupContext: function(options, x, y) {
-      VF.Test.resizeCanvas(options.canvas_sel, x || 350, y || 150);
-      var ctx = Vex.getCanvasContext(options.canvas_sel);
-      ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = " 10pt Arial";
-      var stave = new VF.Stave(10, 30, x || 350).addTrebleGlyph().
-        setContext(ctx).draw();
+    autoRestTwoVoices: function(options) {
+      var vf = VF.Test.makeFactory(options, 900, 200);
+      var score = vf.EasyScore();
+      var x = 10;
 
-      return {context: ctx, stave: stave};
-    },
+      var beams = [];
 
-    threevoices: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 600, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
+      function createMeasure(measureTitle, width, alignRests) {
+        var stave = vf.Stave({ x: x, y: 50, width: width }).setBegBarType(1);
+        x += width;
 
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.draw();
+        var voices = [
+          score.notes(
+            'b4/8/r, e5/16, b4/r, b4/8/r, e5/16, b4/r, b4/8/r, d5/16, b4/r, e5/4',
+            { stem: 'up' }
+          ),
+          score.notes(
+            'c5/16, c4, b4/r, d4, e4, f4, b4/r, g4, g4[stem="up"], a4[stem="up"], b4/r, b4[stem="up"], e4/4',
+            { stem: 'down' }
+          ),
+          [vf.TextNote({ text: measureTitle, line: -1, duration: '1', smooth: true })],
+        ].map(score.voice.bind(score));
 
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.addTimeSignature("4/4");
-      stave.draw();
+        beams = beams
+          .concat(VF.Beam.applyAndGetBeams(voices[0], 1))
+          .concat(VF.Beam.applyAndGetBeams(voices[1], -1));
 
-      var notes = [
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "h"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "h"}),
-      ];
-      notes[0].
-        addModifier(0, newFinger("0", VF.Modifier.Position.LEFT));
-
-      var notes1 = [
-        newNote({ keys: ["d/4", "a/4", "d/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: 1, duration: "8"}),
-      ];
-      notes1[0].addAccidental(2, new VF.Accidental("#")).
-                addModifier(0, newFinger("0", VF.Modifier.Position.LEFT)).
-                addModifier(1, newFinger("2", VF.Modifier.Position.LEFT)).
-                addModifier(2, newFinger("4", VF.Modifier.Position.RIGHT));
-
-      var notes2 = [
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "q"}),
-
-        newNote({ keys: ["f/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["a/3"], stem_direction: -1, duration: "q"}),
-      ];
-
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice1 = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-      voice1.addTickables(notes1);
-      voice2.addTickables(notes2);
-      var beam = VF.Beam.applyAndGetBeams(voice, 1);
-      var beam1 = VF.Beam.applyAndGetBeams(voice1, -1);
-      var beam2 = VF.Beam.applyAndGetBeams(voice2, -1);
-
-      // Set option to position rests near the notes in each voice
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2]).
-        format([voice, voice1, voice2], 400);
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      for (var i = 0; i < beam.length; i++)
-        beam[i].setContext(c).draw();
-      for (var i = 0; i < beam1.length; i++)
-        beam1[i].setContext(c).draw();
-      for (var i = 0; i < beam2.length; i++)
-        beam2[i].setContext(c).draw();
-
-      ok(true, "Three Voices - Test #1");
-    },
-
-    threevoices2: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 600, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
-
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.draw();
-
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.addTimeSignature("4/4");
-      stave.draw();
-
-      var notes = [
-        newNote({ keys: ["a/4", "e/5"], stem_direction: 1, duration: "16"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "16"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "16"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "16"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "8"}),
-
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "h"}),
-      ];
-      notes[0].
-        addModifier(0, newFinger("2", VF.Modifier.Position.LEFT)).
-        addModifier(1, newFinger("0", VF.Modifier.Position.ABOVE));
-    //    addModifier(1, newFinger("0", VF.Modifier.Position.LEFT).
-    //    setOffsetY(-6));
-
-      var notes1 = [
-        newNote({ keys: ["d/4", "d/5"], stem_direction: -1, duration: "16"}),
-        newNote({ keys: ["b/4", "c/5"], stem_direction: -1, duration: "16"}),
-        newNote({ keys: ["d/5"], stem_direction: -1, duration: "16"}),
-        newNote({ keys: ["e/5"], stem_direction: -1, duration: "16"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["d/4", "a/4", "c/5"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: -1, duration: "8"}),
-      ];
-      notes1[0].addAccidental(1, new VF.Accidental("#")).
-                addModifier(0, newFinger("0", VF.Modifier.Position.LEFT)).
-                addModifier(1, newFinger("4", VF.Modifier.Position.LEFT));
-
-      var notes2 = [
-        newNote({ keys: ["b/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["b/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "q"}),
-
-        newNote({ keys: ["f/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["a/3"], stem_direction: -1, duration: "q"}),
-      ];
-
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice1 = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-      voice1.addTickables(notes1);
-      voice2.addTickables(notes2);
-      var beam = VF.Beam.applyAndGetBeams(voice, 1);
-      var beam1 = VF.Beam.applyAndGetBeams(voice1, -1);
-      var beam2 = VF.Beam.applyAndGetBeams(voice2, -1);
-
-      // Set option to position rests near the notes in each voice
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2]).
-        format([voice, voice1, voice2], 400);
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      for (var i = 0; i < beam.length; i++)
-        beam[i].setContext(c).draw();
-      for (var i = 0; i < beam1.length; i++)
-        beam1[i].setContext(c).draw();
-      for (var i = 0; i < beam2.length; i++)
-        beam2[i].setContext(c).draw();
-
-      ok(true, "Three Voices - Test #2 Complex");
-    },
-
-    threevoices3: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 600, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
-
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.draw();
-
-      var stave = new VF.Stave(50, 10, 500).addTrebleGlyph();
-      stave.setContext(c);
-      stave.addTimeSignature("4/4");
-      stave.draw();
-
-      var notes = [
-        newNote({ keys: ["g/4", "e/5"], stem_direction: 1, duration: "q"}),
-        newNote({ keys: ["e/5"], stem_direction: 1, duration: "q"}),
-        newNote({ keys: ["g/4", "e/5"], stem_direction: 1, duration: "h"}),
-      ];
-      notes[0].addModifier(0, newFinger("0", VF.Modifier.Position.LEFT)).
-               addModifier(1, newFinger("0", VF.Modifier.Position.LEFT));
-
-      var notes1 = [
-        newNote({ keys: ["c/5"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["b/4"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["b/4"], stem_direction: -1, duration: "8r"}),
-
-        newNote({ keys: ["a/4"], stem_direction: -1, duration: "qd"}).addDotToAll(),
-        newNote({ keys: ["g/4"], stem_direction: -1, duration: "8"}),
-      ];
-      notes1[0].addAccidental(0, new VF.Accidental("#")).
-                addModifier(0, newFinger("1", VF.Modifier.Position.LEFT));
-
-      var notes2 = [
-        newNote({ keys: ["c/4"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["b/3"], stem_direction: -1, duration: "q"}),
-
-        newNote({ keys: ["a/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["g/3"], stem_direction: -1, duration: "q"}),
-      ];
-      notes2[0].addModifier(0, newFinger("3", VF.Modifier.Position.LEFT));
-
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice1 = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-      voice1.addTickables(notes1);
-      voice2.addTickables(notes2);
-      var beam = VF.Beam.applyAndGetBeams(voice, 1);
-      var beam1 = VF.Beam.applyAndGetBeams(voice1, -1);
-      var beam2 = VF.Beam.applyAndGetBeams(voice2, -1);
-
-      // Set option to position rests near the notes in each voice
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2]).
-        format([voice, voice1, voice2], 400);
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      for (var i = 0; i < beam.length; i++)
-        beam[i].setContext(c).draw();
-      for (var i = 0; i < beam1.length; i++)
-        beam1[i].setContext(c).draw();
-      for (var i = 0; i < beam2.length; i++)
-        beam2[i].setContext(c).draw();
-
-      ok(true, "Three Voices - Test #3");
-    },
-
-    autoresttwovoices: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 900, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
-
-      function getNotes(text) {
-        var notes = [
-          newNote({ keys: ["b/4"], duration: "8r"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["b/4"], duration: "16r"}),
-
-          newNote({ keys: ["b/4"], duration: "8r"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["b/4"], duration: "16r"}),
-
-          newNote({ keys: ["b/4"], duration: "8r"}),
-          newNote({ keys: ["d/5"], duration: "16"}),
-          newNote({ keys: ["b/4"], duration: "16r"}),
-
-          newNote({ keys: ["e/5"], duration: "q"}),
-        ];
-
-        var notes1 = [
-          newNote({ keys: ["c/5"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["c/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["d/4"], stem_direction: -1, duration: "16"}),
-
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["f/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["g/4"], stem_direction: -1, duration: "16"}),
-
-          newNote({ keys: ["g/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["a/4"], stem_direction: 1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: 1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: 1, duration: "16"}),
-
-          newNote({ keys: ["e/4"], duration: "q"}),
-        ];
-
-        var textnote = [
-           new VF.TextNote({text: text, line: -1, duration: "w", smooth: true}),
-        ];
-
-        return {notes: notes, notes1: notes1, textnote: textnote};
-
+        vf.Formatter()
+          .joinVoices(voices)
+          .formatToStave(voices, stave, { align_rests: alignRests });
       }
 
-      var stave = new VF.Stave(50, 20, 400);
-      stave.setContext(c);
-      stave.draw();
+      createMeasure('Default Rest Positions', 400, false);
+      createMeasure('Rests Repositioned To Avoid Collisions', 400, true);
 
-      var n = getNotes("Default Rest Positions");
-      n.textnote[0].setContext(c);
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice1 = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.textnote);
+      vf.draw();
 
-      var beam = VF.Beam.applyAndGetBeams(voice, 1);
-      var beam1 = VF.Beam.applyAndGetBeams(voice1, -1);
-
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = false;
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2]).
-        format([voice, voice1, voice2], 350, {align_rests: false});
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      for (var i = 0; i < beam.length; i++)
-        beam[i].setContext(c).draw();
-      for (var i = 0; i < beam1.length; i++)
-        beam1[i].setContext(c).draw();
-
-      // Draw After rest adjustment
-      var stave = new VF.Stave(stave.width + stave.x, stave.y, 400);
-      stave.setContext(c);
-      stave.draw();
-
-      n = getNotes("Rests Repositioned To Avoid Collisions");
-      n.textnote[0].setContext(c);
-      voice = new VF.Voice(VF.Test.TIME4_4);
-      voice1 = new VF.Voice(VF.Test.TIME4_4);
-      voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.textnote);
-      beam = VF.Beam.applyAndGetBeams(voice, 1);
-      beam1 = VF.Beam.applyAndGetBeams(voice1, -1);
-
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = true;
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2]).
-        format([voice, voice1, voice2], 350, {align_rests: true});
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      for (var i = 0; i < beam.length; i++)
-        beam[i].setContext(c).draw();
-      for (var i = 0; i < beam1.length; i++)
-        beam1[i].setContext(c).draw()
-        ;
-      ok(true, "Auto Adjust Rests - Two Voices");
-    },
-
-    autorestthreevoices: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 850, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
-      function getNotes(text) {
-
-        var notes = [
-          newNote({ keys: ["b/4"], duration: "qr"}),
-          newNote({ keys: ["e/5"], duration: "q"}),
-          newNote({ keys: ["e/5"], duration: "qr"}),
-          newNote({ keys: ["e/5"], duration: "qr"}),
-          newNote({ keys: ["e/5"], duration: "q"}),
-          newNote({ keys: ["e/5"], duration: "q"}),
-          newNote({ keys: ["e/5"], duration: "q"}),
-          newNote({ keys: ["e/5"], duration: "qr"}),
-        ];
-
-        var notes1 = [
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "q"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "q"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "q"}),
-        ];
-
-        var notes2 = [
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["f/4"], stem_direction: -1, duration: "q"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["g/4"], stem_direction: -1, duration: "q"}),
-          newNote({ keys: ["c/4"], stem_direction: -1, duration: "q"}),
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "qr"}),
-          newNote({ keys: ["c/4"], stem_direction: -1, duration: "q"}),
-        ];
-
-        var textnote = [
-           new VF.TextNote({text: text, duration: "w", line: -1, smooth: true}),
-           new VF.TextNote({text: "", duration: "w", line: -1, smooth: true}),
-        ];
-
-        return {notes: notes, notes1: notes1, notes2: notes2, textnote: textnote};
-
+      for (var i = 0; i < beams.length; i++) {
+        beams[i].setContext(vf.getContext()).draw();
       }
 
-      var stave = new VF.Stave(50, 20, 400).addTrebleGlyph();
-      stave.setContext(c);
-      stave.draw();
-
-      var n = getNotes("Default Rest Positions");
-      n.textnote[0].setContext(c);
-      n.textnote[1].setContext(c);
-      var voice = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice1 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice2 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice3 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.notes2);
-      voice3.addTickables(n.textnote);
-
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = false;
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2, voice3]).
-        format([voice, voice1, voice2, voice3], 350, {align_rests: false});
-
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      voice3.draw(c, stave);
-
-      var stave2 = new VF.Stave(stave.width + stave.x, stave.y, 350);
-      stave2.setContext(c);
-      stave2.draw();
-
-      n = getNotes("Rests Repositioned To Avoid Collisions");
-      n.textnote[0].setContext(c);
-      n.textnote[1].setContext(c);
-      voice = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      voice1 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      voice2 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      voice3 = new VF.Voice({
-        num_beats: 8, beat_value: 4, resolution: VF.RESOLUTION });
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.notes2);
-      voice3.addTickables(n.textnote);
-
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = true;
-      var formatter2 = new VF.Formatter().
-        joinVoices([voice, voice1, voice2, voice3]).
-        format([voice, voice1, voice2, voice3], 350, {align_rests: true});
-
-      voice.draw(c, stave2);
-      voice1.draw(c, stave2);
-      voice2.draw(c, stave2);
-      voice3.draw(c, stave2);
-
-      ok(true, "Auto Adjust Rests - three Voices #1");
+      ok(true, 'Auto Adjust Rests - Two Voices');
     },
 
-    autorestthreevoices2: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 950, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      function newFinger(num, pos) { return new VF.FretHandFinger(num).setPosition(pos); }
-      function getNotes(text) {
+    autorestthreevoices: function(options) {
+      var vf = VF.Test.makeFactory(options, 850, 200);
+      var score = vf.EasyScore();
+      var x = 10;
 
-        var notes = [
-          newNote({ keys: ["b/4"], duration: "16r"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["e/5"], duration: "16r"}),
-          newNote({ keys: ["e/5"], duration: "16r"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["e/5"], duration: "16"}),
-          newNote({ keys: ["e/5"], duration: "16r"}),
+      function createMeasure(measureTitle, width, alignRests) {
+        var stave = vf.Stave({ x: x, y: 50, width: width }).setBegBarType(1);
+
+        var voices = [
+          score.voice(score.notes(
+            'b4/4/r, e5, e5/r, e5/r, e5, e5, e5, e5/r',
+            { stem: 'up' }
+          ), { time: '8/4' }),
+          score.voice(score.notes(
+            'b4/4/r, b4/r, b4/r, b4, b4/r, b4/r, b4, b4',
+            { stem: 'down' }
+          ), { time: '8/4' }),
+          score.voice(score.notes(
+            'e4/4/r, e4/r, f4, b4/r, g4, c4, e4/r, c4',
+            { stem: 'down' }
+          ), { time: '8/4' }),
+          score.voice([
+            vf.TextNote({ text: measureTitle, duration: '1', line: -1, smooth: true }),
+            vf.TextNote({ text: '', duration: '1', line: -1, smooth: true }),
+          ], { time: '8/4' }),
         ];
 
-        var notes1 = [
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16"}),
-        ];
+        vf.Formatter()
+          .joinVoices(voices)
+          .formatToStave(voices, stave, { align_rests: alignRests });
 
-        var notes2 = [
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["f/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["b/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["g/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["c/4"], stem_direction: -1, duration: "16"}),
-          newNote({ keys: ["e/4"], stem_direction: -1, duration: "16r"}),
-          newNote({ keys: ["c/4"], stem_direction: -1, duration: "16"}),
-        ];
-
-        var textnote = [
-           new VF.TextNote({text: text, duration: "h", line: -1, smooth: true}),
-        ];
-
-        return {notes: notes, notes1: notes1, notes2: notes2, textnote: textnote};
-
+        x += width;
       }
 
-      var stave = new VF.Stave(50, 20, 450).addTrebleGlyph();
-      stave.setContext(c);
-      stave.draw();
+      createMeasure('Default Rest Positions', 400, false);
+      createMeasure('Rests Repositioned To Avoid Collisions', 400, true);
+      vf.draw();
 
-      var n = getNotes("Default Rest Positions");
-      n.textnote[0].setContext(c);
-      var voice = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice1 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice2 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      var voice3 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.notes2);
-      voice3.addTickables(n.textnote);
+      ok(true);
+    },
 
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = false;
-      var formatter = new VF.Formatter().
-        joinVoices([voice, voice1, voice2, voice3]).
-        format([voice, voice1, voice2, voice3], 400, {align_rests: false});
+    autorestthreevoices2: function(options) {
+      var vf = VF.Test.makeFactory(options, 850, 200);
+      var score = vf.EasyScore();
+      var x = 10;
 
-      voice.draw(c, stave);
-      voice1.draw(c, stave);
-      voice2.draw(c, stave);
-      voice3.draw(c, stave);
+      function createMeasure(measureTitle, width, alignRests) {
+        var stave = vf.Stave({ x: x, y: 50, width: width }).setBegBarType(1);
 
-      var stave2 = new VF.Stave(stave.width + stave.x, stave.y, 425);
-      stave2.setContext(c);
-      stave2.draw();
+        var voices = [
+          score.voice(score.notes(
+            'b4/16/r, e5, e5/r, e5/r, e5, e5, e5, e5/r'
+          ), { time: '2/4' }),
+          score.voice(score.notes(
+            'b4/16/r, b4/r, b4/r, b4, b4/r, b4/r, b4, b4'
+          ), { time: '2/4' }),
+          score.voice(score.notes(
+            'e4/16/r, e4/r, f4, b4/r, g4, c4, e4/r, c4'
+          ), { time: '2/4' }),
+          score.voice([
+            vf.TextNote({ text: measureTitle, duration: 'h', line: -1, smooth: true }),
+          ], { time: '2/4' }),
+        ];
 
-      n = getNotes("Rests Repositioned To Avoid Collisions");
-      n.textnote[0].setContext(c);
-      voice = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      voice1 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      voice2 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      voice3 = new VF.Voice({
-        num_beats: 2, beat_value: 4, resolution: VF.RESOLUTION });
-      voice.addTickables(n.notes);
-      voice1.addTickables(n.notes1);
-      voice2.addTickables(n.notes2);
-      voice3.addTickables(n.textnote);
+        vf.Formatter()
+          .joinVoices(voices)
+          .formatToStave(voices, stave, { align_rests: alignRests });
 
-      // Set option to position rests near the notes in each voice
-      Vex.Debug = true;
-      var formatter2 = new VF.Formatter().
-        joinVoices([voice, voice1, voice2, voice3]).
-        format([voice, voice1, voice2, voice3], 400, {align_rests: true});
+        x += width;
+      }
 
-      voice.draw(c, stave2);
-      voice1.draw(c, stave2);
-      voice2.draw(c, stave2);
-      voice3.draw(c, stave2);
+      createMeasure('Default Rest Positions', 400, false);
+      createMeasure('Rests Repositioned To Avoid Collisions', 400, true);
+      vf.draw();
 
-      ok(true, "Auto Adjust Rests - three Voices #2");
-    }
+      ok(true);
+    },
   };
 
   return ThreeVoices;

--- a/tests/threevoice_tests.js
+++ b/tests/threevoice_tests.js
@@ -45,7 +45,7 @@ VF.Test.ThreeVoices = (function() {
     Start: function() {
       var run = VF.Test.runTests;
 
-      QUnit.module('Multiple Voices');
+      QUnit.module('Three Voice Rests');
 
       run('Three Voices - #1', createThreeVoicesTest(
         ['e5/2, e5', { stem: 'up' }],

--- a/tests/threevoice_tests.js
+++ b/tests/threevoice_tests.js
@@ -3,18 +3,6 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
- /*
- eslint-disable
- no-var,
- no-undef,
- wrap-iife,
- func-names,
- vars-on-top,
- max-len,
- object-shorthand,
- prefer-arrow-callback,
-  */
-
 VF.Test.ThreeVoices = (function() {
   function concat(a, b) { return a.concat(b); }
 
@@ -33,7 +21,7 @@ VF.Test.ThreeVoices = (function() {
       setup(vf, voices);
 
       var beams = [
-        VF.Beam.applyAndGetBeams(voices[0], 1),
+        VF.Beam.applyAndGetBeams(voices[0], +1),
         VF.Beam.applyAndGetBeams(voices[1], -1),
         VF.Beam.applyAndGetBeams(voices[2], -1),
       ].reduce(concat);
@@ -49,7 +37,7 @@ VF.Test.ThreeVoices = (function() {
         beams[i].setContext(vf.getContext()).draw();
       }
 
-      ok(true, 'Three Voices - Test #2 Complex');
+      ok(true);
     };
   }
 


### PR DESCRIPTION
Take a look at the diffs. They are significant due to the new test setup affecting the automatic rest alignment.

Some of these tests relied on formatting code that was executed *only if* missing a stave (which really doesn't make sense to me why any kind of multi-voice formatting would be attempted in this case). Anyway, we are soon making this an invalid state. So now, the rests are formatted by code that formats StaveNotes with a stave. But the output is not good. The vertical adjustments will have to be completely rewritten to take real bounding box metrics into account (but this can only happen once the new stave requirement is in place), and changes will need to be made to support >2 voices.

See comment in code for more details.
