### PR TITLE
Fixed ESLint error

### DIFF
--- a/src/music.js
+++ b/src/music.js
@@ -228,7 +228,7 @@ export class Music {
   getIntervalValue(intervalString) {
     const value = Music.intervals[intervalString];
     if (value == null) {
-      throw new Vex.RERR('BadArguments', 'Invalid interval name: ${intervalString}');
+      throw new Vex.RERR('BadArguments', `Invalid interval name: ${intervalString}`);
     }
 
     return value;


### PR DESCRIPTION
ESLint Error: Unexpected template string expression on Line 231. Looks like template literals were intended instead of quotation marks.

Picked this one up when using Vexflow within create-react-app