### PR TITLE
Fixed gracenote offset after redraw

### DIFF
--- a/src/gracenotegroup.js
+++ b/src/gracenotegroup.js
@@ -164,21 +164,21 @@ export class GraceNoteGroup extends Modifier {
         - extraPx.extraLeft
         + that.getSpacingFromNextModifier();
 
-        grace_notes.forEach(graceNote => {
-          const tick_context = graceNote.getTickContext();
-          const x_offset = tick_context.getX();
-          graceNote.setStave(note.stave);
-          tick_context.setX(x + x_offset);
-        });
-      }
-      
-      if(!note.aligned) {
-        alignGraceNotesWithNote(this.grace_notes, note, this.width);
-        note.aligned = true;
-      } else{
-        this.grace_notes.forEach(graceNote => graceNote.setStave(note.stave));
-      }
-        
+      grace_notes.forEach(graceNote => {
+        const tick_context = graceNote.getTickContext();
+        const x_offset = tick_context.getX();
+        graceNote.setStave(note.stave);
+        tick_context.setX(x + x_offset);
+      });
+    }
+
+    if (!note.graceNotesAligned) {
+      alignGraceNotesWithNote(this.grace_notes, note, this.width);
+      note.graceNotesAligned = true;
+    } else {
+      this.grace_notes.forEach(graceNote => graceNote.setStave(note.stave));
+    }
+
     // Draw notes
     this.grace_notes.forEach(graceNote => {
       graceNote.setContext(this.context).draw();

--- a/src/gracenotegroup.js
+++ b/src/gracenotegroup.js
@@ -164,16 +164,21 @@ export class GraceNoteGroup extends Modifier {
         - extraPx.extraLeft
         + that.getSpacingFromNextModifier();
 
-      grace_notes.forEach(graceNote => {
-        const tick_context = graceNote.getTickContext();
-        const x_offset = tick_context.getX();
-        graceNote.setStave(note.stave);
-        tick_context.setX(x + x_offset);
-      });
-    }
-
-    alignGraceNotesWithNote(this.grace_notes, note, this.width);
-
+        grace_notes.forEach(graceNote => {
+          const tick_context = graceNote.getTickContext();
+          const x_offset = tick_context.getX();
+          graceNote.setStave(note.stave);
+          tick_context.setX(x + x_offset);
+        });
+      }
+      
+      if(!note.aligned) {
+        alignGraceNotesWithNote(this.grace_notes, note, this.width);
+        note.aligned = true;
+      } else{
+        this.grace_notes.forEach(graceNote => graceNote.setStave(note.stave));
+      }
+        
     // Draw notes
     this.grace_notes.forEach(graceNote => {
       graceNote.setContext(this.context).draw();

--- a/src/ornament.js
+++ b/src/ornament.js
@@ -149,13 +149,20 @@ export class Ornament extends Modifier {
 
     // Ajdust x position if ornament is delayed
     if (this.delayed) {
-      glyphX += this.glyph.getMetrics().width;
-      const nextContext = TickContext.getNextContext(this.note.getTickContext());
-      if (nextContext) {
-        glyphX += (nextContext.getX() - glyphX) * 0.5;
+      let delayXShift = 0;
+      if (this.delayXShift !== undefined) {
+        delayXShift = this.delayXShift;
       } else {
-        glyphX += (stave.x + stave.width - glyphX) * 0.5;
+        delayXShift += this.glyph.getMetrics().width;
+        const nextContext = TickContext.getNextContext(this.note.getTickContext());
+        if (nextContext) {
+          delayXShift += (nextContext.getX() - glyphX) * 0.5;
+        } else {
+          delayXShift += (stave.x + stave.width - glyphX) * 0.5;
+        }
+        this.delayXShift = delayXShift;
       }
+      glyphX += delayXShift;
     }
 
     L('Rendering ornament: ', this.ornament, glyphX, glyphY);

--- a/src/ornament.js
+++ b/src/ornament.js
@@ -153,7 +153,7 @@ export class Ornament extends Modifier {
       if (this.delayXShift !== undefined) {
         delayXShift = this.delayXShift;
       } else {
-        delayXShift += this.glyph.getMetrics().width;
+        delayXShift += this.glyph.getMetrics().width / 2;
         const nextContext = TickContext.getNextContext(this.note.getTickContext());
         if (nextContext) {
           delayXShift += (nextContext.getX() - glyphX) * 0.5;


### PR DESCRIPTION
Hi,

we had some problems in opensheetmusicdisplay/opensheetmusicdisplay#293 that grace notes shifted to the right everytime we redraw stuff. We do this a lot because we can zoom in and out and also add debugging layers on top. Anyways I found that the GraceNoteGroup does this ```alignGraceNotesWithNote``` everytime it draws, thus adding the offset again and again which causes the whole group to shift.

My fix checks if the group is already aligned and skips that. It's rather quick and dirty (adding a prop after creation) but so is the mentioned function. Why is there formatting done during draw anyways?