### PR TITLE
Lint tests; Enable dot-location eslint rule;

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   },
   "rules": {
     "camelcase": [0],
+    "dot-location": [2, "property"],
     "max-len": [2, 100],
     "new-cap": [0],
     "import/prefer-default-export": [0],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,10 +96,7 @@ module.exports = (grunt) => {
       },
     },
     eslint: {
-      target: SOURCES,
-      options: {
-        configFile: '.eslintrc.json',
-      },
+      target: SOURCES.concat('./tests'),
     },
     qunit: {
       files: ['tests/flow.html'],

--- a/src/raphaelcontext.js
+++ b/src/raphaelcontext.js
@@ -138,10 +138,10 @@ export class RaphaelContext {
       height = -height;
     }
 
-    this.paper.rect(x, y, width - 0.5, height - 0.5).
-      attr(this.attributes).
-      attr('fill', 'none').
-      attr('stroke-width', this.lineWidth);
+    this.paper.rect(x, y, width - 0.5, height - 0.5)
+      .attr(this.attributes)
+      .attr('fill', 'none')
+      .attr('stroke-width', this.lineWidth);
     return this;
   }
 
@@ -161,8 +161,8 @@ export class RaphaelContext {
       height = -height;
     }
 
-    this.paper.rect(x, y, width - 0.5, height - 0.5).
-      attr(this.background_attributes);
+    this.paper.rect(x, y, width - 0.5, height - 0.5)
+      .attr(this.background_attributes);
     return this;
   }
 
@@ -296,9 +296,9 @@ export class RaphaelContext {
   }
 
   fill() {
-    const elem = this.paper.path(this.path).
-      attr(this.attributes).
-      attr('stroke-width', 0);
+    const elem = this.paper.path(this.path)
+      .attr(this.attributes)
+      .attr('stroke-width', 0);
     this.glow(elem);
     return this;
   }
@@ -322,10 +322,10 @@ export class RaphaelContext {
     // canvascontext.js as well.
 
     const strokeWidth = this.lineWidth * (this.state.scale.x + this.state.scale.y) / 2;
-    const elem = this.paper.path(this.path).
-      attr(this.attributes).
-      attr('fill', 'none').
-      attr('stroke-width', strokeWidth);
+    const elem = this.paper.path(this.path)
+      .attr(this.attributes)
+      .attr('fill', 'none')
+      .attr('stroke-width', strokeWidth);
     this.glow(elem);
     return this;
   }
@@ -336,10 +336,10 @@ export class RaphaelContext {
   }
 
   measureText(text) {
-    const txt = this.paper.text(0, 0, text).
-      attr(this.attributes).
-      attr('fill', 'none').
-      attr('stroke', 'none');
+    const txt = this.paper.text(0, 0, text)
+      .attr(this.attributes)
+      .attr('fill', 'none')
+      .attr('stroke', 'none');
     const bounds = txt.getBBox();
     txt.remove();
 

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -6,6 +6,7 @@
   },
   "rules": {
     "camelcase": [0],
+    "dot-location": [2, "property"],
     "max-len": [2, 100],
     "new-cap": [0],
     "import/prefer-default-export": [0],

--- a/tests/accidental_tests.js
+++ b/tests/accidental_tests.js
@@ -359,7 +359,7 @@ Vex.Flow.Test.Accidental = (function() {
       Vex.Flow.Test.plotLegendForNoteWidth(ctx, 580, 140);
       ok(true, 'Microtonal Accidental');
     },
-    
+
     microtonal_iranian: function(options) {
       var assert = options.assert;
       var vf = VF.Test.makeFactory(options, 700, 240);

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -276,7 +276,7 @@ VF.Test.Articulation = (function() {
 
     tabNotes: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 600, 200);
-      ctx.font = "10pt Arial";
+      ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);
       stave.draw();

--- a/tests/bend_tests.js
+++ b/tests/bend_tests.js
@@ -19,22 +19,22 @@ VF.Test.Bend = (function() {
       var ctx = new contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5); ctx.fillStyle = '#221'; ctx.strokeStyle = '#221';
       ctx.setRawFont(' 10pt Arial');
-      var stave = new VF.TabStave(10, 10, 450).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newBend(text) { return new VF.Bend(text); }
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'q' }).
-          addModifier(newBend('Full'), 0).
-          addModifier(newBend('1/2'), 1),
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'q' })
+          .addModifier(newBend('Full'), 0)
+          .addModifier(newBend('1/2'), 1),
 
         newNote({
-          positions: [{ str: 2, fret: 5 }, { str: 3, fret: 5 }], duration: 'q' }).
-          addModifier(newBend('1/4'), 0).
-          addModifier(newBend('1/4'), 1),
+          positions: [{ str: 2, fret: 5 }, { str: 3, fret: 5 }], duration: 'q' })
+          .addModifier(newBend('1/4'), 0)
+          .addModifier(newBend('1/4'), 1),
 
         newNote({
           positions: [{ str: 4, fret: 7 }], duration: 'h' }),
