### PR TITLE
Does not revert `ticksUsed` when occurred "Too many ticks"

### DIFF
--- a/src/voice.js
+++ b/src/voice.js
@@ -165,7 +165,7 @@ export class Voice extends Element {
         (this.mode === Voice.Mode.STRICT || this.mode === Voice.Mode.FULL) &&
         this.ticksUsed.greaterThan(this.totalTicks)
       ) {
-        this.totalTicks.subtract(ticks);
+        this.ticksUsed.subtract(ticks);
         throw new Vex.RERR('BadArgument', 'Too many ticks.');
       }
 

--- a/tests/voice_tests.js
+++ b/tests/voice_tests.js
@@ -13,7 +13,7 @@ VF.Test.Voice = (function() {
     },
 
     strict: function() {
-      expect(7);
+      expect(8);
       function createTickable() {
         return new VF.Test.MockTickable(VF.Test.TIME4_4);
       }
@@ -36,10 +36,12 @@ VF.Test.Voice = (function() {
       equal(voice.ticksUsed.value(), BEAT * 4, 'Four beats in voice');
       equal(voice.isComplete(), true, 'Voice is complete');
 
+      var beforeNumerator = voice.ticksUsed.numerator;
       try {
         voice.addTickable(createTickable().setTicks(BEAT));
       } catch (e) {
         equal(e.code, 'BadArgument', 'Too many ticks exception');
+        equal(voice.ticksUsed.numerator, beforeNumerator, 'Revert "ticksUsed" when it occurred "Too many ticks" exception');
       }
 
       equal(voice.getSmallestTickCount().value(), BEAT, 'Smallest tick count is BEAT');


### PR DESCRIPTION
When I added notes that over total ticks of a voice, it occurs "Too many ticks" exception, but it does not revert used ticks, so I've fixed it.

**before**

```js
const voice = new VF.Voice({num_beats: 4,  beat_value: 4});
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 8192 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 12288 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 16384 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" })); // Too many ticks

console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 20480 12288
```

**after**

```js
const voice = new VF.Voice({num_beats: 4,  beat_value: 4});
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 8192 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 12288 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" }));
console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 16384 16384
voice.addTickable(new VF.StaveNote({clef: "treble", keys: ["c/4"], duration: "q" })); // Too many ticks

console.log(voice.ticksUsed.numerator, voice.totalTicks.numerator); // 16384 16384
```