### PR TITLE
fix(Stem & StaveNote): applyStyle called without restoreStyle in draw()

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1045,7 +1045,7 @@ export class StaveNote extends StemmableNote {
       modifier.setContext(ctx);
       modifier.draw();
       if (noteheadStyle) {
-        ctx.restore();
+        notehead.restoreStyle(ctx);
       }
     }
     ctx.closeGroup();

--- a/src/stem.js
+++ b/src/stem.js
@@ -152,6 +152,7 @@ export class Stem extends Element {
     ctx.moveTo(stem_x, stem_y - stemletYOffset);
     ctx.lineTo(stem_x, stem_y - stemHeight - (this.renderHeightAdjustment * stem_direction));
     ctx.stroke();
+    this.restoreStyle(ctx);
     ctx.restore();
   }
 }


### PR DESCRIPTION
Fixes an issue where calling `staveNote.setStyle(styleObject)` applied that style to all future elements drawn.