### PR TITLE
Fix dotted note dot y-shifting each draw

### DIFF
--- a/src/dot.js
+++ b/src/dot.js
@@ -57,7 +57,7 @@ export class Dot extends Modifier {
         if (Math.abs(line % 1) === 0.5) {
           // note is on a space, so no dot shift
           half_shiftY = 0;
-        } else if (!note.isRest()) {
+        } else {
           // note is on a line, so shift dot to space above the line
           half_shiftY = 0.5;
           if (last_note != null &&
@@ -72,7 +72,11 @@ export class Dot extends Modifier {
       }
 
       // convert half_shiftY to a multiplier for dots.draw()
-      dot.dot_shiftY += -half_shiftY;
+      if (note.isRest()) {
+        dot.dot_shiftY += -half_shiftY;
+      } else {
+        dot.dot_shiftY = -half_shiftY;
+      }
       prev_dotted_space = line + half_shiftY;
 
       dot.setXShift(dot_shift);


### PR DESCRIPTION
Before this fix, dotted note dots get y-shifted a half line each render/draw:
![image](https://user-images.githubusercontent.com/33069673/43258353-cc1b999a-90d2-11e8-97dc-edf9a974b513.png)
We redraw a lot in OSMD compared to Vexflow tests, so we noticed [this issue](https://github.com/opensheetmusicdisplay/opensheetmusicdisplay/issues/300) pretty quickly.

The bug was introduced by [fixing quarter dotted rest dot positioning](https://github.com/0xfe/vexflow/commit/298cd8813e0a545c31fb312bd9f7dfa31e634e17) ([#607](https://github.com/0xfe/vexflow/issues/607)).

Rest note and stave note shiftY seem to be handled differently, stave notes remember previous y-shift.
The dot_shiftY could also be refactored to operate the same for stave notes and rests (= vs +=), but this fix handles the difference.
All visual regression tests pass and i haven't noticed other issues, using this for a while in OSMD.
Dotted notes are perfect now.

By the way, most physical sheet music editions use a quarter plus eigth rest instead of a dotted quarter, easier to read and can align with other notes in the staff.
Beethoven Sonata Op. 106 "Hammerklavier" beginning:

![image](https://user-images.githubusercontent.com/33069673/43258732-0dfda8e8-90d4-11e8-9ceb-69018d7b2d99.png)
 