### PR TITLE
Allow BarNote to use styling feature

### DIFF
--- a/src/barnote.js
+++ b/src/barnote.js
@@ -73,6 +73,10 @@ export class BarNote extends Note {
     this.checkContext();
     if (!this.stave) throw new Vex.RERR('NoStave', "Can't draw without a stave.");
     L('Rendering bar line at: ', this.getAbsoluteX());
+    //allow barlines to be styled
+    if (this.style) {
+       this.applyStyle(this.context);
+    }
     const barline = new Barline(this.type);
     barline.setX(this.getAbsoluteX());
     barline.draw(this.stave);


### PR DESCRIPTION
`setStyle` and `applyStyle` are in the base `Element` class, but were not applied in the `BarNote.draw()` method. I added a simple check to apply styles before drawing.