### PR TITLE
 stroke outline of NoteHeads

### DIFF
--- a/src/glyph.js
+++ b/src/glyph.js
@@ -86,14 +86,15 @@ export class Glyph extends Element {
    * @param {number} point The point size to use.
    * @param {string} val The glyph code in Vex.Flow.Font.
    * @param {boolean} nocache If set, disables caching of font outline.
+   * @param {boolean} stroke If set, also strokes the outline.
    */
-  static renderGlyph(ctx, x_pos, y_pos, point, val, nocache) {
+  static renderGlyph(ctx, x_pos, y_pos, point, val, nocache, stroke) {
     const scale = point * 72.0 / (Font.resolution * 100.0);
     const metrics = Glyph.loadMetrics(Font, val, !nocache);
-    Glyph.renderOutline(ctx, metrics.outline, scale, x_pos, y_pos);
+    Glyph.renderOutline(ctx, metrics.outline, scale, x_pos, y_pos, stroke);
   }
 
-  static renderOutline(ctx, outline, scale, x_pos, y_pos) {
+  static renderOutline(ctx, outline, scale, x_pos, y_pos, stroke) {
     ctx.beginPath();
     ctx.moveTo(x_pos, y_pos);
     processOutline(outline, x_pos, y_pos, scale, -scale, {
@@ -103,6 +104,9 @@ export class Glyph extends Element {
       b: ctx.bezierCurveTo.bind(ctx),
     });
     ctx.fill();
+    if (stroke) {
+      ctx.stroke();
+    }
   }
 
   static getOutlineBoundingBox(outline, scale, x_pos, y_pos) {

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -175,8 +175,8 @@ export class NoteHead extends Note {
     if (style.shadowColor) context.setShadowColor(style.shadowColor);
     if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
     if (style.fillStyle) context.setFillStyle(style.fillStyle);
-    if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
-    if (style.strokeWidth) context.setLineWidth(style.strokeWidth);
+    if (style.headStrokeStyle) context.setStrokeStyle(style.headStrokeStyle);
+    if (style.headStrokeWidth) context.setLineWidth(style.headStrokeWidth);
     return this;
   }
 
@@ -245,7 +245,7 @@ export class NoteHead extends Note {
         ctx.save();
         this.applyStyle(ctx);
         Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code,
-          false, !!this.style.strokeStyle);
+          false, !!this.style.headStrokeStyle);
         ctx.restore();
       } else {
         Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -176,6 +176,7 @@ export class NoteHead extends Note {
     if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
     if (style.fillStyle) context.setFillStyle(style.fillStyle);
     if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
+    if (style.strokeWidth) context.setLineWidth(style.strokeWidth);
     return this;
   }
 
@@ -243,7 +244,8 @@ export class NoteHead extends Note {
       if (this.style) {
         ctx.save();
         this.applyStyle(ctx);
-        Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);
+        Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code,
+          false, !!this.style.strokeStyle);
         ctx.restore();
       } else {
         Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);


### PR DESCRIPTION
just implemented stroke outline of NoteHeads

not sure how to check if it goes well with other things

not sure how to add it to documentation

I had a need to for bi-colored notes to color colored notes of sharp notes

![colorednotes](https://cloud.githubusercontent.com/assets/314464/21899134/df97336a-d8f7-11e6-8714-3f1a8b0dc28c.png)
