### PR TITLE
build(package.json): add webpack version, add babel-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/0xfe/vexflow/issues"
   },
   "devDependencies": {
+    "babel-core": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
@@ -47,7 +48,7 @@
     "qunit": "^0.9.1",
     "raphael": "^2.1.0",
     "slimerjs": "^0.906.2",
-    "webpack": "*",
+    "webpack": "^1",
     "webpack-dev-server": "^1.14.1"
   },
   "scripts": {


### PR DESCRIPTION
Fresh npm installs were pulling Webpack 3.0 — but 1.x is required for
the rest of the dependencies. This commit fixes that.

babel-loader requires babel-core to be installed locally or globally.
The missing dependency is added here.