### PR TITLE
Rename `selector` to `elementId`

### DIFF
--- a/src/canvascontext.js
+++ b/src/canvascontext.js
@@ -98,8 +98,7 @@ export class CanvasContext {
   }
 
   resize(width, height) {
-    return this.vexFlowCanvasContext.resize(
-        parseInt(width, 10), parseInt(height, 10));
+    return this.vexFlowCanvasContext.resize(parseInt(width, 10), parseInt(height, 10));
   }
 
   rect(x, y, width, height) {

--- a/src/factory.js
+++ b/src/factory.js
@@ -65,7 +65,7 @@ export class Factory {
       },
       renderer: {
         context: null,
-        selector: '',
+        elementId: '',
         backend: Renderer.Backends.SVG,
         width: 500,
         height: 200,
@@ -82,8 +82,8 @@ export class Factory {
     this.setOptions(options);
   }
 
-  static newFromSelector(selector, width = 500, height = 200) {
-    return new Factory({ renderer: { selector, width, height } });
+  static newFromElementId(elementId, width = 500, height = 200) {
+    return new Factory({ renderer: { elementId, width, height } });
   }
 
   reset() {
@@ -99,7 +99,7 @@ export class Factory {
     for (const key of ['stave', 'renderer', 'font']) {
       Object.assign(this.options[key], options[key]);
     }
-    if (this.options.renderer.selector !== null || this.options.renderer.context) {
+    if (this.options.renderer.elementId !== null || this.options.renderer.context) {
       this.initRenderer();
     }
 
@@ -107,12 +107,12 @@ export class Factory {
   }
 
   initRenderer() {
-    const { selector, backend, width, height, background } = this.options.renderer;
-    if (selector === '') {
+    const { elementId, backend, width, height, background } = this.options.renderer;
+    if (elementId === '') {
       throw new X('HTML DOM element not set in Factory');
     }
 
-    this.context = Renderer.buildContext(selector, backend, width, height, background);
+    this.context = Renderer.buildContext(elementId, backend, width, height, background);
   }
 
   getContext() { return this.context; }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -45,8 +45,8 @@ export class Renderer {
     lastContext = ctx;
   }
 
-  static buildContext(sel, backend, width, height, background) {
-    const renderer = new Renderer(sel, backend);
+  static buildContext(elementId, backend, width, height, background) {
+    const renderer = new Renderer(elementId, backend);
     if (width && height) { renderer.resize(width, height); }
 
     if (!background) background = '#FFF';
@@ -56,16 +56,16 @@ export class Renderer {
     return ctx;
   }
 
-  static getCanvasContext(sel, width, height, background) {
-    return Renderer.buildContext(sel, Renderer.Backends.CANVAS, width, height, background);
+  static getCanvasContext(elementId, width, height, background) {
+    return Renderer.buildContext(elementId, Renderer.Backends.CANVAS, width, height, background);
   }
 
-  static getRaphaelContext(sel, width, height, background) {
-    return Renderer.buildContext(sel, Renderer.Backends.RAPHAEL, width, height, background);
+  static getRaphaelContext(elementId, width, height, background) {
+    return Renderer.buildContext(elementId, Renderer.Backends.RAPHAEL, width, height, background);
   }
 
-  static getSVGContext(sel, width, height, background) {
-    return Renderer.buildContext(sel, Renderer.Backends.SVG, width, height, background);
+  static getSVGContext(elementId, width, height, background) {
+    return Renderer.buildContext(elementId, Renderer.Backends.SVG, width, height, background);
   }
 
   static bolsterCanvasContext(ctx) {
@@ -120,16 +120,14 @@ export class Renderer {
     context.stroke();
   }
 
-  constructor(sel, backend) {
-    // Verify selector
-    this.sel = sel;
-    if (!this.sel) {
-      throw new Vex.RERR('BadArgument', 'Invalid selector for renderer.');
+  constructor(elementId, backend) {
+    this.elementId = elementId;
+    if (!this.elementId) {
+      throw new Vex.RERR('BadArgument', 'Invalid id for renderer.');
     }
 
-    // Get element from selector
-    this.element = document.getElementById(sel);
-    if (!this.element) this.element = sel;
+    this.element = document.getElementById(elementId);
+    if (!this.element) this.element = elementId;
 
     // Verify backend and create context
     this.ctx = null;
@@ -138,7 +136,7 @@ export class Renderer {
     if (this.backend === Renderer.Backends.CANVAS) {
       // Create context.
       if (!this.element.getContext) {
-        throw new Vex.RERR('BadElement', `Can't get canvas context from element: ${sel}`);
+        throw new Vex.RERR('BadElement', `Can't get canvas context from element: ${elementId}`);
       }
       this.ctx = Renderer.bolsterCanvasContext(this.element.getContext('2d'));
     } else if (this.backend === Renderer.Backends.RAPHAEL) {
@@ -153,7 +151,9 @@ export class Renderer {
   resize(width, height) {
     if (this.backend === Renderer.Backends.CANVAS) {
       if (!this.element.getContext) {
-        throw new Vex.RERR('BadElement', `Can't get canvas context from element: ${this.sel}`);
+        throw new Vex.RERR(
+          'BadElement', `Can't get canvas context from element: ${this.elementId}`
+        );
       }
       this.element.width = width;
       this.element.height = height;

--- a/src/system.js
+++ b/src/system.js
@@ -67,11 +67,22 @@ export class System extends Element {
 
     if (!params.stave) {
       const options = { left_bar: false };
-      params.stave = this.factory.Stave(
-        { x: this.options.x, y: this.options.y, width: this.options.width, options });
+      params.stave = this.factory.Stave({
+        x: this.options.x,
+        y: this.options.y,
+        width: this.options.width,
+        options,
+      });
     }
 
-    params.voices.forEach(voice => voice.setContext(this.context).setStave(params.stave));
+    params.voices.forEach(voice =>
+      voice
+        .setContext(this.context)
+        .setStave(params.stave)
+        .getTickables()
+        .forEach(tickable => tickable.setStave(params.stave))
+    );
+
     this.parts.push(params);
     return params.stave;
   }

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -20,7 +20,7 @@ VF.Test.Annotation = (function() {
     },
 
     simple: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = " 10pt Arial";
       var stave = new VF.TabStave(10, 10, 450).
@@ -45,7 +45,7 @@ VF.Test.Annotation = (function() {
     },
 
     standard: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       var stave = new VF.Stave(10, 10, 450).
         addClef("treble").setContext(ctx).draw();
@@ -67,7 +67,7 @@ VF.Test.Annotation = (function() {
     },
 
     harmonic: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = " 10pt Arial";
       var stave = new VF.TabStave(10, 10, 450).
@@ -93,7 +93,7 @@ VF.Test.Annotation = (function() {
     },
 
     picking: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.setFillStyle("#221"); ctx.setStrokeStyle("#221");
       ctx.setFont("Arial", VF.Test.Font.size, "");
       var stave = new VF.TabStave(10, 10, 450).
@@ -133,7 +133,7 @@ VF.Test.Annotation = (function() {
     },
 
     bottom: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       var stave = new VF.Stave(10, 10, 300).
         addClef("treble").setContext(ctx).draw();
@@ -162,7 +162,7 @@ VF.Test.Annotation = (function() {
     },
 
     bottomWithBeam: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       var stave = new VF.Stave(10, 10, 300).
         addClef("treble").setContext(ctx).draw();
@@ -194,7 +194,7 @@ VF.Test.Annotation = (function() {
     },
 
     justificationStemUp: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 650, 950);
+      var ctx = contextBuilder(options.elementId, 650, 950);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
 
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
@@ -223,7 +223,7 @@ VF.Test.Annotation = (function() {
     },
 
     justificationStemDown: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 650, 1000);
+      var ctx = contextBuilder(options.elementId, 650, 1000);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
 
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
@@ -252,7 +252,7 @@ VF.Test.Annotation = (function() {
     },
 
     tabNotes: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -34,7 +34,7 @@ VF.Test.Articulation = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 625, 195);
+      var ctx = contextBuilder(options.elementId, 625, 195);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 125);
@@ -116,7 +116,7 @@ VF.Test.Articulation = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 400, 200);
+      var ctx = contextBuilder(options.elementId, 400, 200);
 
       // bar 1
       var staveBar1 = new VF.Stave(50, 30, 150);
@@ -162,7 +162,7 @@ VF.Test.Articulation = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 725, 200);
+      var ctx = contextBuilder(options.elementId, 725, 200);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 250);
@@ -277,7 +277,7 @@ VF.Test.Articulation = (function() {
     },
 
     tabNotes: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/bend_tests.js
+++ b/tests/bend_tests.js
@@ -16,7 +16,7 @@ VF.Test.Bend = (function() {
     },
 
     doubleBends: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = new contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.setRawFont(" 10pt Arial");
       var stave = new VF.TabStave(10, 10, 450).
@@ -49,7 +49,7 @@ VF.Test.Bend = (function() {
     },
 
     doubleBendsWithRelease: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 550, 240);
+      var ctx = new contextBuilder(options.elementId, 550, 240);
       ctx.scale(1.0, 1.0);
       ctx.setBackgroundFillStyle("#FFF");
       ctx.setFont("Arial", VF.Test.Font.size);
@@ -87,7 +87,7 @@ VF.Test.Bend = (function() {
     },
 
     reverseBends: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = new contextBuilder(options.elementId, 500, 240);
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.setRawFont("10pt Arial");
@@ -127,7 +127,7 @@ VF.Test.Bend = (function() {
     },
 
     bendPhrase: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = new contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.setRawFont(" 10pt Arial");
       var stave = new VF.TabStave(10, 10, 450).
@@ -165,7 +165,7 @@ VF.Test.Bend = (function() {
     },
 
     whackoBends: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 240);
+      var ctx = new contextBuilder(options.elementId, 400, 240);
       ctx.scale(1.0, 1.0); ctx.setBackgroundFillStyle("#FFF");
       ctx.setFont("Arial", VF.Test.Font.size);
       var stave = new VF.TabStave(10, 10, 350).

--- a/tests/dot_tests.js
+++ b/tests/dot_tests.js
@@ -47,7 +47,7 @@ VF.Test.Dot = (function() {
     },
 
     basic: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 1000, 240);
+      var ctx = new contextBuilder(options.elementId, 1000, 240);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
 
@@ -95,7 +95,7 @@ VF.Test.Dot = (function() {
     },
 
     multiVoice: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 300);
+      var ctx = new contextBuilder(options.elementId, 500, 300);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
 

--- a/tests/factory_tests.js
+++ b/tests/factory_tests.js
@@ -34,10 +34,8 @@ Vex.Flow.Test.Factory = (function() {
       var options = vf.getOptions();
       assert.equal(options.renderer.width, 700);
       assert.equal(options.renderer.height, 500);
-      assert.equal(options.renderer.selector, null);
+      assert.equal(options.renderer.elementId, null);
       assert.equal(options.stave.space, 10);
-
-      assert.expect(5);
     },
 
     draw: function(options) {

--- a/tests/factory_tests.js
+++ b/tests/factory_tests.js
@@ -25,7 +25,7 @@ Vex.Flow.Test.Factory = (function() {
 
       var vf = new VF.Factory({
         renderer: {
-          selector: null,
+          elementId: null,
           width: 700,
           height: 500
         }
@@ -35,18 +35,18 @@ Vex.Flow.Test.Factory = (function() {
       assert.equal(options.renderer.width, 700);
       assert.equal(options.renderer.height, 500);
       assert.equal(options.renderer.selector, null);
-      assert.equal(options.stave.space, 10); 
+      assert.equal(options.stave.space, 10);
 
       assert.expect(5);
     },
 
     draw: function(options) {
-      var vf = VF.Factory.newFromSelector(options.canvas_sel);
+      var vf = VF.Factory.newFromElementId(options.elementId);
       vf.Stave().setClef('treble');
       vf.draw();
       expect(0);
     }
   };
 
-  return Factory;  
+  return Factory;
 })();

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -8,8 +8,7 @@
   <script src="../build/vexflow-debug.js"></script>
 
   <!-- Test Dependencies: jQuery, QUnit -->
-  <link rel="stylesheet" href="support/qunit.css"
-    type="text/css" media="screen" />
+  <link rel="stylesheet" href="support/qunit.css" type="text/css" media="screen" />
   <script src="support/jquery.js"></script>
   <script src="support/qunit.js"></script>
 

--- a/tests/gracetabnote_tests.js
+++ b/tests/gracetabnote_tests.js
@@ -12,7 +12,7 @@ VF.Test.GraceTabNote = (function() {
     },
 
     setupContext: function(options, x, y) {
-      var ctx = options.contextBuilder(options.canvas_sel, 350, 140);
+      var ctx = options.contextBuilder(options.elementId, 350, 140);
       var stave = new VF.TabStave(10, 10, x || 350).addTabGlyph().
         setContext(ctx).draw();
 

--- a/tests/key_clef_tests.js
+++ b/tests/key_clef_tests.js
@@ -102,7 +102,7 @@ VF.Test.ClefKeySignature = (function() {
         "subbass",
         "percussion"];
 
-      var ctx = new contextBuilder(options.canvas_sel, 400, 20 + 80 * 2 * clefs.length);
+      var ctx = new contextBuilder(options.elementId, 400, 20 + 80 * 2 * clefs.length);
 
 
       var staves = [];
@@ -140,7 +140,7 @@ VF.Test.ClefKeySignature = (function() {
     },
 
     staveHelper: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 400);
+      var ctx = new contextBuilder(options.elementId, 400, 400);
       var stave = new VF.Stave(10, 10, 370);
       var stave2 = new VF.Stave(10, 90, 370);
       var stave3 = new VF.Stave(10, 170, 370);

--- a/tests/keysignature_tests.js
+++ b/tests/keysignature_tests.js
@@ -83,7 +83,7 @@ VF.Test.KeySignature = (function() {
     },
 
     majorKeys: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 240);
+      var ctx = new contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MAJOR_KEYS;
@@ -109,7 +109,7 @@ VF.Test.KeySignature = (function() {
     },
 
     majorKeysCanceled: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 780, 500);
+      var ctx = new contextBuilder(options.elementId, 780, 500);
       ctx.scale(0.9, 0.9);
       var stave = new VF.Stave(10, 10, 750).addTrebleGlyph();
       var stave2 = new VF.Stave(10, 90, 750).addTrebleGlyph();
@@ -163,7 +163,7 @@ VF.Test.KeySignature = (function() {
     },
 
     majorKeysAltered: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 780, 500);
+      var ctx = new contextBuilder(options.elementId, 780, 500);
       ctx.scale(0.9, 0.9);
       var stave = new VF.Stave(10, 10, 750).addTrebleGlyph();
       var stave2 = new VF.Stave(10, 90, 750).addTrebleGlyph();
@@ -215,7 +215,7 @@ VF.Test.KeySignature = (function() {
     },
 
     minorKeys: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 240);
+      var ctx = new contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MINOR_KEYS;
@@ -241,7 +241,7 @@ VF.Test.KeySignature = (function() {
     },
 
     staveHelper: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 240);
+      var ctx = new contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MAJOR_KEYS;

--- a/tests/notehead_tests.js
+++ b/tests/notehead_tests.js
@@ -13,7 +13,7 @@ VF.Test.NoteHead = (function() {
 
     setupContext: function(options, x, y) {
 
-      var ctx = new options.contextBuilder(options.canvas_sel, x || 450, y || 140);
+      var ctx = new options.contextBuilder(options.elementId, x || 450, y || 140);
       ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = " 10pt Arial";
       var stave = new VF.Stave(10, 10, x || 450).addTrebleGlyph();

--- a/tests/ornament_tests.js
+++ b/tests/ornament_tests.js
@@ -20,7 +20,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 750, 195);
+      var ctx = contextBuilder(options.elementId, 750, 195);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 700);
@@ -63,7 +63,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 750, 195);
+      var ctx = contextBuilder(options.elementId, 750, 195);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 700);
@@ -106,7 +106,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 550, 195);
+      var ctx = contextBuilder(options.elementId, 550, 195);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 500);
@@ -131,7 +131,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 550, 195);
+      var ctx = contextBuilder(options.elementId, 550, 195);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 500);
@@ -162,7 +162,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel,650, 250);
+      var ctx = contextBuilder(options.elementId,650, 250);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 60, 600);

--- a/tests/percussion_tests.js
+++ b/tests/percussion_tests.js
@@ -152,7 +152,7 @@ VF.Test.Percussion = (function() {
     },
 
     draw: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = new contextBuilder(options.elementId, 400, 120);
 
       new VF.Stave(10, 10, 300)
         .addClef('percussion')
@@ -182,7 +182,7 @@ VF.Test.Percussion = (function() {
         { keys: ['g/5/x3'], duration: '4' },
       ];
 
-      var ctx = new contextBuilder(options.canvas_sel, notes.length * 25 + 100, 240);
+      var ctx = new contextBuilder(options.elementId, notes.length * 25 + 100, 240);
 
       // Draw two staves, one with up-stems and one with down-stems.
       for (var h = 0; h < 2; ++h) {

--- a/tests/registry_tests.js
+++ b/tests/registry_tests.js
@@ -16,7 +16,7 @@ Vex.Flow.Test.Registry = (function() {
 
     registerAndClear: function(assert) {
       var registry = new VF.Registry();
-      var score = new VF.EasyScore({factory: VF.Factory.newFromSelector(null)});
+      var score = new VF.EasyScore({factory: VF.Factory.newFromElementId(null)});
 
       registry.register(score.notes('C4')[0], 'foobar');
 
@@ -27,7 +27,7 @@ Vex.Flow.Test.Registry = (function() {
       registry.clear();
       assert.notOk(registry.getElementById('foobar'));
       assert.throws(function() {registry.register(score.notes('C4'))});
-      
+
       registry.clear();
       assert.ok(registry
         .register(score.notes('C4[id="boobar"]')[0])
@@ -36,7 +36,7 @@ Vex.Flow.Test.Registry = (function() {
 
     defaultRegistry: function(assert) {
       var registry = new VF.Registry();
-      var score = new VF.EasyScore({factory: VF.Factory.newFromSelector(null)});
+      var score = new VF.EasyScore({factory: VF.Factory.newFromElementId(null)});
 
       VF.Registry.enableDefaultRegistry(registry);
       score.notes('C4[id="foobar"]');
@@ -57,12 +57,12 @@ Vex.Flow.Test.Registry = (function() {
 
     classes: function(assert) {
       var registry = new VF.Registry();
-      var score = new VF.EasyScore({factory: VF.Factory.newFromSelector(null)});
+      var score = new VF.EasyScore({factory: VF.Factory.newFromElementId(null)});
 
       VF.Registry.enableDefaultRegistry(registry);
       score.notes('C4[id="foobar"]');
       const note = registry.getElementById('foobar');
- 
+
       note.addClass('foo');
       assert.ok(note.hasClass('foo'));
       assert.notOk(note.hasClass('boo'));
@@ -84,5 +84,5 @@ Vex.Flow.Test.Registry = (function() {
     }
   };
 
-  return Registry;  
+  return Registry;
 })();

--- a/tests/rests_tests.js
+++ b/tests/rests_tests.js
@@ -22,7 +22,7 @@ VF.Test.Rests = (function() {
     },
 
     setupContext: function(options, contextBuilder, x, y) {
-      var ctx = new contextBuilder(options.canvas_sel, x || 350, y || 150);
+      var ctx = new contextBuilder(options.elementId, x || 350, y || 150);
       ctx.scale(0.9, 0.9);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -294,7 +294,7 @@ VF.Test.Rests = (function() {
     },
 
     multi: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
 
       var stave = new VF.Stave(50, 10, 500)
         .addClef('treble')

--- a/tests/rhythm_tests.js
+++ b/tests/rhythm_tests.js
@@ -16,7 +16,7 @@ VF.Test.Rhythm = (function() {
     },
 
     drawSlash: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 350, 180);
+      var ctx = new contextBuilder(options.elementId, 350, 180);
       var stave = new VF.Stave(10, 10, 350);
       stave.setContext(ctx);
       stave.draw();
@@ -43,7 +43,7 @@ VF.Test.Rhythm = (function() {
     },
 
     drawBasic: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 150);
@@ -133,7 +133,7 @@ VF.Test.Rhythm = (function() {
     },
 
     drawBeamedSlashNotes: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -186,7 +186,7 @@ VF.Test.Rhythm = (function() {
 
     drawSlashAndBeamAndRests : function(options,
                                                               contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -253,7 +253,7 @@ VF.Test.Rhythm = (function() {
 
     drawSixtenthWithScratches : function(options,
                                                                contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -310,7 +310,7 @@ VF.Test.Rhythm = (function() {
 
     drawThirtySecondWithScratches : function(options,
                                                                    contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -84,7 +84,7 @@ VF.Test.Stave = (function() {
     },
 
     draw: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 150);
+      var ctx = new contextBuilder(options.elementId, 400, 150);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();
@@ -98,7 +98,7 @@ VF.Test.Stave = (function() {
     },
 
     drawOpenStave: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 350);
+      var ctx = new contextBuilder(options.elementId, 400, 350);
       var stave = new VF.Stave(10, 10, 300, {left_bar: false});
       stave.setContext(ctx);
       stave.draw();
@@ -111,7 +111,7 @@ VF.Test.Stave = (function() {
     },
 
     drawVerticalBar: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();
@@ -127,7 +127,7 @@ VF.Test.Stave = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 550, 200);
+      var ctx = contextBuilder(options.elementId, 550, 200);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 50, 200);
@@ -182,7 +182,7 @@ VF.Test.Stave = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 750, 120);
+      var ctx = contextBuilder(options.elementId, 750, 120);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 0, 250);
@@ -268,7 +268,7 @@ VF.Test.Stave = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.canvas_sel, 725, 200);
+      var ctx = contextBuilder(options.elementId, 725, 200);
 
       // bar 1
       var mm1 = new VF.Stave(10, 50, 125);
@@ -384,7 +384,7 @@ VF.Test.Stave = (function() {
     drawTempo: function(options, contextBuilder) {
       expect(0);
 
-      var ctx = contextBuilder(options.canvas_sel, 725, 350);
+      var ctx = contextBuilder(options.elementId, 725, 350);
       var padding = 10, x = 0, y = 50;
 
       function drawTempoStaveBar(width, tempo, tempo_y, notes) {
@@ -438,7 +438,7 @@ VF.Test.Stave = (function() {
     },
 
     configureSingleLine: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = new contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setConfigForLine(0, { visible: true })
         .setConfigForLine(1, { visible: false })
@@ -458,7 +458,7 @@ VF.Test.Stave = (function() {
     },
 
     configureAllLines: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = new contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setConfigForLines([
         { visible: false },
@@ -479,7 +479,7 @@ VF.Test.Stave = (function() {
     },
 
     drawStaveText: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 900, 140);
+      var ctx = new contextBuilder(options.elementId, 900, 140);
       var stave = new VF.Stave(300, 10, 300);
       stave.setText("Violin", VF.Modifier.Position.LEFT);
       stave.setText("Right Text", VF.Modifier.Position.RIGHT);
@@ -491,7 +491,7 @@ VF.Test.Stave = (function() {
     },
 
     drawStaveTextMultiLine: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 900, 200);
+      var ctx = new contextBuilder(options.elementId, 900, 200);
       var stave = new VF.Stave(300, 40, 300);
       stave.setText("Violin", VF.Modifier.Position.LEFT, {shift_y: -10});
       stave.setText("2nd line", VF.Modifier.Position.LEFT, {shift_y: 10});

--- a/tests/staveconnector_tests.js
+++ b/tests/staveconnector_tests.js
@@ -25,7 +25,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawSingle: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -42,7 +42,7 @@ VF.Test.StaveConnector = (function() {
 
     drawSingle1pxBarlines: function(options, contextBuilder) {
       VF.STAVE_LINE_THICKNESS = 1;
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -59,7 +59,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawSingleBoth: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -79,7 +79,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawDouble: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -100,7 +100,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawBrace: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 450, 300);
+      var ctx = new contextBuilder(options.elementId, 450, 300);
       var stave = new VF.Stave(100, 10, 300);
       var stave2 = new VF.Stave(100, 120, 300);
       stave.setContext(ctx);
@@ -122,7 +122,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawBraceWide: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, -20, 300);
       var stave2 = new VF.Stave(25, 200, 300);
       stave.setContext(ctx);
@@ -143,7 +143,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawBracket: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -164,7 +164,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawRepeatBegin: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -183,7 +183,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawRepeatEnd: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -202,7 +202,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawThinDouble: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -221,7 +221,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawRepeatAdjacent: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(175, 10, 150);
@@ -265,7 +265,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawRepeatOffset2: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(175, 10, 150);
@@ -329,7 +329,7 @@ VF.Test.StaveConnector = (function() {
       ok(true, "all pass");
     },
     drawRepeatOffset: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 300);
+      var ctx = new contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(175, 10, 150);
@@ -396,7 +396,7 @@ VF.Test.StaveConnector = (function() {
     },
 
     drawCombined: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 550, 700);
+      var ctx = new contextBuilder(options.elementId, 550, 700);
       var stave = new VF.Stave(150, 10, 300);
       var stave2 = new VF.Stave(150, 100, 300);
       var stave3 = new VF.Stave(150, 190, 300);

--- a/tests/stavemodifier_tests.js
+++ b/tests/stavemodifier_tests.js
@@ -15,7 +15,7 @@ VF.Test.StaveModifier = (function() {
     },
 
     draw: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = new contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();
@@ -29,7 +29,7 @@ VF.Test.StaveModifier = (function() {
     },
 
     drawVerticalBar: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();
@@ -41,7 +41,7 @@ VF.Test.StaveModifier = (function() {
     },
 
     drawBeginAndEnd: function(options, contextBuilder) {
-      var ctx = contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       var stave = new VF.Stave(10, 10, 400);
       stave.setContext(ctx);
       stave.setTimeSignature('C|');

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -233,7 +233,7 @@ VF.Test.StaveNote = (function() {
       var octaveShift = options.params.octaveShift;
       var restKey = options.params.restKey;
 
-      var ctx = new contextBuilder(options.canvas_sel, 700, 180);
+      var ctx = new contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 30, 750);
       stave.setContext(ctx);
       stave.addClef(clef);
@@ -313,7 +313,7 @@ VF.Test.StaveNote = (function() {
       var octaveShift = options.params.octaveShift;
       var restKey = options.params.restKey;
 
-      var ctx = new contextBuilder(options.canvas_sel, 700, 180);
+      var ctx = new contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 30, 750);
       stave.setContext(ctx);
       stave.addClef(clef);
@@ -373,7 +373,7 @@ VF.Test.StaveNote = (function() {
 
     drawBass: function(options, contextBuilder) {
       expect(40);
-      var ctx = new contextBuilder(options.canvas_sel, 600, 280);
+      var ctx = new contextBuilder(options.elementId, 600, 280);
       var stave = new VF.Stave(10, 10, 650);
       stave.setContext(ctx);
       stave.addClef('bass');
@@ -414,7 +414,7 @@ VF.Test.StaveNote = (function() {
     },
 
     displacements: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 700, 140);
+      var ctx = new contextBuilder(options.elementId, 700, 140);
       ctx.scale(0.9, 0.9);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -452,7 +452,7 @@ VF.Test.StaveNote = (function() {
     },
 
     drawHarmonicAndMuted: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 300, 180);
+      var ctx = new contextBuilder(options.elementId, 300, 180);
       var stave = new VF.Stave(10, 10, 280);
       stave.setContext(ctx);
       stave.draw();
@@ -509,7 +509,7 @@ VF.Test.StaveNote = (function() {
     },
 
     drawSlash: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 700, 180);
+      var ctx = new contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 10, 650);
       stave.setContext(ctx);
       stave.draw();
@@ -555,7 +555,7 @@ VF.Test.StaveNote = (function() {
     },
 
     drawKeyStyles: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 300, 280);
+      var ctx = new contextBuilder(options.elementId, 300, 280);
       ctx.scale(3, 3);
 
       var stave = new VF.Stave(10, 0, 100);
@@ -578,7 +578,7 @@ VF.Test.StaveNote = (function() {
     },
 
     drawNoteStyles: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 300, 280);
+      var ctx = new contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
       ctx.scale(3, 3);
 
@@ -619,7 +619,7 @@ VF.Test.StaveNote = (function() {
     },
 
     dotsAndFlagsStemUp: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -654,7 +654,7 @@ VF.Test.StaveNote = (function() {
 
 
     dotsAndFlagsStemDown: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 160);
+      var ctx = new contextBuilder(options.elementId, 800, 160);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -688,7 +688,7 @@ VF.Test.StaveNote = (function() {
     },
 
     dotsAndBeamsUp: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 150);
+      var ctx = new contextBuilder(options.elementId, 800, 150);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -724,7 +724,7 @@ VF.Test.StaveNote = (function() {
     },
 
     dotsAndBeamsDown: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 800, 160);
+      var ctx = new contextBuilder(options.elementId, 800, 160);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');

--- a/tests/tabnote_tests.js
+++ b/tests/tabnote_tests.js
@@ -89,7 +89,7 @@ VF.Test.TabNote = (function() {
     },
 
     draw: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 140);
+      var ctx = new contextBuilder(options.elementId, 600, 140);
 
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550);
@@ -123,7 +123,7 @@ VF.Test.TabNote = (function() {
     },
 
     drawStemsUp: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 30, 550);
       stave.setContext(ctx);
@@ -154,7 +154,7 @@ VF.Test.TabNote = (function() {
     },
 
     drawStemsDown: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
 
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550);
@@ -187,7 +187,7 @@ VF.Test.TabNote = (function() {
     },
 
     drawStemsUpThrough: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 30, 550);
       stave.setContext(ctx);
@@ -220,7 +220,7 @@ VF.Test.TabNote = (function() {
     },
 
     drawStemsDownThrough: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 250);
+      var ctx = new contextBuilder(options.elementId, 600, 250);
 
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550,{num_lines:8});
@@ -256,7 +256,7 @@ VF.Test.TabNote = (function() {
     },
 
     drawStemsDotted: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 600, 200);
+      var ctx = new contextBuilder(options.elementId, 600, 200);
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/tabslide_tests.js
+++ b/tests/tabslide_tests.js
@@ -33,7 +33,7 @@ VF.Test.TabSlide = (function() {
     },
 
     setupContext: function(options, x, y) {
-      var ctx = options.contextBuilder(options.canvas_sel, 350, 140);
+      var ctx = options.contextBuilder(options.elementId, 350, 140);
       ctx.scale(0.9, 0.9); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = "10pt Arial";
       var stave = new VF.TabStave(10, 10, x || 350).addTabGlyph().

--- a/tests/tabstave_tests.js
+++ b/tests/tabstave_tests.js
@@ -12,7 +12,7 @@ VF.Test.TabStave = (function() {
     },
 
     draw: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 160);
+      var ctx = new contextBuilder(options.elementId, 400, 160);
       var stave = new VF.TabStave(10, 10, 300);
       stave.setNumLines(6);
       stave.setContext(ctx);
@@ -27,7 +27,7 @@ VF.Test.TabStave = (function() {
     },
 
     drawVerticalBar: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 400, 160);
+      var ctx = new contextBuilder(options.elementId, 400, 160);
       var stave = new VF.TabStave(10, 10, 300);
       stave.setNumLines(6);
       stave.setContext(ctx);

--- a/tests/tabtie_tests.js
+++ b/tests/tabtie_tests.js
@@ -35,7 +35,7 @@ VF.Test.TabTie = (function() {
     },
 
     setupContext: function(options, x, y) {
-      var ctx = options.contextBuilder(options.canvas_sel, x || 350, y || 160);
+      var ctx = options.contextBuilder(options.elementId, x || 350, y || 160);
       ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.setFont("Arial", VF.Test.Font.size, "");
       var stave = new VF.TabStave(10, 10, x || 350).addTabGlyph().

--- a/tests/threevoice_tests.js
+++ b/tests/threevoice_tests.js
@@ -229,4 +229,4 @@ VF.Test.ThreeVoices = (function() {
   };
 
   return ThreeVoices;
-})();
+}());

--- a/tests/timesignature_tests.js
+++ b/tests/timesignature_tests.js
@@ -28,7 +28,7 @@ VF.Test.TimeSignature = (function() {
       var run = VF.Test.runTests;
 
       run('Basic Time Signatures', function(options, contextBuilder) {
-        var ctx = new contextBuilder(options.canvas_sel, 600, 120);
+        var ctx = new contextBuilder(options.elementId, 600, 120);
 
         new VF.Stave(10, 10, 500)
           .addTimeSignature('2/2')
@@ -51,7 +51,7 @@ VF.Test.TimeSignature = (function() {
       });
 
       run('Big Signature Test', function(options, contextBuilder) {
-        var ctx = new contextBuilder(options.canvas_sel, 400, 120);
+        var ctx = new contextBuilder(options.elementId, 400, 120);
 
         new VF.Stave(10, 10, 300)
           .addTimeSignature('12/8')
@@ -65,7 +65,7 @@ VF.Test.TimeSignature = (function() {
       });
 
       run('Time Signature multiple staves alignment test', function(options, contextBuilder) {
-        var ctx = new contextBuilder(options.canvas_sel, 400, 350);
+        var ctx = new contextBuilder(options.elementId, 400, 350);
 
         var stave = new VF.Stave(15, 0, 300)
           .setConfigForLines(

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -8,15 +8,15 @@
 if (!window.QUnit) {
   var process = require('system');
 
-  window.QUnit = {}
+  window.QUnit = {};
 
   QUnit.assertions = {
-    ok: function() {return true;},
-    equal: function() {return true;},
-    deepEqual: function() {return true;},
-    expect: function() {return true;},
-    throws: function() {return true;},
-    notOk: function() {return true;}
+    ok: function() { return true; },
+    equal: function() { return true; },
+    deepEqual: function() { return true; },
+    expect: function() { return true; },
+    throws: function() { return true; },
+    notOk: function() { return true; },
   };
 
   QUnit.module = function(name) {
@@ -25,7 +25,7 @@ if (!window.QUnit) {
 
   QUnit.test = function(name, func) {
     QUnit.current_test = name;
-    process.stdout.write("\033[0G" + QUnit.current_module + " :: " + name + "\033[0K");
+    process.stdout.write(" \033[0G" + QUnit.current_module + " :: " + name + "\033[0K");
     func(QUnit.assertions);
   };
 
@@ -38,7 +38,7 @@ if (!window.QUnit) {
   notOk = QUnit.assertions.notOk;
 }
 
-if (typeof require == "function") {
+if (typeof require === 'function') {
   Vex = require('./vexflow-debug.js');
 }
 
@@ -52,13 +52,19 @@ VF.Test = (function() {
     RUN_NODE_TESTS: false,
 
     // Where images are stored for NodeJS tests.
-    NODE_IMAGEDIR: "images",
+    NODE_IMAGEDIR: 'images',
 
     // Default font properties for tests.
-    Font: {size: 10},
+    Font: { size: 10 },
 
     // Returns a unique ID for a test.
-    genID: function() { return VF.Test.genID.ID++; },
+    genID: function(prefix) {
+      return prefix + VF.Test.genID.ID++;
+    },
+
+    genTitle: function(type, assert, name) {
+      return assert.test.module.name + ' (' + type + '): ' + name;
+    },
 
     // Run `func` inside a QUnit test for each of the enabled
     // rendering backends.
@@ -86,86 +92,115 @@ VF.Test = (function() {
       }
     },
 
-    createTestCanvas: function(canvas_sel_name, test_name) {
-      var sel = VF.Test.createTestCanvas.sel;
-      var test_div = $('<div></div>').addClass("testcanvas");
-      test_div.append($('<div></div>').addClass("name").text(test_name));
-      test_div.append($('<canvas></canvas>').addClass("vex-tabdiv").
-          attr("id", canvas_sel_name).
-          addClass("name").text(name));
-      $(sel).append(test_div);
+    createTestCanvas: function(testId, testName) {
+      var testContainer = $('<div></div>').addClass('testcanvas');
+
+      testContainer.append(
+        $('<div></div>')
+          .addClass('name')
+          .text(testName)
+      );
+
+      testContainer.append(
+        $('<canvas></canvas>')
+          .addClass('vex-tabdiv')
+          .attr('id', testId)
+          .addClass('name')
+          .text(name)
+      );
+
+      $(VF.Test.testRootSelector).append(testContainer);
     },
 
-    createTestSVG: function(canvas_sel_name, test_name) {
-      var sel = VF.Test.createTestCanvas.sel;
-      var test_div = $('<div></div>').addClass("testcanvas");
-      test_div.append($('<div></div>').addClass("name").text(test_name));
-      test_div.append($('<div></div>').addClass("vex-tabdiv").
-          attr("id", canvas_sel_name));
-      $(sel).append(test_div);
+    createTestSVG: function(testId, testName) {
+      var testContainer = $('<div></div>').addClass('testcanvas');
+
+      testContainer.append(
+        $('<div></div>')
+          .addClass('name')
+          .text(testName)
+      );
+
+      testContainer.append(
+        $('<div></div>')
+          .addClass('vex-tabdiv')
+          .attr('id', testId)
+      );
+
+      $(VF.Test.testRootSelector).append(testContainer);
     },
 
-    resizeCanvas: function(sel, width, height) {
-      $("#" + sel).width(width);
-      $("#" + sel).attr("width", width);
-      $("#" + sel).attr("height", height);
+    resizeCanvas: function(elementId, width, height) {
+      $('#' + elementId).width(width);
+      $('#' + elementId).attr('width', width);
+      $('#' + elementId).attr('height', height);
     },
 
     makeFactory: function(options, width, height) {
       return new VF.Factory({
         renderer: {
-          selector: options.canvas_sel,
+          elementId: options.elementId,
           backend: options.backend,
           width: width || 450,
           height: height || 140,
-        }
-      })
+        },
+      });
     },
 
-    runCanvasTest: function(name, func, params) {
+    runCanvasTest: function(name, testFunc, params) {
       QUnit.test(name, function(assert) {
-        // console.log("Running test (Canvas):", assert.test.module.name, "--", name);
-          var test_canvas_sel = "canvas_" + VF.Test.genID();
-          var test_canvas = VF.Test.createTestCanvas(test_canvas_sel,
-            assert.test.module.name + " (Canvas): " + name);
-          func({
-            canvas_sel: test_canvas_sel,
-            backend: VF.Renderer.Backends.CANVAS,
-            params: params,
-            assert: assert },
-            VF.Renderer.getCanvasContext);
-        });
+        var elementId = VF.Test.genID('canvas_');
+        var title = VF.Test.genTitle('Canvas', assert, name);
+
+        VF.Test.createTestCanvas(elementId, title);
+
+        var testOptions = {
+          backend: VF.Renderer.Backends.CANVAS,
+          elementId: elementId,
+          params: params,
+          assert: assert,
+        };
+
+        testFunc(testOptions, VF.Renderer.getCanvasContext);
+      });
     },
 
     runRaphaelTest: function(name, func, params) {
       QUnit.test(name, function(assert) {
-          // console.log("Running test (Raphael):", assert.test.module.name, "--", name);
-          var test_canvas_sel = "canvas_" + VF.Test.genID();
-          var test_canvas = VF.Test.createTestSVG(test_canvas_sel,
-            assert.test.module.name + " (Raphael): " + name);
-          func({
-            canvas_sel: test_canvas_sel,
-            backend: VF.Renderer.Backends.RAPHAEL,
-            params: params,
-            assert: assert },
-            VF.Renderer.getRaphaelContext);
-        });
+        var elementId = VF.Test.genID('raphael_');
+        var title = VF.Test.genTitle('Raphael', assert, name);
+
+        VF.Test.createTestSVG(elementId, title);
+
+        var testOptions = {
+          elementId: elementId,
+          backend: VF.Renderer.Backends.RAPHAEL,
+          params: params,
+          assert: assert,
+        };
+
+        func(testOptions, VF.Renderer.getRaphaelContext);
+      });
     },
 
     runSVGTest: function(name, func, params) {
       if (!VF.Test.RUN_SVG_TESTS) return;
+
       QUnit.test(name, function(assert) {
-          // console.log("Running test (SVG):", assert.test.module.name, "--", name);
-          var test_canvas_sel = "canvas_" + VF.Test.genID();
-          var test_canvas = VF.Test.createTestSVG(test_canvas_sel,
-            assert.test.module.name + " (SVG): " + name);
-          func({
-            canvas_sel: test_canvas_sel,
-            backend: VF.Renderer.Backends.SVG,
-            params: params,
-            assert: assert },
-            VF.Renderer.getSVGContext);
-        });
+        var elementId = VF.Test.genID('svg_');
+        var title = VF.Test.genTitle('SVG', assert, name);
+
+        VF.Test.createTestSVG(elementId, title);
+
+        var testOptions = {
+          elementId: elementId,
+          backend: VF.Renderer.Backends.SVG,
+          params: params,
+          assert: assert,
+        };
+
+        func(testOptions, VF.Renderer.getSVGContext);
+      });
     },
 
     runNodeTest: function(name, func, params) {
@@ -173,35 +208,38 @@ VF.Test = (function() {
 
       // Allows `name` to be used inside file names.
       function sanitizeName(name) {
-        return name.replace(/[^a-zA-Z0-9]/g, "_")
+        return name.replace(/[^a-zA-Z0-9]/g, '_');
       }
 
       QUnit.test(name, function(assert) {
-        var div = document.createElement("div");
-        div.setAttribute("id", "canvas_" + VF.Test.genID());
+        var div = document.createElement('div');
+        div.setAttribute('id', VF.Test.genID('node_'));
         document.getElementsByTagName('body')[0].appendChild(div);
 
-        func({
-          canvas_sel: div,
+        var testOptions = {
+          id: div,
           backend: VF.Renderer.Backends.SVG,
           params: params,
-          assert: assert },
-          VF.Renderer.getSVGContext);
+          assert: assert,
+        };
+
+        func(testOptions, VF.Renderer.getSVGContext);
 
         if (VF.Renderer.lastContext != null) {
           // If an SVG context was used, then serialize and save its contents to
           // a local file.
           var svgData = new XMLSerializer().serializeToString(VF.Renderer.lastContext.svg);
-
           var moduleName = sanitizeName(QUnit.current_module);
           var testName = sanitizeName(QUnit.current_test);
-          var filename = VF.Test.NODE_IMAGEDIR + "/" + moduleName + "." + testName + ".svg";
+          var filename = VF.Test.NODE_IMAGEDIR + '/' + moduleName + '.' + testName + '.svg';
+
           try {
-            fs.write(filename, svgData, "w");
-          } catch(e) {
-            console.log("Can't save file: " + filename + ". Error: " + e);
+            fs.write(filename, svgData, 'w');
+          } catch (e) {
+            console.log("Can't save file: " + filename + '. Error: ' + e);
             slimer.exit();
-          };
+          }
+
           VF.Renderer.lastContext = null;
         }
       });
@@ -210,29 +248,29 @@ VF.Test = (function() {
     plotNoteWidth: VF.Note.plotMetrics,
     plotLegendForNoteWidth: function(ctx, x, y) {
       ctx.save();
-      ctx.setFont("Arial", 8, "");
+      ctx.setFont('Arial', 8, '');
 
       var spacing = 12;
       var lastY = y;
 
       function legend(color, text) {
         ctx.beginPath();
-        ctx.setStrokeStyle(color)
-        ctx.setFillStyle(color)
+        ctx.setStrokeStyle(color);
+        ctx.setFillStyle(color);
         ctx.setLineWidth(10);
         ctx.moveTo(x, lastY - 4);
         ctx.lineTo(x + 10, lastY - 4);
         ctx.stroke();
 
-        ctx.setFillStyle("black");
+        ctx.setFillStyle('black');
         ctx.fillText(text, x + 15, lastY);
         lastY += spacing;
       }
 
-      legend("green", "Note + Flag")
-      legend("red", "Modifiers")
-      legend("#999", "Displaced Head")
-      legend("#DDD", "Formatter Shift")
+      legend('green', 'Note + Flag');
+      legend('red', 'Modifiers');
+      legend('#999', 'Displaced Head');
+      legend('#DDD', 'Formatter Shift');
 
       ctx.restore();
     },
@@ -243,7 +281,7 @@ VF.Test = (function() {
   };
 
   Test.genID.ID = 0;
-  Test.createTestCanvas.sel = "#vexflow_testoutput";
+  Test.testRootSelector = '#vexflow_testoutput';
 
   return Test;
-})();
+}());

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -147,7 +147,7 @@ VF.Test = (function() {
       });
     },
 
-    runCanvasTest: function(name, testFunc, params) {
+    runCanvasTest: function(name, func, params) {
       QUnit.test(name, function(assert) {
         var elementId = VF.Test.genID('canvas_');
         var title = VF.Test.genTitle('Canvas', assert, name);
@@ -161,7 +161,7 @@ VF.Test = (function() {
           assert: assert,
         };
 
-        testFunc(testOptions, VF.Renderer.getCanvasContext);
+        func(testOptions, VF.Renderer.getCanvasContext);
       });
     },
 
@@ -212,12 +212,14 @@ VF.Test = (function() {
       }
 
       QUnit.test(name, function(assert) {
+        var elementId = VF.Test.genID('node_');
+
         var div = document.createElement('div');
-        div.setAttribute('id', VF.Test.genID('node_'));
+        div.setAttribute('id', elementId);
         document.getElementsByTagName('body')[0].appendChild(div);
 
         var testOptions = {
-          id: div,
+          elementId: elementId,
           backend: VF.Renderer.Backends.SVG,
           params: params,
           assert: assert,

--- a/tests/vibrato_tests.js
+++ b/tests/vibrato_tests.js
@@ -14,7 +14,7 @@ VF.Test.Vibrato = (function() {
     },
 
     simple: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 140);
+      var ctx = new contextBuilder(options.elementId, 500, 140);
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = "10pt Arial";
@@ -38,7 +38,7 @@ VF.Test.Vibrato = (function() {
     },
 
     harsh: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = new contextBuilder(options.elementId, 500, 240);
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = "#221"; ctx.strokeStyle = "#221";
       ctx.font = "10pt Arial";
@@ -62,7 +62,7 @@ VF.Test.Vibrato = (function() {
     },
 
     withBend: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.canvas_sel, 500, 240);
+      var ctx = new contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.3, 1.3); ctx.setFillStyle("#221"); ctx.setStrokeStyle("#221");
       ctx.setFont("Arial", VF.Test.Font.size, "");
       var stave = new VF.TabStave(10, 10, 450).

--- a/tests/voice_tests.js
+++ b/tests/voice_tests.js
@@ -68,7 +68,7 @@ VF.Test.Voice = (function() {
     },
 
     full: function(options, contextBuilder) {
-      var ctx  = contextBuilder(options.canvas_sel, 550, 200);
+      var ctx  = contextBuilder(options.elementId, 550, 200);
 
       var stave = new VF.Stave(10, 50, 500)
         .addClef('treble')


### PR DESCRIPTION
Pretty much every occurrence of the name `selector`/`sel` is incorrect. [The `Renderer` class uses `document.getElementById` to get a DOM Element](https://github.com/0xfe/vexflow/pull/512/files#diff-5326222f837d36fd2bff476584c07621R129) so in fact passing in a valid selector wouldn't even work. An id on its own, eg: `'container'`, is not the same as a selector which uses an id, eg:  `'#container'`.