### PR TITLE
svgcontest: remove some attributes: (1)

### DIFF
--- a/src/svgcontext.js
+++ b/src/svgcontext.js
@@ -3,6 +3,33 @@
 
 import { Vex } from './vex';
 
+const attrNamesToIgnoreMap = {
+  path: {
+    x: true,
+    y: true,
+    width: true,
+    height: true,
+  },
+  rect: {
+  },
+  text: {
+    width: true,
+    height: true,
+  },
+};
+
+{
+  const fontAttrNamesToIgnore = {
+    'font-family': true,
+    'font-weight': true,
+    'font-style': true,
+    'font-size': true,
+  };
+
+  Vex.Merge(attrNamesToIgnoreMap.rect, fontAttrNamesToIgnore);
+  Vex.Merge(attrNamesToIgnoreMap.path, fontAttrNamesToIgnore);
+}
+
 export class SVGContext {
   constructor(element) {
     // element is the parent DOM object
@@ -268,10 +295,15 @@ export class SVGContext {
   // ### Drawing helper methods:
 
   applyAttributes(element, attributes) {
+    const attrNamesToIgnore = attrNamesToIgnoreMap[element.nodeName];
     Object
       .keys(attributes)
-      .forEach(propertyName =>
-        element.setAttributeNS(null, propertyName, attributes[propertyName]));
+      .forEach(propertyName => {
+        if (attrNamesToIgnore && attrNamesToIgnore[propertyName]) {
+          return;
+        }
+        element.setAttributeNS(null, propertyName, attributes[propertyName]);
+      });
 
     return element;
   }


### PR DESCRIPTION
* #596
> 1. Rewrite applyAttributes to only apply those attributes that modify an element of that type (shape/path vs. text) as indicated in @sug1no's description.

* simple test: tests/596-1.html
```html
<!DOCTYPE html>
<html>

<head>
  <title>VexFlow 2 - JavaScript Music Notation and Guitar Tab</title>
  <link rel="stylesheet" href="flow.css" type="text/css" media="screen" />
  <!-- VexFlow Sources -->
  <script src="../build/vexflow-debug.js"></script>

  <!-- Test Dependencies: jQuery, QUnit -->
  <link rel="stylesheet" href="support/qunit.css" type="text/css" media="screen" />
  <script src="support/jquery.js"></script>
  <script src="support/qunit.js"></script>

  <!-- VexFlow Tests. Note the charset below: this is required for
       the measureText cache, since the index contains weird unicode
       characters.
  <script src="../build/vexflow-tests.js" charset="utf-8"></script>
 -->

  </head>

<body>
  <div id="boo"></div>
</body>

<script>
VF = Vex.Flow;

// Create an SVG renderer and attach it to the DIV element named "boo".
var div = document.getElementById("boo")
var renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);

// Configure the rendering context.
renderer.resize(500, 500);
var context = renderer.getContext();
context.setFont("Arial", 10, "").setBackgroundFillStyle("#eed");

// Create a stave of width 400 at position 10, 40 on the canvas.
var stave = new VF.Stave(10, 40, 400);

// Add a clef and time signature.
stave.addClef("treble").addTimeSignature("4/4");

// Connect it to the rendering context and draw!
stave.setContext(context).draw();


var text = new Vex.Flow.TextNote({
  text: "Render this",
  font: {
    family: "Arial",
    size: 12,
    weight: ""
  },
  duration: 'w'
})
.setLine(2)
.setStave(stave)
    .setJustification(Vex.Flow.TextNote.Justification.LEFT);
    
var voice2 = new Vex.Flow.Voice({
  num_beats: 4,
  beat_value: 4,
  resolution: Vex.Flow.RESOLUTION
});

voice2.addTickables([text]);

var formatter = new Vex.Flow.Formatter().joinVoices([voice2]).format([voice2], 400);

// Render voice
voice2.draw(context, stave);
  </script>

</html>
```
* grunt test:
```text
> grunt test
...
Running "qunit:files" (qunit) task
Testing tests/flow.html ........

...

............................................................................................................OK
>> 641 tests completed with 0 failed, 0 skipped, and 0 todo.
>> 2703 assertions (in 47458ms), passed: 2703, failed: 0

Done.
```

* attributes(before):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg width="500" height="500">
   <path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none"
     font-family="Arial" font-size="10pt" font-weight="normal" font-style="normal"
     d="M10 80L410 80" />
...
   <rect stroke-width="0.3" fill="black" stroke="black" stroke-dasharray="none"
    font-family="Arial" font-size="10pt" font-weight="normal" font-style="normal"
    x="10" y="79.5" width="1" height="41" />
...
   <path stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none"
    font-family="Arial" font-size="10pt" font-weight="normal" font-style="normal"
    x="410" y="79.5" width="1" height="41" d="..." />
...
   <text stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none"
    font-family="Arial" font-size="12pt" font-weight="normal" font-style="normal"
    x="79.90079999999999" y="70"
    width="1" height="41">Render this</text>
...
</svg>
```

* attributes:(after):

```xml
<svg width="500" height="500">
    <path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 80L410 80"></path><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 90L410 90"></path>
...
    <rect stroke-width="0.3" fill="black" stroke="black" stroke-dasharray="none" x="10" y="79.5" width="1" height="41"></rect>
...

<path stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none" d="..."></path>
...
<text stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none" font-family="Arial" font-size="12pt" font-weight="normal" font-style="normal" x="79.90079999999999" y="70">Render this</text></svg>
...
</svg>
```