@@ -53,25 +53,25 @@ VF.Test.Bend = (function() {
       ctx.scale(1.0, 1.0);
       ctx.setBackgroundFillStyle('#FFF');
       ctx.setFont('Arial', VF.Test.Font.size);
-      var stave = new VF.TabStave(10, 10, 550).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 550)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newBend(text, release) { return new VF.Bend(text, release); }
 
       var notes = [
         newNote({
-          positions: [{ str: 1, fret: 10 }, { str: 4, fret: 9 }], duration: 'q' }).
-          addModifier(newBend('1/2', true), 0).
-          addModifier(newBend('Full', true), 1),
+          positions: [{ str: 1, fret: 10 }, { str: 4, fret: 9 }], duration: 'q' })
+          .addModifier(newBend('1/2', true), 0)
+          .addModifier(newBend('Full', true), 1),
 
         newNote({
           positions: [{ str: 2, fret: 5 },
                       { str: 3, fret: 5 },
-                      { str: 4, fret: 5 }], duration: 'q' }).
-          addModifier(newBend('1/4', true), 0).
-          addModifier(newBend('Monstrous', true), 1).
-          addModifier(newBend('1/4', true), 2),
+                      { str: 4, fret: 5 }], duration: 'q' })
+          .addModifier(newBend('1/4', true), 0)
+          .addModifier(newBend('Monstrous', true), 1)
+          .addModifier(newBend('1/4', true), 2),
 
         newNote({
           positions: [{ str: 4, fret: 7 }], duration: 'q' }),
@@ -91,22 +91,22 @@ VF.Test.Bend = (function() {
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = '#221'; ctx.strokeStyle = '#221';
       ctx.setRawFont('10pt Arial');
-      var stave = new VF.TabStave(10, 10, 450).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newBend(text) { return new VF.Bend(text); }
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'w' }).
-          addModifier(newBend('Full'), 1).
-          addModifier(newBend('1/2'), 0),
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'w' })
+          .addModifier(newBend('Full'), 1)
+          .addModifier(newBend('1/2'), 0),
 
         newNote({
-          positions: [{ str: 2, fret: 5 }, { str: 3, fret: 5 }], duration: 'w' }).
-          addModifier(newBend('1/4'), 1).
-          addModifier(newBend('1/4'), 0),
+          positions: [{ str: 2, fret: 5 }, { str: 3, fret: 5 }], duration: 'w' })
+          .addModifier(newBend('1/4'), 1)
+          .addModifier(newBend('1/4'), 0),
 
         newNote({
           positions: [{ str: 4, fret: 7 }], duration: 'w' }),
@@ -145,8 +145,8 @@ VF.Test.Bend = (function() {
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }], duration: 'w' }).
-          addModifier(bend1, 0),
+          positions: [{ str: 2, fret: 10 }], duration: 'w' })
+          .addModifier(bend1, 0),
       ];
 
       for (var i = 0; i < notes.length; ++i) {
@@ -192,9 +192,9 @@ VF.Test.Bend = (function() {
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }, { str: 3, fret: 9 }], duration: 'q' }).
-          addModifier(newBend(phrase1), 0).
-          addModifier(newBend(phrase2), 1),
+          positions: [{ str: 2, fret: 10 }, { str: 3, fret: 9 }], duration: 'q' })
+          .addModifier(newBend(phrase1), 0)
+          .addModifier(newBend(phrase2), 1),
       ];
 
       VF.Formatter.FormatAndDraw(ctx, stave, notes);

