### PR TITLE
Styling via Element

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -825,7 +825,10 @@ export class Beam extends Element {
     if (!this.postFormatted) {
       this.postFormat();
     }
+
     this.drawStems();
+    this.applyStyle();
     this.drawBeamLines();
+    this.restoreStyle();
   }
 }

--- a/src/element.js
+++ b/src/element.js
@@ -30,6 +30,29 @@ export class Element {
     }
   }
 
+  // set the draw style of a stemmable note:
+  setStyle(style) { this.style = style; return this; }
+  getStyle() { return this.style; }
+
+  // Apply current style to Canvas `context`
+  applyStyle(context = this.context) {
+    context.save();
+    const style = this.getStyle();
+    if (!style) return this;
+    if (style.shadowColor) context.setShadowColor(style.shadowColor);
+    if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
+    if (style.fillStyle) context.setFillStyle(style.fillStyle);
+    if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
+
+    return this;
+  }
+
+  restoreStyle(context = this.context) {
+    if (!this.style) return this;
+    context.restore();
+    return this;
+  }
+
   // An element can have multiple class labels.
   hasClass(className) { return (this.attrs.classes[className] === true); }
   addClass(className) {

--- a/src/element.js
+++ b/src/element.js
@@ -35,10 +35,10 @@ export class Element {
   getStyle() { return this.style; }
 
   // Apply current style to Canvas `context`
-  applyStyle(context = this.context) {
-    context.save();
-    const style = this.getStyle();
+  applyStyle(context = this.context, style = this.getStyle()) {
     if (!style) return this;
+
+    context.save();
     if (style.shadowColor) context.setShadowColor(style.shadowColor);
     if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
     if (style.fillStyle) context.setFillStyle(style.fillStyle);
@@ -47,8 +47,8 @@ export class Element {
     return this;
   }
 
-  restoreStyle(context = this.context) {
-    if (!this.style) return this;
+  restoreStyle(context = this.context, style = this.getStyle()) {
+    if (!style) return this;
     context.restore();
     return this;
   }

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -219,7 +219,9 @@ export class Glyph extends Element {
     const scale = this.scale;
 
     this.setRendered();
+    this.applyStyle(ctx);
     Glyph.renderOutline(ctx, outline, scale, x + this.originShift.x, y + this.originShift.y);
+    this.restoreStyle(ctx);
   }
 
   renderToStave(x) {
@@ -237,7 +239,9 @@ export class Glyph extends Element {
     const scale = this.scale;
 
     this.setRendered();
+    this.applyStyle();
     Glyph.renderOutline(this.context, outline, scale,
         x + this.x_shift, this.stave.getYForGlyphs() + this.y_shift);
+    this.restoreStyle();
   }
 }

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -118,13 +118,6 @@ export class NoteHead extends Note {
   // Determine if the notehead is displaced
   isDisplaced() { return this.displaced === true; }
 
-  // Get/set the notehead's style
-  //
-  // `style` is an `object` with the following properties: `shadowColor`,
-  // `shadowBlur`, `fillStyle`, `strokeStyle`
-  getStyle() { return this.style; }
-  setStyle(style) { this.style = style; return this; }
-
   // Get the glyph data
   getGlyph() { return this.glyph; }
 
@@ -167,16 +160,6 @@ export class NoteHead extends Note {
     const min_y = this.y - half_spacing;
 
     return new Flow.BoundingBox(this.getAbsoluteX(), min_y, this.width, spacing);
-  }
-
-  // Apply current style to Canvas `context`
-  applyStyle(context) {
-    const style = this.getStyle();
-    if (style.shadowColor) context.setShadowColor(style.shadowColor);
-    if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
-    if (style.fillStyle) context.setFillStyle(style.fillStyle);
-    if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
-    return this;
   }
 
   // Set notehead to a provided `stave`
@@ -241,10 +224,9 @@ export class NoteHead extends Note {
       drawSlashNoteHead(ctx, this.duration, head_x, y, stem_direction, staveSpace);
     } else {
       if (this.style) {
-        ctx.save();
         this.applyStyle(ctx);
         Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);
-        ctx.restore();
+        this.restoreStyle(ctx);
       } else {
         Glyph.renderGlyph(ctx, head_x, y, glyph_font_scale, this.glyph_code);
       }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -733,6 +733,15 @@ export class StaveNote extends StemmableNote {
     this.stem.setStyle(style);
   }
 
+  setStemStyle(style) {
+    const stem = this.getStem();
+    stem.setStyle(style);
+  }
+  getStemStyle() { return this.stem.getStyle(); }
+
+  setLedgerLineStyle(style) { this.ledgerLineStyle = style; }
+  getLedgerLineStyle() { return this.ledgerLineStyle; }
+
   // Sets the notehead at `index` to the provided coloring `style`.
   //
   // `style` is an `object` with the following properties: `shadowColor`,
@@ -929,6 +938,7 @@ export class StaveNote extends StemmableNote {
       ctx.fillRect(x, y, length, 1);
     };
 
+    this.applyStyle(ctx, this.getLedgerLineStyle() || false);
     for (let line = 6; line <= highest_line; ++line) {
       drawLedgerLine(stave.getYForNote(line));
     }
@@ -936,6 +946,7 @@ export class StaveNote extends StemmableNote {
     for (let line = 0; line >= lowest_line; --line) {
       drawLedgerLine(stave.getYForNote(line));
     }
+    this.restoreStyle(ctx, this.getLedgerLineStyle() || false);
   }
 
   // Draw all key modifiers
@@ -1003,6 +1014,9 @@ export class StaveNote extends StemmableNote {
 
   // Render the stem onto the canvas
   drawStem(stemStruct) {
+    // GCR TODO: I can't find any context in which this is called with the stemStruct
+    // argument in the codebase or tests. Nor can I find a case where super.drawStem
+    // is called at all. Perhaps these should be removed?
     if (!this.context) {
       throw new Vex.RERR('NoCanvasContext', "Can't draw without a canvas context.");
     }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -350,7 +350,12 @@ export class StaveNote extends StemmableNote {
 
   reset() {
     super.reset();
+
+    // Save prior noteHead styles & reapply them after making new noteheads.
+    const noteHeadStyles = this.note_heads.map(noteHead => noteHead.getStyle());
     this.buildNoteHeads();
+    this.note_heads.forEach((noteHead, index) => noteHead.setStyle(noteHeadStyles[index]));
+
     if (this.stave) {
       this.note_heads.forEach(head => head.setStave(this.stave));
     }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -728,6 +728,7 @@ export class StaveNote extends StemmableNote {
   // Sets the style of the complete StaveNote, including all keys
   // and the stem.
   setStyle(style) {
+    super.setStyle(style);
     this.note_heads.forEach(notehead => notehead.setStyle(style));
     this.stem.setStyle(style);
   }
@@ -1042,6 +1043,8 @@ export class StaveNote extends StemmableNote {
     // Draw each part of the note
     this.drawLedgerLines();
 
+    // Apply the overall style -- may be contradicted by local settings:
+    this.applyStyle();
     this.setAttribute('el', this.context.openGroup('stavenote', this.getAttribute('id')));
     this.context.openGroup('note', null, { pointerBBox: true });
     if (shouldRenderStem) this.drawStem();
@@ -1050,6 +1053,7 @@ export class StaveNote extends StemmableNote {
     this.context.closeGroup();
     this.drawModifiers();
     this.context.closeGroup();
+    this.restoreStyle();
     this.setRendered();
   }
 }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -742,6 +742,9 @@ export class StaveNote extends StemmableNote {
   setLedgerLineStyle(style) { this.ledgerLineStyle = style; }
   getLedgerLineStyle() { return this.ledgerLineStyle; }
 
+  setFlagStyle(style) { this.flagStyle = style; }
+  getFlagStyle() { return this.flagStyle; }
+
   // Sets the notehead at `index` to the provided coloring `style`.
   //
   // `style` is an `object` with the following properties: `shadowColor`,
@@ -998,7 +1001,9 @@ export class StaveNote extends StemmableNote {
 
       // Draw the Flag
       ctx.openGroup('flag', null, { pointerBBox: true });
+      this.applyStyle(ctx, this.getFlagStyle() || false);
       this.flag.render(ctx, flagX, flagY);
+      this.restoreStyle(ctx, this.getFlagStyle() || false);
       ctx.closeGroup();
     }
   }

--- a/src/stem.js
+++ b/src/stem.js
@@ -104,10 +104,6 @@ export class Stem extends Element {
     return { topY: stemTipY, baseY: outerMostNoteheadY };
   }
 
-  // set the draw style of a stem:
-  setStyle(style) { this.style = style; return this; }
-  getStyle() { return this.style; }
-
   setVisibility(isVisible) {
     this.hide = !isVisible;
     return this;
@@ -116,17 +112,6 @@ export class Stem extends Element {
   setStemlet(isStemlet, stemletHeight) {
     this.isStemlet = isStemlet;
     this.stemletHeight = stemletHeight;
-    return this;
-  }
-
-  // Apply current style to Canvas `context`
-  applyStyle(context) {
-    const style = this.getStyle();
-    if (style) {
-      if (style.shadowColor) context.setShadowColor(style.shadowColor);
-      if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
-      if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
-    }
     return this;
   }
 

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -30,7 +30,9 @@ VF.Test.StaveNote = (function() {
       runTests('Displacements', StaveNote.displacements);
       runTests('StaveNote Draw - Bass 2', StaveNote.drawBass);
       runTests('StaveNote Draw - Key Styles', StaveNote.drawKeyStyles);
+      runTests('StaveNote Draw - Beam Styles', StaveNote.drawBeamStyles);
       runTests('StaveNote Draw - StaveNote Styles', StaveNote.drawNoteStyles);
+      runTests('StaveNote Draw - StaveNote Flag Styles', StaveNote.drawNoteStylesWithFlag);
       runTests('Flag and Dot Placement - Stem Up', StaveNote.dotsAndFlagsStemUp);
       runTests('Flag and Dots Placement - Stem Down', StaveNote.dotsAndFlagsStemDown);
       runTests('Beam and Dot Placement - Stem Up', StaveNote.dotsAndBeamsUp);
@@ -599,6 +601,65 @@ VF.Test.StaveNote = (function() {
       ok(note.getYs().length > 0, 'Note has Y values');
     },
 
+    drawNoteStylesWithFlag: function(options, contextBuilder) {
+      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var stave = new VF.Stave(10, 0, 100);
+      ctx.scale(3, 3);
+
+      var note = new VF.StaveNote({ keys: ['g/4', 'bb/4', 'd/5'], duration: '8' })
+        .setStave(stave)
+        .addAccidental(1, new VF.Accidental('b'));
+
+      note.setStyle({ shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
+
+      new VF.TickContext()
+        .addTickable(note)
+        .preFormat()
+        .setX(25);
+
+      stave.setContext(ctx).draw();
+      note.setContext(ctx).draw();
+
+      ok(note.getX() > 0, 'Note has X value');
+      ok(note.getYs().length > 0, 'Note has Y values');
+    },
+
+    drawBeamStyles: function(options, contextBuilder) {
+      var ctx = new contextBuilder(options.elementId, 700, 180);
+      var stave = new VF.Stave(10, 10, 650);
+      stave.setContext(ctx);
+      stave.draw();
+
+      var notes = [
+        // Beam
+        { keys: ['b/4'], duration: '8', stem_direction: -1 },
+        { keys: ['b/4'], duration: '8', stem_direction: -1 },
+        { keys: ['b/4'], duration: '8', stem_direction: 1 },
+        { keys: ['b/4'], duration: '8', stem_direction: 1 },
+        { keys: ['b/4'], duration: '2', stem_direction: 1 },
+      ];
+
+      var stave_notes = notes.map(function(note) { return new VF.StaveNote(note); });
+      var beam1 = new VF.Beam([stave_notes[0], stave_notes[1]]);
+      var beam2 = new VF.Beam([stave_notes[2], stave_notes[3]]);
+
+      beam1.setStyle({
+        fillStyle: 'blue',
+        strokeStyle: 'blue',
+      });
+
+      beam2.setStyle({
+        shadowBlur: 20,
+        shadowColor: 'blue',
+      });
+
+      VF.Formatter.FormatAndDraw(ctx, stave, stave_notes, false);
+
+      beam1.setContext(ctx).draw();
+      beam2.setContext(ctx).draw();
+
+      ok('draw beam styles');
+    },
 
     renderNote: function(note, stave, ctx, x) {
       note.setStave(stave);

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -30,9 +30,10 @@ VF.Test.StaveNote = (function() {
       runTests('Displacements', StaveNote.displacements);
       runTests('StaveNote Draw - Bass 2', StaveNote.drawBass);
       runTests('StaveNote Draw - Key Styles', StaveNote.drawKeyStyles);
-      runTests('StaveNote Draw - Beam Styles', StaveNote.drawBeamStyles);
       runTests('StaveNote Draw - StaveNote Styles', StaveNote.drawNoteStyles);
+      runTests('StaveNote Draw - StaveNote Stem Styles', StaveNote.drawNoteStemStyles);
       runTests('StaveNote Draw - StaveNote Flag Styles', StaveNote.drawNoteStylesWithFlag);
+      runTests('StaveNote Draw - Beam, Stem & Ledger Line Styles', StaveNote.drawBeamStyles);
       runTests('Flag and Dot Placement - Stem Up', StaveNote.dotsAndFlagsStemUp);
       runTests('Flag and Dots Placement - Stem Down', StaveNote.dotsAndFlagsStemDown);
       runTests('Beam and Dot Placement - Stem Up', StaveNote.dotsAndBeamsUp);
@@ -601,6 +602,28 @@ VF.Test.StaveNote = (function() {
       ok(note.getYs().length > 0, 'Note has Y values');
     },
 
+    drawNoteStemStyles: function(options, contextBuilder) {
+      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var stave = new VF.Stave(10, 0, 100);
+      ctx.scale(3, 3);
+
+      var note = new VF.StaveNote({ keys: ['g/4', 'bb/4', 'd/5'], duration: 'q' })
+        .setStave(stave)
+        .addAccidental(1, new VF.Accidental('b'));
+
+      note.setStemStyle({ shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
+
+      new VF.TickContext()
+        .addTickable(note)
+        .preFormat()
+        .setX(25);
+
+      stave.setContext(ctx).draw();
+      note.setContext(ctx).draw();
+
+      ok('Note Stem Style');
+    },
+
     drawNoteStylesWithFlag: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
@@ -625,8 +648,8 @@ VF.Test.StaveNote = (function() {
     },
 
     drawBeamStyles: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 700, 180);
-      var stave = new VF.Stave(10, 10, 650);
+      var ctx = new contextBuilder(options.elementId, 200, 180);
+      var stave = new VF.Stave(10, 10, 180);
       stave.setContext(ctx);
       stave.draw();
 
@@ -636,12 +659,24 @@ VF.Test.StaveNote = (function() {
         { keys: ['b/4'], duration: '8', stem_direction: -1 },
         { keys: ['b/4'], duration: '8', stem_direction: 1 },
         { keys: ['b/4'], duration: '8', stem_direction: 1 },
-        { keys: ['b/4'], duration: '2', stem_direction: 1 },
+        { keys: ['d/6'], duration: '8', stem_direction: -1 },
+        { keys: ['c/6', 'd/6'], duration: '8', stem_direction: -1 },
+        { keys: ['d/6', 'e/6'], duration: '8', stem_direction: -1 },
       ];
 
       var stave_notes = notes.map(function(note) { return new VF.StaveNote(note); });
+      stave_notes[0].setStemStyle({ strokeStyle: 'green' });
+      stave_notes[1].setStemStyle({ strokeStyle: 'orange' });
+
+      stave_notes[0].setKeyStyle(0, { fillStyle: 'purple' });
+      stave_notes[4].setLedgerLineStyle({ fillStyle: 'red', strokeStyle: 'red' });
+
       var beam1 = new VF.Beam([stave_notes[0], stave_notes[1]]);
       var beam2 = new VF.Beam([stave_notes[2], stave_notes[3]]);
+      var beam3 = new VF.Beam(stave_notes.slice(4));
+
+      stave_notes[1].setKeyStyle(0, { fillStyle: 'chartreuse' });
+      stave_notes[2].setStyle({ fillStyle: 'tomato', strokeStyle: 'tomato' });
 
       beam1.setStyle({
         fillStyle: 'blue',
@@ -657,6 +692,7 @@ VF.Test.StaveNote = (function() {
 
       beam1.setContext(ctx).draw();
       beam2.setContext(ctx).draw();
+      beam3.setContext(ctx).draw();
 
       ok('draw beam styles');
     },

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -673,10 +673,12 @@ VF.Test.StaveNote = (function() {
 
       var beam1 = new VF.Beam([stave_notes[0], stave_notes[1]]);
       var beam2 = new VF.Beam([stave_notes[2], stave_notes[3]]);
-      var beam3 = new VF.Beam(stave_notes.slice(4));
+      var beam3 = new VF.Beam(stave_notes.slice(4, 6));
 
       stave_notes[1].setKeyStyle(0, { fillStyle: 'chartreuse' });
       stave_notes[2].setStyle({ fillStyle: 'tomato', strokeStyle: 'tomato' });
+
+      stave_notes[6].setFlagStyle({ fillStyle: 'orange', strokeStyle: 'orante' });
 
       beam1.setStyle({
         fillStyle: 'blue',


### PR DESCRIPTION
This PR consolidates various setStyle & applyStyle methods into the Element class, extends styling to glyphs and beams, and adds styling options on StaveNotes for stems, flags, and ledger lines.

Fixes #557