### PR TITLE
[Breaking Change] Require stave to be set before formatting StaveNotes

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -206,7 +206,8 @@ export class Formatter {
     // Start by creating a voice and adding all the notes to it.
     const voice = new Voice(Flow.TIME4_4)
       .setMode(Voice.Mode.SOFT)
-      .addTickables(notes);
+      .addTickables(notes)
+      .updateStave(stave);
 
     // Then create beams, if requested.
     const beams = options.auto_beam ? Beam.applyAndGetBeams(voice) : [];
@@ -217,7 +218,7 @@ export class Formatter {
       .formatToStave([voice], stave, { align_rests: options.align_rests, stave });
 
     // Render the voice and beams to the stave.
-    voice.setStave(stave).draw(ctx, stave);
+    voice.draw(ctx);
     beams.forEach(beam => beam.setContext(ctx).draw());
 
     // Return the bounding box of the voice.
@@ -252,12 +253,14 @@ export class Formatter {
     // Create a `4/4` voice for `notes`.
     const notevoice = new Voice(Flow.TIME4_4)
       .setMode(Voice.Mode.SOFT)
-      .addTickables(notes);
+      .addTickables(notes)
+      .updateStave(stave);
 
     // Create a `4/4` voice for `tabnotes`.
     const tabvoice = new Voice(Flow.TIME4_4)
       .setMode(Voice.Mode.SOFT)
-      .addTickables(tabnotes);
+      .addTickables(tabnotes)
+      .updateStave(tabstave);
 
       // Then create beams, if requested.
     const beams = opts.auto_beam ? Beam.applyAndGetBeams(notevoice) : [];
@@ -269,8 +272,8 @@ export class Formatter {
       .formatToStave([notevoice, tabvoice], stave, { align_rests: opts.align_rests });
 
     // Render voices and beams to staves.
-    notevoice.draw(ctx, stave);
-    tabvoice.draw(ctx, tabstave);
+    notevoice.draw(ctx);
+    tabvoice.draw(ctx);
     beams.forEach(beam => beam.setContext(ctx).draw());
 
     // Draw a connector between tab and note staves.
@@ -441,7 +444,7 @@ export class Formatter {
     // If voices and a stave were provided, set the Stave for each voice
     // and preFormat to apply Y values to the notes;
     if (voices && stave) {
-      voices.forEach(voice => voice.setStave(stave).preFormat());
+      voices.forEach(voice => voice.updateStave(stave).preFormat());
     }
 
     // Now distribute the ticks to each tick context, and assign them their

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -839,6 +839,13 @@ export class StaveNote extends StemmableNote {
 
   // Pre-render formatting
   preFormat() {
+    if (!this.stave) {
+      throw new Vex.RERR(
+        'MissingStave',
+        'Can\'t format a StaveNote without a `stave` being set beforehand.'
+      );
+    }
+
     if (this.preFormatted) return;
     if (this.modifierContext) this.modifierContext.preFormat();
 

--- a/src/system.js
+++ b/src/system.js
@@ -74,12 +74,7 @@ export class System extends Element {
         options,
       });
     }
-
-    params.voices.forEach(voice =>
-      voice
-        .setContext(this.context)
-        .updateStave(params.stave)
-    );
+    params.voices.forEach(voice => voice.setContext(this.context));
 
     this.parts.push(params);
     return params.stave;
@@ -101,10 +96,15 @@ export class System extends Element {
       formatter.joinVoices(part.voices);
       y = y + part.stave.space(part.spaceBelow);
       y = y + part.stave.space(this.options.spaceBetweenStaves);
+
       if (part.debugNoteMetrics) {
         debugNoteMetricsYs.push({ y, voice: part.voices[0] });
         y += 15;
       }
+
+      // Now that the staves are positioned, we can update voice's stave
+      part.voices.forEach(voice => voice.updateStave(part.stave));
+
       allVoices = allVoices.concat(part.voices);
 
       startX = Math.max(startX, part.stave.getNoteStartX());

--- a/src/system.js
+++ b/src/system.js
@@ -78,9 +78,7 @@ export class System extends Element {
     params.voices.forEach(voice =>
       voice
         .setContext(this.context)
-        .setStave(params.stave)
-        .getTickables()
-        .forEach(tickable => tickable.setStave(params.stave))
+        .updateStave(params.stave)
     );
 
     this.parts.push(params);

--- a/src/voice.js
+++ b/src/voice.js
@@ -93,9 +93,16 @@ export class Voice extends Element {
   getActualResolution() { return this.resolutionMultiplier * this.time.resolution; }
 
   // Set the voice's stave
-  setStave(stave) {
+  updateStave(stave) {
     this.stave = stave;
     this.boundingBox = null; // Reset bounding box so we can reformat
+
+    this.tickables.forEach(tickable => {
+      if (tickable.setStave) {
+        tickable.setStave(stave);
+      }
+    });
+
     return this;
   }
 
@@ -209,17 +216,22 @@ export class Voice extends Element {
     return this;
   }
 
-  // Render the voice onto the canvas `context` and an optional `stave`.
-  // If `stave` is omitted, it is expected that the notes have staves
-  // already set.
-  draw(context = this.context, stave = this.stave) {
+  // Render the voice onto the canvas `context`
+  draw(context = this.context, stave) {
+    if (stave) {
+      throw new Vex.RERR(
+        'InvalidArgument',
+        'Voice#draw no longer takes a stave because it must be set before ' +
+        'formatting. Use Voice#updateStave to set the stave on each tickable ' +
+        'contained in the voice.'
+      );
+    }
+
     this.setRendered();
+
     let boundingBox = null;
     for (let i = 0; i < this.tickables.length; ++i) {
       const tickable = this.tickables[i];
-
-      // Set the stave if provided
-      if (stave) tickable.setStave(stave);
 
       if (!tickable.getStave()) {
         throw new Vex.RuntimeError(

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -301,18 +301,18 @@ VF.Test.Annotation = (function() {
       notes3[2].addModifier(new VF.Annotation('Text').setVerticalJustification(3), 0); // U
       notes3[3].addModifier(new VF.Annotation('Text').setVerticalJustification(4), 0); // D
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .addTickables(notes2)
+        .addTickables(notes3)
+        .updateStave(stave);
 
-      voice.addTickables(notes);
-      voice.addTickables(notes2);
-      voice.addTickables(notes3);
-
-
-      new VF.Formatter().joinVoices([voice])
+      new VF.Formatter()
+        .joinVoices([voice])
         .formatToStave([voice], stave);
 
-
-      voice.draw(ctx, stave);
+      voice.draw(ctx);
 
       ok(true, 'TabNotes successfully drawn');
     },

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -321,17 +321,18 @@ VF.Test.Articulation = (function() {
       notes3[2].addModifier(new VF.Articulation('a.').setPosition(3), 0);
       notes3[3].addModifier(new VF.Articulation('a.').setPosition(4), 0);
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-
-      voice.addTickables(notes);
-      voice.addTickables(notes2);
-      voice.addTickables(notes3);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .addTickables(notes2)
+        .addTickables(notes3)
+        .updateStave(stave);
 
       new VF.Formatter()
         .joinVoices([voice])
         .formatToStave([voice], stave);
 
-      voice.draw(ctx, stave);
+      voice.draw(ctx);
 
       ok(true, 'TabNotes successfully drawn');
     },

--- a/tests/gracetabnote_tests.js
+++ b/tests/gracetabnote_tests.js
@@ -4,6 +4,8 @@
  */
 
 VF.Test.GraceTabNote = (function() {
+  function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+
   var GraceTabNote = {
     Start: function() {
       QUnit.module('Grace Tab Notes');
@@ -24,7 +26,8 @@ VF.Test.GraceTabNote = (function() {
     simple: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
       var c = VF.Test.GraceTabNote.setupContext(options);
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      var ctx = c.context;
+      var stave = c.stave;
 
       var note0 = newNote({ positions: [{ str: 4, fret: 6 }], duration: '4' });
       var note1 = newNote({ positions: [{ str: 4, fret: 12 }], duration: '4' });
@@ -63,12 +66,15 @@ VF.Test.GraceTabNote = (function() {
       note2.addModifier(new VF.GraceNoteGroup(gracenotes2));
       note3.addModifier(new VF.GraceNoteGroup(gracenotes3));
 
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables([note0, note1, note2, note3]);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables([note0, note1, note2, note3])
+        .updateStave(stave);
 
-      new VF.Formatter().joinVoices([voice]).format([voice], 250);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      voice.draw(c.context, c.stave);
+      voice.draw(ctx);
 
       ok(true, 'Simple Test');
     },
@@ -76,7 +82,8 @@ VF.Test.GraceTabNote = (function() {
     slurred: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
       var c = VF.Test.GraceTabNote.setupContext(options);
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      var ctx = c.context;
+      var stave = c.stave;
 
       var note0 = newNote({ positions: [{ str: 4, fret: 12 }], duration: 'h' });
       var note1 = newNote({ positions: [{ str: 4, fret: 10 }], duration: 'h' });
@@ -102,12 +109,15 @@ VF.Test.GraceTabNote = (function() {
       note0.addModifier(new VF.GraceNoteGroup(gracenotes0, true));
       note1.addModifier(new VF.GraceNoteGroup(gracenotes1, true));
 
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables([note0, note1]);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables([note0, note1])
+        .updateStave(stave);
 
-      new VF.Formatter().joinVoices([voice]).format([voice], 200);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      voice.draw(c.context, c.stave);
+      voice.draw(ctx);
 
       ok(true, 'Slurred Test');
     },

--- a/tests/notehead_tests.js
+++ b/tests/notehead_tests.js
@@ -22,74 +22,79 @@ VF.Test.NoteHead = (function() {
 
     basic: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
-      var c = VF.Test.NoteHead.setupContext(options, 450, 250);
 
-      c.stave = new VF.Stave(10, 0, 250).addTrebleGlyph();
+      var ctx = VF.Test.NoteHead.setupContext(options, 450, 250).context;
+      var stave = new VF.Stave(10, 0, 250).addTrebleGlyph();
+      ctx.scale(2.0, 2.0);
 
-      c.context.scale(2.0, 2.0);
-      c.stave.setContext(c.context).draw();
-
-      var formatter = new VF.Formatter();
-      var voice = new VF.Voice(VF.TIME4_4).setStrict(false);
-
-      var note_head1 = new VF.NoteHead({
+      var notehead1 = new VF.NoteHead({
         duration: '4',
         line: 3,
       });
 
-      var note_head2 = new VF.NoteHead({
+      var notehead2 = new VF.NoteHead({
         duration: '1',
         line: 2.5,
       });
 
-      var note_head3 = new VF.NoteHead({
+      var notehead3 = new VF.NoteHead({
         duration: '2',
         line: 0,
       });
 
-      voice.addTickables([note_head1, note_head2, note_head3]);
-      formatter.joinVoices([voice]).formatToStave([voice], c.stave);
+      var voice = new VF.Voice(VF.TIME4_4)
+        .setStrict(false)
+        .addTickables([notehead1, notehead2, notehead3])
+        .updateStave(stave);
 
-      voice.draw(c.context, c.stave);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      stave.setContext(ctx).draw();
+      voice.draw(ctx);
 
       ok('Basic NoteHead test');
     },
 
     basicBoundingBoxes: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
-      var c = VF.Test.NoteHead.setupContext(options, 350, 250);
 
-      c.stave = new VF.Stave(10, 0, 250).addTrebleGlyph();
+      var ctx = VF.Test.NoteHead.setupContext(options, 350, 250).context;
+      ctx.scale(2.0, 2.0);
 
-      c.context.scale(2.0, 2.0);
-      c.stave.setContext(c.context).draw();
+      var stave = new VF.Stave(10, 0, 250).addTrebleGlyph();
 
-      var formatter = new VF.Formatter();
-      var voice = new VF.Voice(VF.TIME4_4).setStrict(false);
-
-      var note_head1 = new VF.NoteHead({
+      var notehead1 = new VF.NoteHead({
         duration: '4',
         line: 3,
       });
 
-      var note_head2 = new VF.NoteHead({
+      var notehead2 = new VF.NoteHead({
         duration: '2',
         line: 2.5,
       });
 
-      var note_head3 = new VF.NoteHead({
+      var notehead3 = new VF.NoteHead({
         duration: '1',
         line: 0,
       });
 
-      voice.addTickables([note_head1, note_head2, note_head3]);
-      formatter.joinVoices([voice]).formatToStave([voice], c.stave);
+      var voice = new VF.Voice(VF.TIME4_4)
+        .setStrict(false)
+        .addTickables([notehead1, notehead2, notehead3])
+        .updateStave(stave);
 
-      voice.draw(c.context, c.stave);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
 
-      note_head1.getBoundingBox().draw(c.context);
-      note_head2.getBoundingBox().draw(c.context);
-      note_head3.getBoundingBox().draw(c.context);
+      stave.setContext(ctx).draw();
+      voice.draw(ctx);
+
+      notehead1.getBoundingBox().draw(ctx);
+      notehead2.getBoundingBox().draw(ctx);
+      notehead3.getBoundingBox().draw(ctx);
 
       ok('NoteHead Bounding Boxes');
     },

--- a/tests/tabnote_tests.js
+++ b/tests/tabnote_tests.js
@@ -148,17 +148,24 @@ VF.Test.TabNote = (function() {
         return tabNote;
       });
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
+
       ok(true, 'TabNotes successfully drawn');
     },
 
     drawStemsDown: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 600, 200);
-
       ctx.font = '10pt Arial';
+
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);
       stave.draw();
@@ -180,10 +187,16 @@ VF.Test.TabNote = (function() {
         return tabNote;
       });
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
       ok(true, 'All objects have been drawn');
     },
 
@@ -212,10 +225,16 @@ VF.Test.TabNote = (function() {
       });
 
       ctx.setFont('sans-serif', 10, 'bold');
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
       ok(true, 'TabNotes successfully drawn');
     },
 
@@ -247,10 +266,16 @@ VF.Test.TabNote = (function() {
 
       ctx.setFont('Arial', 10, 'bold');
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
       ok(true, 'All objects have been drawn');
     },
 
@@ -277,10 +302,16 @@ VF.Test.TabNote = (function() {
       notes[2].addDot();
       notes[2].addDot();
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).setMode(VF.Voice.Mode.SOFT);
-      voice.addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).formatToStave([voice], stave);
-      voice.draw(ctx, stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .setMode(VF.Voice.Mode.SOFT)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
       ok(true, 'TabNotes successfully drawn');
     },
   };

--- a/tests/tabslide_tests.js
+++ b/tests/tabslide_tests.js
@@ -14,11 +14,15 @@ VF.Test.TabSlide = (function() {
     },
 
     tieNotes: function(notes, indices, stave, ctx) {
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
 
-      new VF.Formatter().joinVoices([voice]).format([voice], 100);
-      voice.draw(ctx, stave);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .format([voice], 100);
+
+      voice.draw(ctx);
 
       var tie = new VF.TabSlide({
         first_note: notes[0],
@@ -45,7 +49,6 @@ VF.Test.TabSlide = (function() {
       return { context: ctx, stave: stave };
     },
 
-
     simple: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
       var c = VF.Test.TabSlide.setupContext(options);
@@ -60,6 +63,8 @@ VF.Test.TabSlide = (function() {
 
     multiTest: function(options, factory) {
       var c = VF.Test.TabSlide.setupContext(options, 440, 100);
+      var ctx = c.context;
+      var stave = c.stave;
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
 
       var notes = [
@@ -73,16 +78,22 @@ VF.Test.TabSlide = (function() {
         newNote({ positions: [{ str: 2, fret: 16 }, { str: 3, fret: 16 }], duration: '8' }),
       ];
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).format([voice], 300);
-      voice.draw(c.context, c.stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .format([voice], stave);
+
+      voice.draw(ctx);
 
       factory({
         first_note: notes[0],
         last_note: notes[1],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Single note');
 
@@ -91,7 +102,7 @@ VF.Test.TabSlide = (function() {
         last_note: notes[3],
         first_indices: [0, 1],
         last_indices: [0, 1],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Chord');
 
@@ -100,7 +111,7 @@ VF.Test.TabSlide = (function() {
         last_note: notes[5],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Single note high-fret');
 
@@ -109,7 +120,7 @@ VF.Test.TabSlide = (function() {
         last_note: notes[7],
         first_indices: [0, 1],
         last_indices: [0, 1],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Chord high-fret');
     },

--- a/tests/tabslide_tests.js
+++ b/tests/tabslide_tests.js
@@ -4,68 +4,74 @@
  */
 
 VF.Test.TabSlide = (function() {
+  function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+
+  function createMultiTest(createTabSlide) {
+    return function(options, contextBuilder) {
+      options.contextBuilder = contextBuilder;
+      VF.Test.TabSlide.multiTest(options, createTabSlide);
+    };
+  }
+
+  function setupContext(options) {
+    var ctx = options.contextBuilder(options.elementId, 350, 140);
+    ctx.scale(0.9, 0.9);
+    ctx.fillStyle = '#221';
+    ctx.strokeStyle = '#221';
+    ctx.font = '10pt Arial';
+    var stave = new VF.TabStave(10, 10, 350).addClef('tab');
+
+    return { context: ctx, stave: stave };
+  }
+
   var TabSlide = {
     Start: function() {
-      var runTests = VF.Test.runTests;
+      var run = VF.Test.runTests;
+
       QUnit.module('TabSlide');
-      runTests('Simple TabSlide', TabSlide.simple);
-      runTests('Slide Up', TabSlide.slideUp);
-      runTests('Slide Down', TabSlide.slideDown);
-    },
 
-    tieNotes: function(notes, indices, stave, ctx) {
-      var voice = new VF.Voice(VF.Test.TIME4_4)
-        .addTickables(notes)
-        .updateStave(stave);
-
-      new VF.Formatter()
-        .joinVoices([voice])
-        .format([voice], 100);
-
-      voice.draw(ctx);
-
-      var tie = new VF.TabSlide({
-        first_note: notes[0],
-        last_note: notes[1],
-        first_indices: indices,
-        last_indices: indices,
-      }, VF.TabSlide.SLIDE_UP);
-
-      tie.setContext(ctx);
-      tie.draw();
-    },
-
-    setupContext: function(options, x) {
-      var ctx = options.contextBuilder(options.elementId, 350, 140);
-      ctx.scale(0.9, 0.9);
-      ctx.fillStyle = '#221';
-      ctx.strokeStyle = '#221';
-      ctx.font = '10pt Arial';
-      var stave = new VF.TabStave(10, 10, x || 350)
-        .addTabGlyph()
-        .setContext(ctx)
-        .draw();
-
-      return { context: ctx, stave: stave };
+      run('Simple TabSlide', TabSlide.simple);
+      run('Slide Up', createMultiTest(VF.TabSlide.createSlideUp));
+      run('Slide Down', createMultiTest(VF.TabSlide.createSlideDown));
     },
 
     simple: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
-      var c = VF.Test.TabSlide.setupContext(options);
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      var c = setupContext(options);
+      var ctx = c.context;
+      var stave = c.stave;
 
-      VF.Test.TabSlide.tieNotes([
-        newNote({ positions: [{ str: 4, fret: 4 }], duration: 'h' }),
-        newNote({ positions: [{ str: 4, fret: 6 }], duration: 'h' }),
-      ], [0], c.stave, c.context);
+      var notes = [
+        newNote({ positions: [{ str: 4, fret: 4 }], duration: '2' }),
+        newNote({ positions: [{ str: 4, fret: 6 }], duration: '2' }),
+      ];
+
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      var tie = new VF.TabSlide({
+        first_note: notes[0],
+        last_note: notes[1],
+        first_indices: [0],
+        last_indices: [0],
+      }, VF.TabSlide.SLIDE_UP);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .format([voice], stave.width / 4);
+
+      stave.setContext(ctx).draw();
+      voice.draw(ctx);
+      tie.setContext(ctx).draw();
+
       ok(true, 'Simple Test');
     },
 
     multiTest: function(options, factory) {
-      var c = VF.Test.TabSlide.setupContext(options, 440, 100);
+      var c = setupContext(options);
       var ctx = c.context;
       var stave = c.stave;
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
 
       var notes = [
         newNote({ positions: [{ str: 4, fret: 4 }], duration: '8' }),
@@ -82,57 +88,44 @@ VF.Test.TabSlide = (function() {
         .addTickables(notes)
         .updateStave(stave);
 
+      var tabSlides = [
+        factory({
+          first_note: notes[0],
+          last_note: notes[1],
+          first_indices: [0],
+          last_indices: [0],
+        }),
+        factory({
+          first_note: notes[2],
+          last_note: notes[3],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+        }),
+        factory({
+          first_note: notes[4],
+          last_note: notes[5],
+          first_indices: [0],
+          last_indices: [0],
+        }),
+        factory({
+          first_note: notes[6],
+          last_note: notes[7],
+          first_indices: [0, 1],
+          last_indices: [0, 1],
+        }),
+      ];
+
       new VF.Formatter()
         .joinVoices([voice])
-        .format([voice], stave);
+        .formatToStave([voice], stave);
 
+      stave.setContext(ctx).draw();
       voice.draw(ctx);
+      tabSlides.forEach(function(tabSlide) {
+        tabSlide.setContext(ctx).draw();
+      });
 
-      factory({
-        first_note: notes[0],
-        last_note: notes[1],
-        first_indices: [0],
-        last_indices: [0],
-      }).setContext(ctx).draw();
-
-      ok(true, 'Single note');
-
-      factory({
-        first_note: notes[2],
-        last_note: notes[3],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-      }).setContext(ctx).draw();
-
-      ok(true, 'Chord');
-
-      factory({
-        first_note: notes[4],
-        last_note: notes[5],
-        first_indices: [0],
-        last_indices: [0],
-      }).setContext(ctx).draw();
-
-      ok(true, 'Single note high-fret');
-
-      factory({
-        first_note: notes[6],
-        last_note: notes[7],
-        first_indices: [0, 1],
-        last_indices: [0, 1],
-      }).setContext(ctx).draw();
-
-      ok(true, 'Chord high-fret');
-    },
-
-    slideUp: function(options, contextBuilder) {
-      options.contextBuilder = contextBuilder;
-      VF.Test.TabSlide.multiTest(options, VF.TabSlide.createSlideUp);
-    },
-
-    slideDown: function(options, contextBuilder) {
-      options.contextBuilder = contextBuilder;
-      VF.Test.TabSlide.multiTest(options, VF.TabSlide.createSlideDown);
+      ok(true);
     },
   };
 

--- a/tests/tabtie_tests.js
+++ b/tests/tabtie_tests.js
@@ -4,6 +4,8 @@
  */
 
 VF.Test.TabTie = (function() {
+  function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+
   var TabTie = {
     Start: function() {
       var run = VF.Test.runTests;
@@ -18,11 +20,15 @@ VF.Test.TabTie = (function() {
     },
 
     tieNotes: function(notes, indices, stave, ctx, text) {
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-      voice.addTickables(notes);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
 
-      new VF.Formatter().joinVoices([voice]).format([voice], 100);
-      voice.draw(ctx, stave);
+      new VF.Formatter()
+        .joinVoices([voice])
+        .format([voice], 100);
+
+      voice.draw(ctx);
 
       var tie = new VF.TabTie({
         first_note: notes[0],
@@ -56,11 +62,10 @@ VF.Test.TabTie = (function() {
 
     simple: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
 
       VF.Test.TabTie.drawTie([
-        newNote({ positions: [{ str: 4, fret: 4 }], duration: 'h' }),
-        newNote({ positions: [{ str: 4, fret: 6 }], duration: 'h' }),
+        newNote({ positions: [{ str: 4, fret: 4 }], duration: '2' }),
+        newNote({ positions: [{ str: 4, fret: 6 }], duration: '2' }),
       ], [0], options);
 
       ok(true, 'Simple Test');
@@ -68,12 +73,11 @@ VF.Test.TabTie = (function() {
 
     tap: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
 
       VF.Test.TabTie.drawTie([
-        newNote({ positions: [{ str: 4, fret: 12 }], duration: 'h' })
+        newNote({ positions: [{ str: 4, fret: 12 }], duration: '2' })
           .addModifier(new VF.Annotation('T'), 0),
-        newNote({ positions: [{ str: 4, fret: 10 }], duration: 'h' }),
+        newNote({ positions: [{ str: 4, fret: 10 }], duration: '2' }),
       ], [0], options, 'P');
 
       ok(true, 'Tapping Test');
@@ -81,7 +85,8 @@ VF.Test.TabTie = (function() {
 
     multiTest: function(options, factory) {
       var c = VF.Test.TabTie.setupContext(options, 440, 140);
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      var ctx = c.context;
+      var stave = c.stave;
 
       var notes = [
         newNote({ positions: [{ str: 4, fret: 4 }], duration: '8' }),
@@ -94,16 +99,22 @@ VF.Test.TabTie = (function() {
         newNote({ positions: [{ str: 2, fret: 16 }, { str: 3, fret: 16 }], duration: '8' }),
       ];
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).format([voice], 300);
-      voice.draw(c.context, c.stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      voice.draw(ctx);
 
       factory({
         first_note: notes[0],
         last_note: notes[1],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Single note');
 
@@ -112,7 +123,7 @@ VF.Test.TabTie = (function() {
         last_note: notes[3],
         first_indices: [0, 1],
         last_indices: [0, 1],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Chord');
 
@@ -121,7 +132,7 @@ VF.Test.TabTie = (function() {
         last_note: notes[5],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Single note high-fret');
 
@@ -130,7 +141,7 @@ VF.Test.TabTie = (function() {
         last_note: notes[7],
         first_indices: [0, 1],
         last_indices: [0, 1],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       ok(true, 'Chord high-fret');
     },
@@ -148,31 +159,38 @@ VF.Test.TabTie = (function() {
     continuous: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
       var c = VF.Test.TabTie.setupContext(options, 440, 140);
-      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      var ctx = c.context;
+      var stave = c.stave;
 
       var notes = [
-        newNote({ positions: [{ str: 4, fret: 4 }], duration: 'q' }),
-        newNote({ positions: [{ str: 4, fret: 5 }], duration: 'q' }),
-        newNote({ positions: [{ str: 4, fret: 6 }], duration: 'h' }),
+        newNote({ positions: [{ str: 4, fret: 4 }], duration: '4' }),
+        newNote({ positions: [{ str: 4, fret: 5 }], duration: '4' }),
+        newNote({ positions: [{ str: 4, fret: 6 }], duration: '2' }),
       ];
 
-      var voice = new VF.Voice(VF.Test.TIME4_4).addTickables(notes);
-      new VF.Formatter().joinVoices([voice]).format([voice], 300);
-      voice.draw(c.context, c.stave);
+      var voice = new VF.Voice(VF.Test.TIME4_4)
+        .addTickables(notes)
+        .updateStave(stave);
+
+      new VF.Formatter()
+        .joinVoices([voice])
+        .format([voice], 300);
+
+      voice.draw(ctx);
 
       VF.TabTie.createHammeron({
         first_note: notes[0],
         last_note: notes[1],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
 
       VF.TabTie.createPulloff({
         first_note: notes[1],
         last_note: notes[2],
         first_indices: [0],
         last_indices: [0],
-      }).setContext(c.context).draw();
+      }).setContext(ctx).draw();
       ok(true, 'Continuous Hammeron');
     },
   };


### PR DESCRIPTION
This shouldn't get merged in until we have an agreed way forward for the next string of releases. Things like the tutorials/jsfiddles will need to be updated.

- `StaveNote#preFormat` throws if no stave is set
- Renamed `StaveNote#setStave` to `StaveNote#updateStave` as per the discussion in #412 
- `Voice#draw` throws if passed a `stave`, to notify the user that this pattern is not valid.