### PR TITLE
Issue #376 - add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = null
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.js]
+[*]
 indent_style = space
 indent_size = 2
 charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*]
+[*.js]
 indent_style = space
 indent_size = 2
 charset = utf-8


### PR DESCRIPTION
Addressed #376 and added the .editorconfig. As you're extending airbnb as a base for eslint, I used their base editorconfig with an additional line so trailing whitespace isn't trimmed in .md files. The rest is standard.

```
root = true

[*]
indent_style = space
indent_size = 2
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true
end_of_line = lf
# editorconfig-tools is unable to ignore longs strings or urls
max_line_length = null

[*.md]
trim_trailing_whitespace = false