### PR TITLE
Refactor Stroke tests

### DIFF
--- a/tests/strokes_tests.js
+++ b/tests/strokes_tests.js
@@ -6,429 +6,341 @@
 VF.Test.Strokes = (function() {
   var Strokes = {
     Start: function() {
-      var runTests = VF.Test.runTests;
+      var run = VF.Test.runTests;
 
-      QUnit.module("Strokes");
-      runTests("Strokes - Brush/Arpeggiate/Rasquedo", Strokes.drawMultipleMeasures);
-      runTests("Strokes - Multi Voice", Strokes.multi);
-      runTests("Strokes - Notation and Tab", Strokes.notesWithTab);
-      runTests("Strokes - Multi-Voice Notation and Tab", Strokes.multiNotationAndTab);
+      QUnit.module('Strokes');
+
+      run('Strokes - Brush/Arpeggiate/Rasquedo', Strokes.drawMultipleMeasures);
+      run('Strokes - Multi Voice', Strokes.multi);
+      run('Strokes - Notation and Tab', Strokes.notesWithTab);
+      run('Strokes - Multi-Voice Notation and Tab', Strokes.multiNotationAndTab);
     },
 
-    drawMultipleMeasures: function(options, contextBuilder) {
-      // Get the rendering context
-
-      var ctx = contextBuilder(options.canvas_sel, 600, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    drawMultipleMeasures: function(options) {
+      var vf = VF.Test.makeFactory(options, 600, 200);
+      var score = vf.EasyScore();
 
       // bar 1
-      var staveBar1 = new VF.Stave(10, 50, 250);
-      staveBar1.setEndBarType(VF.Barline.type.DOUBLE);
-      staveBar1.setContext(ctx);
-      staveBar1.draw();
+      var stave1 = vf.Stave({ width: 250 }).setEndBarType(VF.Barline.type.DOUBLE);
 
-      var notesBar1 = [
-        new VF.StaveNote({ keys: ["a/3", "e/4", "a/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "e/4", "g/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "e/4", "g/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "e/4", "g/4"], duration: "q" })
-      ];
-      notesBar1[0].addStroke(0, new VF.Stroke(1));
-      notesBar1[1].addStroke(0, new VF.Stroke(2));
-      notesBar1[2].addStroke(0, new VF.Stroke(1));
-      notesBar1[3].addStroke(0, new VF.Stroke(2));
-      notesBar1[1].addAccidental(1, new VF.Accidental("#"));
-      notesBar1[1].addAccidental(2, new VF.Accidental("#"));
-      notesBar1[1].addAccidental(0, new VF.Accidental("#"));
+      var notes1 = score.notes(
+        '(a3 e4 a4)/4, (c4 e4 g4), (c4 e4 g4), (c4 e4 g4)',
+        { stem: 'up' }
+      );
 
-      // Helper function to justify and draw a 4/4 voice
-      VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+      notes1[0]
+        .addStroke(0, new VF.Stroke(1));
+      notes1[1]
+        .addStroke(0, new VF.Stroke(2))
+        .addAccidental(1, vf.Accidental({ type: '#' }))
+        .addAccidental(2, vf.Accidental({ type: '#' }))
+        .addAccidental(0, vf.Accidental({ type: '#' }));
+      notes1[2]
+        .addStroke(0, new VF.Stroke(1));
+      notes1[3]
+        .addStroke(0, new VF.Stroke(2));
+
+      var voice1 = score.voice(notes1);
+
+      vf.Formatter()
+        .joinVoices([voice1])
+        .formatToStave([voice1], stave1);
 
       // bar 2
-      var staveBar2 = new VF.Stave(staveBar1.width + staveBar1.x, staveBar1.y, 300);
-      staveBar2.setEndBarType(VF.Barline.type.DOUBLE);
-      staveBar2.setContext(ctx);
-      staveBar2.draw();
-      var notesBar2 = [
-        new VF.StaveNote({ keys: ["c/4", "d/4", "g/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "d/4", "g/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "d/4", "g/4"], duration: "q" }),
-        new VF.StaveNote({ keys: ["c/4", "d/4", "a/4"], duration: "q" })
-      ];
-      notesBar2[0].addStroke(0, new VF.Stroke(3));
-      notesBar2[1].addStroke(0, new VF.Stroke(4));
-      notesBar2[2].addStroke(0, new VF.Stroke(5));
-      notesBar2[3].addStroke(0, new VF.Stroke(6));
-      notesBar2[3].addAccidental(0, new VF.Accidental("bb"));
-      notesBar2[3].addAccidental(1, new VF.Accidental("bb"));
-      notesBar2[3].addAccidental(2, new VF.Accidental("bb"));
+      var stave2 = vf.Stave({ x: stave1.width + stave1.x, y: stave1.y, width: 300 })
+        .setEndBarType(VF.Barline.type.DOUBLE);
 
-      // Helper function to justify and draw a 4/4 voice
-      VF.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
+      var notes2 = score.notes(
+        '(c4 d4 g4)/4, (c4 d4 g4), (c4 d4 g4), (c4 d4 a4)',
+        { stem: 'up' }
+      );
 
-      ok(true, "Brush/Roll/Rasquedo");
+      notes2[0]
+        .addStroke(0, new VF.Stroke(3));
+      notes2[1]
+        .addStroke(0, new VF.Stroke(4));
+      notes2[2]
+        .addStroke(0, new VF.Stroke(5));
+      notes2[3]
+        .addStroke(0, new VF.Stroke(6))
+        .addAccidental(0, vf.Accidental({ type: 'bb' }))
+        .addAccidental(1, vf.Accidental({ type: 'bb' }))
+        .addAccidental(2, vf.Accidental({ type: 'bb' }));
+
+      var voice2 = score.voice(notes2);
+
+      vf.Formatter()
+        .joinVoices([voice2])
+        .formatToStave([voice2], stave2);
+
+      vf.draw();
+
+      ok(true, 'Brush/Roll/Rasquedo');
     },
 
-    multi: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 400, 200);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      var stave = new VF.Stave(50, 10, 300);
-      stave.setContext(c);
-      stave.draw();
+    multi: function(options) {
+      var vf = VF.Test.makeFactory(options, 500, 200);
+      var score = vf.EasyScore();
+      var stave = vf.Stave();
 
-      var notes = [
-        newNote({ keys: ["c/4", "e/4", "g/4"], duration: "q" }),
-        newNote({ keys: ["c/4", "e/4", "g/4"], duration: "q" }),
-        newNote({ keys: ["c/4", "d/4", "a/4"], duration: "q" }),
-        newNote({ keys: ["c/4", "d/4", "a/4"], duration: "q" })
-      ];
-      // Create the strokes
-      var stroke1 = new VF.Stroke(5);
-      var stroke2 = new VF.Stroke(6);
-      var stroke3 = new VF.Stroke(2);
-      var stroke4 = new VF.Stroke(1);
-      notes[0].addStroke(0, stroke1);
-      notes[1].addStroke(0, stroke2);
-      notes[2].addStroke(0, stroke3);
-      notes[3].addStroke(0, stroke4);
-      notes[1].addAccidental(0, new VF.Accidental("#"));
-      notes[1].addAccidental(2, new VF.Accidental("#"));
+      var notes1 = score.notes(
+        '(c4 e4 g4)/4, (c4 e4 g4), (c4 d4 a4), (c4 d4 a4)',
+        { stem: 'up' }
+      );
 
-      var notes2 = [
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"}),
-        newNote({ keys: ["e/3"], stem_direction: -1, duration: "8"})
-      ];
+      notes1[0]
+        .addStroke(0, new VF.Stroke(5));
+      notes1[1]
+        .addStroke(0, new VF.Stroke(6))
+        .addAccidental(0, vf.Accidental({ type: '#' }))
+        .addAccidental(2, vf.Accidental({ type: '#' }));
+      notes1[2]
+        .addStroke(0, new VF.Stroke(2));
+      notes1[3]
+        .addStroke(0, new VF.Stroke(1));
 
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-      voice2.addTickables(notes2);
+      var notes2 = score.notes(
+        'e3/8, e3, e3, e3, e3, e3, e3, e3',
+        { stem: 'down' }
+      );
 
-      var formatter = new VF.Formatter().joinVoices([voice, voice2]).
-        format([voice, voice2], 275);
+      vf.Beam({ notes: notes2.slice(0, 4) });
+      vf.Beam({ notes: notes2.slice(4, 8) });
 
-      var beam2_1 = new VF.Beam(notes2.slice(0, 4));
-      var beam2_2 = new VF.Beam(notes2.slice(4, 8));
+      var voices = [notes1, notes2].map(score.voice.bind(score));
 
-      voice2.draw(c, stave);
-      beam2_1.setContext(c).draw();
-      beam2_2.setContext(c).draw();
-      voice.draw(c, stave);
+      vf.Formatter()
+        .joinVoices(voices)
+        .formatToStave(voices, stave);
 
-      ok(true, "Strokes Test Multi Voice");
+      vf.draw();
+
+      ok(true, 'Strokes Test Multi Voice');
     },
 
-    multiNotationAndTab: function(options, contextBuilder) {
-      var c = new contextBuilder(options.canvas_sel, 400, 275);
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newTabNote(tab_struct) { return new VF.TabNote(tab_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
-      var stave = new VF.Stave(10, 10, 400).addTrebleGlyph().
-        setContext(c).draw();
-      var tabstave = new VF.TabStave(10, 125, 400).addTabGlyph().
-        setNoteStartX(stave.getNoteStartX()).setContext(c).draw();
+    multiNotationAndTab: function(options) {
+      var vf = VF.Test.makeFactory(options, 400, 275);
+      var score = vf.EasyScore();
+      var stave = vf.Stave().addClef('treble');
 
       // notation upper voice notes
-      var notes = [
-        newNote({ keys: ["g/4", "b/4", "e/5"], duration: "q" }),
-        newNote({ keys: ["g/4", "b/4", "e/5"], duration: "q" }),
-        newNote({ keys: ["g/4", "b/4", "e/5"], duration: "q" }),
-        newNote({ keys: ["g/4", "b/4", "e/5"], duration: "q" })
-      ];
+      var notes1 = score.notes(
+        '(g4 b4 e5)/4, (g4 b4 e5), (g4 b4 e5), (g4 b4 e5)',
+        { stem: 'up' }
+      );
+
+      notes1[0].addStroke(0, new VF.Stroke(3, { all_voices: false }));
+      notes1[1].addStroke(0, new VF.Stroke(6));
+      notes1[2].addStroke(0, new VF.Stroke(2, { all_voices: false }));
+      notes1[3].addStroke(0, new VF.Stroke(1));
+
+      var notes2 = score.notes(
+        'g3/4, g3, g3, g3',
+        { stem: 'down' }
+      );
+
+      vf.TabStave({ y: 100 })
+        .addClef('tab')
+        .setNoteStartX(stave.getNoteStartX());
 
       // tablature upper voice notes
-      var notes3 = [
-        newTabNote({ positions: [{str: 3, fret: 0},
-                                 {str: 2, fret: 0},
-                                 {str: 1, fret: 1}], duration: "q"}),
-        newTabNote({ positions: [{str: 3, fret: 0},
-                                 {str: 2, fret: 0},
-                                 {str: 1, fret: 1}], duration: "q"}),
-        newTabNote({ positions: [{str: 3, fret: 0},
-                                 {str: 2, fret: 0},
-                                 {str: 1, fret: 1}], duration: "q"}),
-        newTabNote({ positions: [{str: 3, fret: 0},
-                                 {str: 2, fret: 0},
-                                 {str: 1, fret: 1}], duration: "q"})
+      var tabNotes1 = [
+        vf.TabNote({ positions: [{ str: 3, fret: 0 },
+                                 { str: 2, fret: 0 },
+                                 { str: 1, fret: 1 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 3, fret: 0 },
+                                 { str: 2, fret: 0 },
+                                 { str: 1, fret: 1 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 3, fret: 0 },
+                                 { str: 2, fret: 0 },
+                                 { str: 1, fret: 1 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 3, fret: 0 },
+                                 { str: 2, fret: 0 },
+                                 { str: 1, fret: 1 }], duration: '4' }),
       ];
 
-      // Create the strokes for notation
-      var stroke1 = new VF.Stroke(3, {all_voices: false});
-      var stroke2 = new VF.Stroke(6);
-      var stroke3 = new VF.Stroke(2, {all_voices: false});
-      var stroke4 = new VF.Stroke(1);
-      // add strokes to notation
-      notes[0].addStroke(0, stroke1);
-      notes[1].addStroke(0, stroke2);
-      notes[2].addStroke(0, stroke3);
-      notes[3].addStroke(0, stroke4);
+      tabNotes1[0].addStroke(0, new VF.Stroke(3, { all_voices: false }));
+      tabNotes1[1].addStroke(0, new VF.Stroke(6));
+      tabNotes1[2].addStroke(0, new VF.Stroke(2, { all_voices: false }));
+      tabNotes1[3].addStroke(0, new VF.Stroke(1));
 
-      // creae strokes for tab
-      var stroke5 = new VF.Stroke(3, {all_voices: false});
-      var stroke6 = new VF.Stroke(6);
-      var stroke7 = new VF.Stroke(2, {all_voices: false});
-      var stroke8 = new VF.Stroke(1);
-      // add strokes to tab
-      notes3[0].addStroke(0, stroke5);
-      notes3[1].addStroke(0, stroke6);
-      notes3[2].addStroke(0, stroke7);
-      notes3[3].addStroke(0, stroke8);
-
-      // notation lower voice notes
-      var notes2 = [
-        newNote({ keys: ["g/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["g/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["g/3"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["g/3"], stem_direction: -1, duration: "q"})
+      var tabNotes2 = [
+        vf.TabNote({ positions: [{ str: 6, fret: 3 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 6, fret: 3 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 6, fret: 3 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 6, fret: 3 }], duration: '4' }),
       ];
 
-      // tablature lower voice notes
-      var notes4 = [
-        newTabNote({ positions: [{str: 6, fret: 3}], duration: "q"}),
-        newTabNote({ positions: [{str: 6, fret: 3}], duration: "q"}),
-        newTabNote({ positions: [{str: 6, fret: 3}], duration: "q"}),
-        newTabNote({ positions: [{str: 6, fret: 3}], duration: "q"})
-      ];
+      var voices = [notes1, notes2, tabNotes1, tabNotes2].map(score.voice.bind(score));
 
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var voice2 = new VF.Voice(VF.Test.TIME4_4);
-      var voice3 = new VF.Voice(VF.Test.TIME4_4);
-      var voice4 = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
-      voice2.addTickables(notes2);
-      voice4.addTickables(notes4);
-      voice3.addTickables(notes3);
+      vf.Formatter()
+        .joinVoices(voices)
+        .formatToStave(voices, stave);
 
-      var formatter = new VF.Formatter().joinVoices([voice, voice2, voice3, voice4]).
-        format([voice, voice2, voice3, voice4], 275);
+      vf.draw();
 
-      voice2.draw(c, stave);
-      voice.draw(c, stave);
-      voice4.draw(c, tabstave);
-      voice3.draw(c, tabstave);
-
-      ok(true, "Strokes Test Notation & Tab Multi Voice");
+      ok(true, 'Strokes Test Notation & Tab Multi Voice');
     },
 
-    drawTabStrokes: function(options, contextBuilder) {
-      // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 600, 200);
+    drawTabStrokes: function(options) {
+      var vf = VF.Test.makeFactory(options, 600, 200);
+      var stave1 = vf.TabStave({ width: 250 }).setEndBarType(VF.Barline.type.DOUBLE);
 
-      // bar 1
-      var staveBar1 = new VF.TabStave(10, 50, 250);
-      staveBar1.setEndBarType(VF.Barline.type.DOUBLE);
-      staveBar1.setContext(ctx).draw();
-
-      var notesBar1 = [
-        new VF.TabNote({ positions: [{str: 2, fret: 8 },
-                                           {str: 3, fret: 9},
-                                           {str: 4, fret: 10}], duration: "q"}),
-        new VF.TabNote({ positions: [{str: 3, fret: 7 },
-                                           {str: 4, fret: 8},
-                                           {str: 5, fret: 9}], duration: "q"}),
-        new VF.TabNote({ positions: [{str: 1, fret: 5 },
-                                           {str: 2, fret: 6},
-                                           {str: 3, fret: 7},
-                                           {str: 4, fret: 7},
-                                           {str: 5, fret: 5},
-                                           {str: 6, fret: 5}], duration: "q"}),
-        new VF.TabNote({ positions: [{str: 4, fret: 3 },
-                                           {str: 5, fret: 4},
-                                           {str: 6, fret: 5}], duration: "q"}),
+      var tabNotes1 = [
+        vf.TabNote({ positions: [{ str: 2, fret: 8 },
+                                 { str: 3, fret: 9 },
+                                 { str: 4, fret: 10 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 3, fret: 7 },
+                                 { str: 4, fret: 8 },
+                                 { str: 5, fret: 9 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 1, fret: 5 },
+                                 { str: 2, fret: 6 },
+                                 { str: 3, fret: 7 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 5 },
+                                 { str: 6, fret: 5 }], duration: '4' }),
+        vf.TabNote({ positions: [{ str: 4, fret: 3 },
+                                 { str: 5, fret: 4 },
+                                 { str: 6, fret: 5 }], duration: '4' }),
       ];
 
-      var stroke1 = new VF.Stroke(1);
-      var stroke2 = new VF.Stroke(2);
-      var stroke3 = new VF.Stroke(3);
-      var stroke4 = new VF.Stroke(4);
+      tabNotes1[0].addStroke(0, new VF.Stroke(1));
+      tabNotes1[1].addStroke(0, new VF.Stroke(2));
+      tabNotes1[2].addStroke(0, new VF.Stroke(3));
+      tabNotes1[3].addStroke(0, new VF.Stroke(4));
 
-      notesBar1[0].addStroke(0, stroke1);
-      notesBar1[1].addStroke(0, stroke2);
-      notesBar1[2].addStroke(0, stroke4);
-      notesBar1[3].addStroke(0, stroke3);
+      var tabVoice1 = vf.Voice().addTickables(tabNotes1);
 
-      // Helper function to justify and draw a 4/4 voice
-      VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+      vf.Formatter()
+        .joinVoices([tabVoice1])
+        .formatToStave([tabVoice1], stave1);
 
      // bar 2
-      var staveBar2 = new VF.TabStave(staveBar1.width + staveBar1.x, staveBar1.y, 300);
-      staveBar2.setEndBarType(VF.Barline.type.DOUBLE);
-      staveBar2.setContext(ctx).draw();
-      var notesBar2 = [new VF.TabNote({ positions: [{str: 2, fret: 7 },
-                                                          {str: 3, fret: 8},
-                                                          {str: 4, fret: 9}], duration: "h"}),
-                       new VF.TabNote({ positions: [{str: 1, fret: 5 },
-                                                          {str: 2, fret: 6},
-                                                          {str: 3, fret: 7},
-                                                          {str: 4, fret: 7},
-                                                          {str: 5, fret: 5},
-                                                          {str: 6, fret: 5}], duration: "h"}),
+      var stave2 = vf.TabStave({ x: stave1.width + stave1.x, width: 300 })
+        .setEndBarType(VF.Barline.type.DOUBLE);
+
+      var tabNotes2 = [
+        vf.TabNote({ positions: [{ str: 2, fret: 7 },
+                                 { str: 3, fret: 8 },
+                                 { str: 4, fret: 9 }], duration: '2' }),
+        vf.TabNote({ positions: [{ str: 1, fret: 5 },
+                                 { str: 2, fret: 6 },
+                                 { str: 3, fret: 7 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 5 },
+                                 { str: 6, fret: 5 }], duration: '2' }),
       ];
 
-      notesBar2[0].addStroke(0, new VF.Stroke(6));
-      notesBar2[1].addStroke(0, new VF.Stroke(5));
+      tabNotes2[0].addStroke(0, new VF.Stroke(6));
+      tabNotes2[1].addStroke(0, new VF.Stroke(5));
 
-      // Helper function to justify and draw a 4/4 voice
-      VF.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
-      ok(true, "Strokes Tab test");
+      var tabVoice2 = vf.Voice().addTickables(tabNotes2);
 
+      vf.Formatter()
+        .joinVoices([tabVoice2])
+        .formatToStave([tabVoice2], stave2);
+
+      vf.draw();
+
+      ok(true, 'Strokes Tab test');
     },
 
-    getTabNotes: function() {
-      function newNote(note_struct) { return new VF.StaveNote(note_struct); }
-      function newTabNote(tab_struct) { return new VF.TabNote(tab_struct); }
-      function newAcc(type) { return new VF.Accidental(type); }
+    notesWithTab: function(options) {
+      var vf = VF.Test.makeFactory(options, 500, 300);
 
-      var notes1 = [
-        newNote({ keys: ["b/4", "d/5", "g/5"], stem_direction: -1, duration: "q"}).
-          addAccidental(1, newAcc("b")).
-          addAccidental(0, newAcc("b")),
-        newNote({ keys: ["c/5", "d/5"], stem_direction: -1, duration: "q"}),
-        newNote({ keys: ["b/3", "e/4", "a/4", "d/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["a/3", "e/4", "a/4", "c/5", "e/5", "a/5"], stem_direction: 1, duration: "8"}).
-          addAccidental(3, newAcc("#")),
-        newNote({ keys: ["b/3", "e/4", "a/4", "d/5"], stem_direction: 1, duration: "8"}),
-        newNote({ keys: ["a/3", "e/4", "a/4", "c/5", "f/5", "a/5"], stem_direction: 1, duration: "8"}).
-            addAccidental(3, newAcc("#")).
-            addAccidental(4, newAcc("#"))
+      var stave = vf.Stave({ x: 15, y: 40, width: 450 }).addClef('treble');
+
+      var notes = [
+        vf.StaveNote({ keys: ['b/4', 'd/5', 'g/5'], stem_direction: -1, duration: '4' })
+          .addAccidental(1, vf.Accidental({ type: 'b' }))
+          .addAccidental(0, vf.Accidental({ type: 'b' })),
+        vf.StaveNote({ keys: ['c/5', 'd/5'], stem_direction: -1, duration: '4' }),
+        vf.StaveNote({ keys: ['b/3', 'e/4', 'a/4', 'd/5'], stem_direction: 1, duration: '8' }),
+        vf.StaveNote({ keys: ['a/3', 'e/4', 'a/4', 'c/5', 'e/5', 'a/5'], stem_direction: 1, duration: '8' })
+          .addAccidental(3, vf.Accidental({ type: '#' })),
+        vf.StaveNote({ keys: ['b/3', 'e/4', 'a/4', 'd/5'], stem_direction: 1, duration: '8' }),
+        vf.StaveNote({ keys: ['a/3', 'e/4', 'a/4', 'c/5', 'f/5', 'a/5'], stem_direction: 1, duration: '8' })
+          .addAccidental(3, vf.Accidental({ type: '#' }))
+          .addAccidental(4, vf.Accidental({ type: '#' })),
       ];
 
-      var tabs1 = [
-        newTabNote({ positions: [{str: 1, fret: 3},
-                                 {str: 2, fret: 2},
-                                 {str: 3, fret: 3}], duration: "q"}).
-          addModifier(new VF.Bend("Full"), 0),
-        newTabNote({ positions: [{str: 2, fret: 3},
-                                 {str: 3, fret: 5}], duration: "q"}).
-          addModifier(new VF.Bend("Unison"), 1),
-        newTabNote({ positions: [{str: 3, fret: 7},
-                                 {str: 4, fret: 7},
-                                 {str: 5, fret: 7},
-                                 {str: 6, fret: 7},], duration: "8"}),
-        newTabNote({ positions: [{str: 1, fret: 5},
-                                 {str: 2, fret: 5},
-                                 {str: 3, fret: 6},
-                                 {str: 4, fret: 7},
-                                 {str: 5, fret: 7},
-                                 {str: 6, fret: 5}], duration: "8"}),
-        newTabNote({ positions: [{str: 3, fret: 7},
-                                 {str: 4, fret: 7},
-                                 {str: 5, fret: 7},
-                                 {str: 6, fret: 7},], duration: "8"}),
-        newTabNote({ positions: [{str: 1, fret: 5},
-                                 {str: 2, fret: 5},
-                                 {str: 3, fret: 6},
-                                 {str: 4, fret: 7},
-                                 {str: 5, fret: 7},
-                                 {str: 6, fret: 5}], duration: "8"})
+      var tabstave = vf.TabStave({ x: stave.x, y: 140, width: 450 })
+        .addClef('tab')
+        .setNoteStartX(stave.getNoteStartX());
+
+      var tabNotes = [
+        vf.TabNote({ positions: [{ str: 1, fret: 3 },
+                                 { str: 2, fret: 2 },
+                                 { str: 3, fret: 3 }], duration: '4' }).addModifier(new VF.Bend('Full'), 0),
+        vf.TabNote({ positions: [{ str: 2, fret: 3 },
+                                 { str: 3, fret: 5 }], duration: '4' }).addModifier(new VF.Bend('Unison'), 1),
+        vf.TabNote({ positions: [{ str: 3, fret: 7 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 7 },
+                                 { str: 6, fret: 7 }], duration: '8' }),
+        vf.TabNote({ positions: [{ str: 1, fret: 5 },
+                                 { str: 2, fret: 5 },
+                                 { str: 3, fret: 6 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 7 },
+                                 { str: 6, fret: 5 }], duration: '8' }),
+        vf.TabNote({ positions: [{ str: 3, fret: 7 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 7 },
+                                 { str: 6, fret: 7 }], duration: '8' }),
+        vf.TabNote({ positions: [{ str: 1, fret: 5 },
+                                 { str: 2, fret: 5 },
+                                 { str: 3, fret: 6 },
+                                 { str: 4, fret: 7 },
+                                 { str: 5, fret: 7 },
+                                 { str: 6, fret: 5 }], duration: '8' }),
 
       ];
 
-      var noteStr1 = new VF.Stroke(1);
-      var noteStr2 = new VF.Stroke(2);
-      var noteStr3 = new VF.Stroke(3);
-      var noteStr4 = new VF.Stroke(4);
-      var noteStr5 = new VF.Stroke(5);
-      var noteStr6 = new VF.Stroke(6);
+      notes[0].addStroke(0, new VF.Stroke(1));
+      notes[1].addStroke(0, new VF.Stroke(2));
+      notes[2].addStroke(0, new VF.Stroke(3));
+      notes[3].addStroke(0, new VF.Stroke(4));
+      notes[4].addStroke(0, new VF.Stroke(5));
+      notes[5].addStroke(0, new VF.Stroke(6));
 
-      notes1[0].addStroke(0, noteStr1);
-      notes1[1].addStroke(0, noteStr2);
-      notes1[2].addStroke(0, noteStr3);
-      notes1[3].addStroke(0, noteStr4);
-      notes1[4].addStroke(0, noteStr5);
-      notes1[5].addStroke(0, noteStr6);
+      tabNotes[0].addStroke(0, new VF.Stroke(1));
+      tabNotes[1].addStroke(0, new VF.Stroke(2));
+      tabNotes[2].addStroke(0, new VF.Stroke(3));
+      tabNotes[3].addStroke(0, new VF.Stroke(4));
+      tabNotes[4].addStroke(0, new VF.Stroke(5));
+      tabNotes[5].addStroke(0, new VF.Stroke(6));
 
-      var tabStr1 = new VF.Stroke(1);
-      var tabStr2 = new VF.Stroke(2);
-      var tabStr3 = new VF.Stroke(3);
-      var tabStr4 = new VF.Stroke(4);
-      var tabStr5 = new VF.Stroke(5);
-      var tabStr6 = new VF.Stroke(6);
+      vf.StaveConnector({
+        top_stave: stave,
+        bottom_stave: tabstave,
+        type: 'bracket',
+      });
 
-      tabs1[0].addStroke(0, tabStr1);
-      tabs1[1].addStroke(0, tabStr2);
-      tabs1[2].addStroke(0, tabStr3);
-      tabs1[3].addStroke(0, tabStr4);
-      tabs1[4].addStroke(0, tabStr5);
-      tabs1[5].addStroke(0, tabStr6);
+      vf.StaveConnector({
+        top_stave: stave,
+        bottom_stave: tabstave,
+        type: 'single',
+      });
 
-      return { notes: notes1, tabs: tabs1 };
-    },
-
-    renderNotesWithTab:
-      function(notes, ctx, staves, justify) {
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      var tabVoice = new VF.Voice(VF.Test.TIME4_4);
-
-      voice.addTickables(notes.notes);
-      // Takes a voice and returns it's auto beamsj
+      var voice = vf.Voice().addTickables(notes);
+      var tabVoice = vf.Voice().addTickables(tabNotes);
       var beams = VF.Beam.applyAndGetBeams(voice);
 
-      tabVoice.addTickables(notes.tabs);
+      vf.Formatter()
+        .joinVoices([voice])
+        .joinVoices([tabVoice])
+        .formatToStave([voice, tabVoice], stave);
 
-      new VF.Formatter().
-        joinVoices([voice]).joinVoices([tabVoice]).
-        format([voice, tabVoice], justify);
+      vf.draw();
 
-      voice.draw(ctx, staves.notes);
-      beams.forEach(function(beam){
-        beam.setContext(ctx).draw();
+      beams.forEach(function(beam) {
+        beam.setContext(vf.getContext()).draw();
       });
-      tabVoice.draw(ctx, staves.tabs);
+
+      ok(true);
     },
-
-    notesWithTab: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 420, 450);
-      ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
-      ctx.font = "10pt Arial";
-
-      // Get test voices.
-      var notes = VF.Test.Strokes.getTabNotes();
-      var stave = new VF.Stave(10, 10, 400).addTrebleGlyph().
-        setContext(ctx).draw();
-      var tabstave = new VF.TabStave(10, 100, 400).addTabGlyph().
-        setNoteStartX(stave.getNoteStartX()).setContext(ctx).draw();
-      var connector = new VF.StaveConnector(stave, tabstave);
-      var line = new VF.StaveConnector(stave, tabstave);
-      connector.setType(VF.StaveConnector.type.BRACKET);
-      connector.setContext(ctx);
-      line.setType(VF.StaveConnector.type.SINGLE);
-      connector.setContext(ctx);
-      line.setContext(ctx);
-      connector.draw();
-      line.draw();
-
-      VF.Test.Strokes.renderNotesWithTab(notes, ctx,
-          { notes: stave, tabs: tabstave });
-      ok(true);
-
-      var stave2 = new VF.Stave(10, 250, 400).addTrebleGlyph().
-        setContext(ctx).draw();
-      var tabstave2 = new VF.TabStave(10, 350, 400).addTabGlyph().
-        setNoteStartX(stave2.getNoteStartX()).setContext(ctx).draw();
-      var connector = new VF.StaveConnector(stave2, tabstave2);
-      var line = new VF.StaveConnector(stave2, tabstave2);
-      connector.setType(VF.StaveConnector.type.BRACKET);
-      connector.setContext(ctx);
-      line.setType(VF.StaveConnector.type.SINGLE);
-      connector.setContext(ctx);
-      line.setContext(ctx);
-      connector.draw();
-      line.draw();
-
-      VF.Test.Strokes.renderNotesWithTab(notes, ctx,
-          { notes: stave2, tabs: tabstave2 }, 385);
-      ok(true);
-    }
   };
 
   return Strokes;
-})();
+}());


### PR DESCRIPTION
On the last test, there are two formatting iterations: with and without justification. Testing justification is already done in the formatter tests, so I've only kept the the justified iteration.

![strokes strokes___brush_arpeggiate_rasquedo_blessed](https://cloud.githubusercontent.com/assets/1631625/21467255/e9f29e1c-c9de-11e6-8482-eac4be6174e0.png)
![strokes strokes___brush_arpeggiate_rasquedo_current](https://cloud.githubusercontent.com/assets/1631625/21467256/e9f57092-c9de-11e6-8aa7-cd036c1dbfd3.png)
![strokes strokes___brush_arpeggiate_rasquedo](https://cloud.githubusercontent.com/assets/1631625/21467257/e9f874cc-c9de-11e6-9520-7f84a4fe66ee.png)
![strokes strokes___multi_voice_blessed](https://cloud.githubusercontent.com/assets/1631625/21467258/e9fc600a-c9de-11e6-84cd-3da5612a7a8d.png)
![strokes strokes___multi_voice_current](https://cloud.githubusercontent.com/assets/1631625/21467259/e9fe660c-c9de-11e6-8ddc-32d8f6d3ac8c.png)
![strokes strokes___multi_voice_notation_and_tab_blessed](https://cloud.githubusercontent.com/assets/1631625/21467260/ea05140c-c9de-11e6-8ce0-36ede4acedf8.png)
![strokes strokes___multi_voice_notation_and_tab_current](https://cloud.githubusercontent.com/assets/1631625/21467261/ea07c2a6-c9de-11e6-8644-a13329994bea.png)
![strokes strokes___multi_voice_notation_and_tab](https://cloud.githubusercontent.com/assets/1631625/21467262/ea0b4444-c9de-11e6-8a8b-3614358ef2f5.png)
![strokes strokes___multi_voice](https://cloud.githubusercontent.com/assets/1631625/21467263/ea11a172-c9de-11e6-98d3-0ab32bf18f44.png)
![strokes strokes___notation_and_tab_blessed](https://cloud.githubusercontent.com/assets/1631625/21467264/ea1523f6-c9de-11e6-855d-2605f4d1e20f.png)
![strokes strokes___notation_and_tab_current](https://cloud.githubusercontent.com/assets/1631625/21467265/ea15b5b4-c9de-11e6-883a-f95ea0a65967.png)
![strokes strokes___notation_and_tab](https://cloud.githubusercontent.com/assets/1631625/21467266/ea186dae-c9de-11e6-82d6-4d129b8c0835.png)
