### PR TITLE
fix(dot.js): Dot.format should not overwrite dot.dot_shiftY. Fixes #607

### DIFF
--- a/src/dot.js
+++ b/src/dot.js
@@ -72,7 +72,7 @@ export class Dot extends Modifier {
       }
 
       // convert half_shiftY to a multiplier for dots.draw()
-      dot.dot_shiftY = -half_shiftY;
+      dot.dot_shiftY += -half_shiftY;
       prev_dotted_space = line + half_shiftY;
 
       dot.setXShift(dot_shift);


### PR DESCRIPTION
Resolves an issue preventing correct dot placement for rests.