--- a/tests/ornament_tests.js
+++ b/tests/ornament_tests.js
@@ -162,7 +162,7 @@ VF.Test.Ornament = (function() {
       expect(0);
 
       // Get the rendering context
-      var ctx = contextBuilder(options.elementId,650, 250);
+      var ctx = contextBuilder(options.elementId, 650, 250);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 60, 600);

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -3,6 +3,14 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
+/*
+eslint-disable
+no-require,
+global-require,
+import/no-unresolved,
+import/no-extraneous-dependencies,
+ */
+
 // Mock out the QUnit stuff for generating svg images,
 // since we don't really care about the assertions.
 if (!window.QUnit) {
@@ -23,9 +31,10 @@ if (!window.QUnit) {
     QUnit.current_module = name;
   };
 
+  /* eslint-disable */
   QUnit.test = function(name, func) {
     QUnit.current_test = name;
-    process.stdout.write(" \033[0G" + QUnit.current_module + " :: " + name + "\033[0K");
+    process.stdout.write(" \u001B[0G" + QUnit.current_module + " :: " + name + "\u001B[0K");
     func(QUnit.assertions);
   };
 

--- a/tests/vibrato_tests.js
+++ b/tests/vibrato_tests.js
@@ -18,19 +18,19 @@ VF.Test.Vibrato = (function() {
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = '#221'; ctx.strokeStyle = '#221';
       ctx.font = '10pt Arial';
-      var stave = new VF.TabStave(10, 10, 450).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newVibrato() { return new VF.Vibrato(); }
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h' }).
-          addModifier(newVibrato(), 0),
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h' })
+          .addModifier(newVibrato(), 0),
         newNote({
-          positions: [{ str: 2, fret: 10 }], duration: 'h' }).
-          addModifier(newVibrato(), 0),
+          positions: [{ str: 2, fret: 10 }], duration: 'h' })
+          .addModifier(newVibrato(), 0),
       ];
 
       VF.Formatter.FormatAndDraw(ctx, stave, notes);
@@ -42,19 +42,19 @@ VF.Test.Vibrato = (function() {
 
       ctx.scale(1.5, 1.5); ctx.fillStyle = '#221'; ctx.strokeStyle = '#221';
       ctx.font = '10pt Arial';
-      var stave = new VF.TabStave(10, 10, 450).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newVibrato() { return new VF.Vibrato(); }
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h' }).
-          addModifier(newVibrato().setHarsh(true), 0),
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h' })
+          .addModifier(newVibrato().setHarsh(true), 0),
         newNote({
-          positions: [{ str: 2, fret: 10 }], duration: 'h' }).
-          addModifier(newVibrato().setHarsh(true), 0),
+          positions: [{ str: 2, fret: 10 }], duration: 'h' })
+          .addModifier(newVibrato().setHarsh(true), 0),
       ];
 
       VF.Formatter.FormatAndDraw(ctx, stave, notes);
@@ -65,8 +65,8 @@ VF.Test.Vibrato = (function() {
       var ctx = new contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.3, 1.3); ctx.setFillStyle('#221'); ctx.setStrokeStyle('#221');
       ctx.setFont('Arial', VF.Test.Font.size, '');
-      var stave = new VF.TabStave(10, 10, 450).
-        addTabGlyph().setContext(ctx).draw();
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph().setContext(ctx).draw();
 
       function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
       function newBend(text, release) { return new VF.Bend(text, release); }
@@ -74,17 +74,17 @@ VF.Test.Vibrato = (function() {
 
       var notes = [
         newNote({
-          positions: [{ str: 2, fret: 9 }, { str: 3, fret: 9 }], duration: 'q' }).
-          addModifier(newBend('1/2', true), 0).
-          addModifier(newBend('1/2', true), 1).
-          addModifier(newVibrato(), 0),
+          positions: [{ str: 2, fret: 9 }, { str: 3, fret: 9 }], duration: 'q' })
+          .addModifier(newBend('1/2', true), 0)
+          .addModifier(newBend('1/2', true), 1)
+          .addModifier(newVibrato(), 0),
         newNote({
-          positions: [{ str: 2, fret: 10 }], duration: 'q' }).
-          addModifier(newBend('Full', false), 0).
-          addModifier(newVibrato().setVibratoWidth(60), 0),
+          positions: [{ str: 2, fret: 10 }], duration: 'q' })
+          .addModifier(newBend('Full', false), 0)
+          .addModifier(newVibrato().setVibratoWidth(60), 0),
         newNote({
-          positions: [{ str: 2, fret: 10 }], duration: 'h' }).
-          addModifier(newVibrato().setVibratoWidth(120).setHarsh(true), 0),
+          positions: [{ str: 2, fret: 10 }], duration: 'h' })
+          .addModifier(newVibrato().setVibratoWidth(120).setHarsh(true), 0),
       ];
 
       VF.Formatter.FormatAndDraw(ctx, stave, notes);


### PR DESCRIPTION
[See rule documentation for details](http://eslint.org/docs/rules/dot-location). This now enforces the dot operator to be placed the same line as the property being accessed. All lingering occurrences of this style have now been fixed.