### PR TITLE
Ledger Line Logic

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -43,7 +43,7 @@ export class Element {
     if (style.shadowBlur) context.setShadowBlur(style.shadowBlur);
     if (style.fillStyle) context.setFillStyle(style.fillStyle);
     if (style.strokeStyle) context.setStrokeStyle(style.strokeStyle);
-
+    if (style.lineWidth) context.setLineWidth(style.lineWidth);
     return this;
   }
 

--- a/src/notehead.js
+++ b/src/notehead.js
@@ -197,27 +197,6 @@ export class NoteHead extends Note {
     // Begin and end positions for head.
     const stem_direction = this.stem_direction;
     const glyph_font_scale = this.render_options.glyph_font_scale;
-    const line = this.line;
-
-    // If note above/below the staff, draw the small staff
-    if (line <= 0 || line >= 6) {
-      let line_y = y;
-      const floor = Math.floor(line);
-      if (line < 0 && floor - line === -0.5) {
-        line_y -= 5;
-      } else if (line > 6 &&  floor - line === -0.5) {
-        line_y += 5;
-      }
-
-      if (this.note_type !== 'r') {
-        ctx.fillRect(
-          head_x - this.render_options.stroke_px,
-          line_y,
-          this.getWidth() + (this.render_options.stroke_px * 2),
-          1
-        );
-      }
-    }
 
     if (this.note_type === 's') {
       const staveSpace = this.stave.getSpacingBetweenLines();

--- a/src/stave.js
+++ b/src/stave.js
@@ -136,6 +136,14 @@ export class Stave extends Element {
     return this.width;
   }
 
+  getStyle() {
+    return Object.assign({
+      fillStyle: this.options.fill_style,
+      strokeStyle: this.options.fill_style, // yes, this is correct for legacy compatibility
+      lineWidth: Flow.STAVE_LINE_THICKNESS,
+    }, this.style || {});
+  }
+
   setMeasure(measure) { this.measure = measure; return this; }
 
   /**
@@ -502,17 +510,14 @@ export class Stave extends Element {
     for (let line = 0; line < num_lines; line++) {
       y = this.getYForLine(line);
 
-      this.context.save();
-      this.context.setFillStyle(this.options.fill_style);
-      this.context.setStrokeStyle(this.options.fill_style);
-      this.context.setLineWidth(Flow.STAVE_LINE_THICKNESS);
+      this.applyStyle();
       if (this.options.line_config[line].visible) {
         this.context.beginPath();
         this.context.moveTo(x, y);
         this.context.lineTo(x + width, y);
         this.context.stroke();
       }
-      this.context.restore();
+      this.restoreStyle();
     }
 
     // Draw the modifiers (bar lines, coda, segno, repeat brackets, etc.)

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1006,11 +1006,7 @@ export class StaveNote extends StemmableNote {
       ctx.stroke();
     };
 
-    const style = Object.assign({
-      strokeStyle: stave.options.fill_style,
-      lineWidth: Flow.STAVE_LINE_THICKNESS,
-    }, this.getLedgerLineStyle() || {});
-
+    const style = Object.assign({}, stave.getStyle() || {}, this.getLedgerLineStyle() || {});
     this.applyStyle(ctx, style);
 
     // Draw ledger lines below the staff:

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -650,6 +650,10 @@ VF.Test.StaveNote = (function() {
     drawBeamStyles: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 200, 180);
       var stave = new VF.Stave(10, 10, 180);
+      stave.setStyle({
+        strokeStyle: '#EEAAEE',
+        lineWidth: '3',
+      });
       stave.setContext(ctx);
       stave.draw();
 
@@ -669,7 +673,7 @@ VF.Test.StaveNote = (function() {
       stave_notes[1].setStemStyle({ strokeStyle: 'orange' });
 
       stave_notes[0].setKeyStyle(0, { fillStyle: 'purple' });
-      stave_notes[4].setLedgerLineStyle({ fillStyle: 'red', strokeStyle: 'red' });
+      stave_notes[4].setLedgerLineStyle({ fillStyle: 'red', strokeStyle: 'red', lineWidth: 1 });
 
       var beam1 = new VF.Beam([stave_notes[0], stave_notes[1]]);
       var beam2 = new VF.Beam([stave_notes[2], stave_notes[3]]);


### PR DESCRIPTION
Fixes #566, fixes ledger line formatting issues remaining in #557.

Changes:
- Ledger line drawing is now handled entirely by `StaveNote`
- All ledger line logic is removed from `NoteHead`
- Ledger lines are now drawn with the same style of the staff they're related to
- If both displaced and non-displaced notes are present above or below the staff, ledger lines are drawn for both positions until no longer needed in either position.
- `Stave.setStyle()` is now available to match the api's of other `Element`s.
- `StaveNote.setLedgerLineStyle()` uses `Stave.getStyle()` as its default style, merging onto it any changes.

This results in two obvious visual changes throughout with ledger lines:
- Ledger lines are now thinner than before (1px, matching Vex.Flow.STAVE_LINE_THICKNESS)
- Ledger lines are now colored as `#999999` by default (matching `Stave.options.fill_style`'s default).

Before:
![annotation bottom_annotations_with_beams_blessed](https://user-images.githubusercontent.com/8905340/28747012-a2bc008a-7463-11e7-8c7a-d5305c10557c.png)
After:
![annotation bottom_annotations_with_beams_current](https://user-images.githubusercontent.com/8905340/28747013-a5fa6b9c-7463-11e7-9a86-30a3c64fa154.png)

To my eyes, I really appreciate the consistency of style between the ledger lines and the staves. However: I find myself wondering if `#999999` is too light of a default now that the ledger lines are the same color and thinner. Thoughts?

Finally, the NoteHead Bounding Boxes test loses a ledger line because this logic is moved into `StaveNote`. This isn't a grave concern to me -- I think it's pretty unlikely anyone is using VexFlow in a way that they're relying on `NoteHead` to draw a ledger line. (And, anyway, it would only ever draw the final ledger line before a note -- not all of the ones between the note and the staff.)

Before:
![notehead bounding_boxes_blessed](https://user-images.githubusercontent.com/8905340/28747057-94f58286-7464-11e7-917c-f483bbee811c.png)

After:
![notehead bounding_boxes_current](https://user-images.githubusercontent.com/8905340/28747059-99c88f1a-7464-11e7-8328-5c2ecdbb1008.png)

That said: if anyone sees an issue with consolidating ledger lines in `StaveNote` please let me know. I'll hold off on merging this for a few days.

Thanks!