### PR TITLE
fix NoteSubGroup x-shift each render

### DIFF
--- a/src/gracenotegroup.js
+++ b/src/gracenotegroup.js
@@ -153,31 +153,7 @@ export class GraceNoteGroup extends Modifier {
     }
 
     this.setRendered();
-    const that = this;
-    function alignGraceNotesWithNote(grace_notes, note) {
-      // Shift over the tick contexts of each note
-      // So that th aligned with the note
-      const tickContext = note.getTickContext();
-      const extraPx = tickContext.getExtraPx();
-      const x = tickContext.getX()
-        - extraPx.left
-        - extraPx.extraLeft
-        + that.getSpacingFromNextModifier();
-
-      grace_notes.forEach(graceNote => {
-        const tick_context = graceNote.getTickContext();
-        const x_offset = tick_context.getX();
-        graceNote.setStave(note.stave);
-        tick_context.setX(x + x_offset);
-      });
-    }
-
-    if (!note.graceNotesAligned) {
-      alignGraceNotesWithNote(this.grace_notes, note, this.width);
-      note.graceNotesAligned = true;
-    } else {
-      this.grace_notes.forEach(graceNote => graceNote.setStave(note.stave));
-    }
+    this.alignSubNotesWithNote(this.getGraceNotes(), note); // Modifier function
 
     // Draw notes
     this.grace_notes.forEach(graceNote => {

--- a/src/modifier.js
+++ b/src/modifier.js
@@ -120,7 +120,7 @@ export class Modifier extends Element {
     throw new Vex.RERR('MethodNotImplemented', 'draw() not implemented for this modifier.');
   }
 
-  // aligns sub notes of NoteSubGroup (or GraceNoteGroup) to the main notes with correct x-offset 
+  // aligns sub notes of NoteSubGroup (or GraceNoteGroup) to the main note with correct x-offset
   alignSubNotesWithNote(subNotes, note) {
     // Shift over the tick contexts of each note
     const tickContext = note.getTickContext();

--- a/src/modifier.js
+++ b/src/modifier.js
@@ -119,4 +119,19 @@ export class Modifier extends Element {
     this.checkContext();
     throw new Vex.RERR('MethodNotImplemented', 'draw() not implemented for this modifier.');
   }
+
+  // aligns sub notes of NoteSubGroup (or GraceNoteGroup) to the main notes with correct x-offset 
+  alignSubNotesWithNote(subNotes, note) {
+    // Shift over the tick contexts of each note
+    const tickContext = note.getTickContext();
+    const extraPx = tickContext.getExtraPx();
+    const subNoteXOffset = tickContext.getX() - extraPx.left - extraPx.extraLeft
+      + this.getSpacingFromNextModifier();
+
+    subNotes.forEach((subNote) => {
+      const subTickContext = subNote.getTickContext();
+      subNote.setStave(note.stave);
+      subTickContext.setXOffset(subNoteXOffset); // don't touch baseX to avoid shift each render
+    });
+  }
 }

--- a/src/notesubgroup.js
+++ b/src/notesubgroup.js
@@ -86,22 +86,7 @@ export class NoteSubGroup extends Modifier {
     }
 
     this.setRendered();
-    const alignSubNotesWithNote = (subNotes, note) => {
-      // Shift over the tick contexts of each note
-      const tickContext = note.getTickContext();
-      const extraPx = tickContext.getExtraPx();
-      const x = tickContext.getX() - extraPx.left - extraPx.extraLeft +
-        this.getSpacingFromNextModifier();
-
-      subNotes.forEach(subNote => {
-        const tick_context = subNote.getTickContext();
-        const x_offset = tick_context.getX();
-        subNote.setStave(note.stave);
-        tick_context.setX(x + x_offset);
-      });
-    };
-
-    alignSubNotesWithNote(this.subNotes, note, this.width);
+    this.alignSubNotesWithNote(this.subNotes, note); // Modifier function
 
     // Draw notes
     this.subNotes.forEach(subNote => subNote.setContext(this.context).draw());

--- a/src/tickcontext.js
+++ b/src/tickcontext.js
@@ -24,6 +24,8 @@ export class TickContext extends Tickable {
     this.minTicks = null;
     this.padding = 3;     // padding on each side (width += padding * 2)
     this.x = 0;
+    this.xBase = 0;
+    this.xOffset = 0;
     this.tickables = [];   // Notes, tabs, chords, lyrics.
     this.notePx = 0;       // width of widest note in this context
     this.extraLeftPx = 0;  // Extra left pixels for modifers & displace notes
@@ -32,7 +34,11 @@ export class TickContext extends Tickable {
   }
 
   getX() { return this.x; }
-  setX(x) { this.x = x; return this; }
+  setX(x) { this.x = x; this.xBase = x; this.xOffset = 0; return this; }
+  getXBase() { return this.xBase; } // use of xBase and xOffset is optional, avoids offset creep
+  setXBase(xBase) { this.xBase = xBase; this.x = xBase + this.xOffset; }
+  getXOffset() { return this.xOffset; }
+  setXOffset(xOffset) { this.xOffset = xOffset; this.x = this.xBase + xOffset; }
   getWidth() { return this.width + (this.padding * 2); }
   setPadding(padding) { this.padding = padding; return this; }
   getMaxTicks() { return this.maxTicks; }

--- a/src/tickcontext.js
+++ b/src/tickcontext.js
@@ -24,8 +24,8 @@ export class TickContext extends Tickable {
     this.minTicks = null;
     this.padding = 3;     // padding on each side (width += padding * 2)
     this.x = 0;
-    this.xBase = 0;
-    this.xOffset = 0;
+    this.xBase = 0;        // base x position without xOffset
+    this.xOffset = 0;      // xBase and xOffset are an alternative way to describe x (x = xB + xO)
     this.tickables = [];   // Notes, tabs, chords, lyrics.
     this.notePx = 0;       // width of widest note in this context
     this.extraLeftPx = 0;  // Extra left pixels for modifers & displace notes

--- a/tests/gracenote_tests.js
+++ b/tests/gracenote_tests.js
@@ -10,6 +10,7 @@ VF.Test.GraceNote = (function() {
       VF.Test.runTests('Grace Note Basic', VF.Test.GraceNote.basic);
       VF.Test.runTests('Grace Note Basic with Slurs', VF.Test.GraceNote.basicSlurred);
       VF.Test.runTests('Grace Notes Multiple Voices', VF.Test.GraceNote.multipleVoices);
+      VF.Test.runTests('Grace Notes Multiple Voices Multiple Draws', VF.Test.GraceNote.multipleVoicesMultipleDraws);
     },
 
     basic: function(options) {
@@ -215,6 +216,82 @@ VF.Test.GraceNote = (function() {
       vf.draw();
 
       ok(true, 'Sixteenth Test');
+    },
+
+    multipleVoicesMultipleDraws: function(options) {
+      const vf = VF.Test.makeFactory(options, 450, 140);
+      const stave = vf.Stave({ x: 10, y: 10, width: 450 });
+
+      var notes = [
+        { keys: ['f/5'], stem_direction: 1, duration: '16' },
+        { keys: ['f/5'], stem_direction: 1, duration: '16' },
+        { keys: ['d/5'], stem_direction: 1, duration: '16' },
+        { keys: ['c/5'], stem_direction: 1, duration: '16' },
+        { keys: ['c/5'], stem_direction: 1, duration: '16' },
+        { keys: ['d/5'], stem_direction: 1, duration: '16' },
+        { keys: ['f/5'], stem_direction: 1, duration: '16' },
+        { keys: ['e/5'], stem_direction: 1, duration: '16' },
+      ].map(vf.StaveNote.bind(vf));
+
+      var notes2 = [
+        { keys: ['f/4'], stem_direction: -1, duration: '16' },
+        { keys: ['e/4'], stem_direction: -1, duration: '16' },
+        { keys: ['d/4'], stem_direction: -1, duration: '16' },
+        { keys: ['c/4'], stem_direction: -1, duration: '16' },
+        { keys: ['c/4'], stem_direction: -1, duration: '16' },
+        { keys: ['d/4'], stem_direction: -1, duration: '16' },
+        { keys: ['f/4'], stem_direction: -1, duration: '16' },
+        { keys: ['e/4'], stem_direction: -1, duration: '16' },
+      ].map(vf.StaveNote.bind(vf));
+
+      var gracenotes1 = [
+        { keys: ['b/4'], stem_direction: 1, duration: '8', slash: true },
+      ].map(vf.GraceNote.bind(vf));
+
+      var gracenotes2 = [
+        { keys: ['f/4'], stem_direction: -1, duration: '8', slash: true },
+      ].map(vf.GraceNote.bind(vf));
+
+      var gracenotes3 = [
+        { keys: ['f/4'], duration: '32', stem_direction: -1 },
+        { keys: ['e/4'], duration: '32', stem_direction: -1 },
+      ].map(vf.GraceNote.bind(vf));
+
+      var gracenotes4 = [
+        { keys: ['f/5'], duration: '32', stem_direction: 1 },
+        { keys: ['e/5'], duration: '32', stem_direction: 1 },
+        { keys: ['e/5'], duration: '8', stem_direction: 1 },
+      ].map(vf.GraceNote.bind(vf));
+
+      gracenotes2[0].setStemDirection(-1);
+      gracenotes2[0].addAccidental(0, vf.Accidental({ type: '#' }));
+
+      notes[1].addModifier(0, vf.GraceNoteGroup({ notes: gracenotes4 }).beamNotes());
+      notes[3].addModifier(0, vf.GraceNoteGroup({ notes: gracenotes1 }));
+      notes2[1].addModifier(0, vf.GraceNoteGroup({ notes: gracenotes2 }).beamNotes());
+      notes2[5].addModifier(0, vf.GraceNoteGroup({ notes: gracenotes3 }).beamNotes());
+
+      var voice = vf.Voice()
+        .setStrict(false)
+        .addTickables(notes);
+
+      var voice2 = vf.Voice()
+        .setStrict(false)
+        .addTickables(notes2);
+
+      vf.Beam({ notes: notes.slice(0, 4) });
+      vf.Beam({ notes: notes.slice(4, 8) });
+      vf.Beam({ notes: notes2.slice(0, 4) });
+      vf.Beam({ notes: notes2.slice(4, 8) });
+
+      new VF.Formatter()
+        .joinVoices([voice, voice2])
+        .formatToStave([voice, voice2], stave);
+
+      vf.draw();
+      vf.draw();
+
+      ok(true, 'Seventeenth Test');
     },
   };
 

--- a/tests/notesubgroup_tests.js
+++ b/tests/notesubgroup_tests.js
@@ -14,6 +14,7 @@ VF.Test.NoteSubGroup = (function() {
 
       run('Basic - ClefNote, TimeSigNote and BarNote', VF.Test.NoteSubGroup.draw);
       run('Multi Voice', VF.Test.NoteSubGroup.drawMultiVoice);
+      run('Multi Voice Multiple Draws', VF.Test.NoteSubGroup.drawMultiVoiceMultipleDraw);
       run('Multi Staff', VF.Test.NoteSubGroup.drawMultiStaff);
     },
 
@@ -136,6 +137,71 @@ VF.Test.NoteSubGroup = (function() {
         .joinVoices(voices)
         .formatToStave(voices, stave);
 
+      vf.draw();
+
+      notes1.forEach(function(note) {
+        Vex.Flow.Test.plotNoteWidth(ctx, note, 150);
+      });
+
+      ok(true, 'all pass');
+    },
+
+    // draws multiple times. prevents incremental x-shift each draw.
+    drawMultiVoiceMultipleDraw: function(options) {
+      var vf = VF.Test.makeFactory(options, 550, 200);
+      var ctx = vf.getContext();
+      var stave = vf.Stave().addClef('treble');
+
+      var notes1 = [
+        { keys: ['f/5'], stem_direction: 1, duration: '4' },
+        { keys: ['d/4'], stem_direction: 1, duration: '4', clef: 'bass' },
+        { keys: ['c/5'], stem_direction: 1, duration: '4', clef: 'alto' },
+        { keys: ['c/5'], stem_direction: 1, duration: '4', clef: 'soprano' },
+      ].map(vf.StaveNote.bind(vf));
+
+      var notes2 = [
+        { keys: ['c/4'], stem_direction: -1, duration: '4' },
+        { keys: ['c/3'], stem_direction: -1, duration: '4', clef: 'bass' },
+        { keys: ['d/4'], stem_direction: -1, duration: '4', clef: 'alto' },
+        { keys: ['f/4'], stem_direction: -1, duration: '4', clef: 'soprano' },
+      ].map(vf.StaveNote.bind(vf));
+
+      function addAccidental(note, accid) {
+        return note.addModifier(0, vf.Accidental({ type: accid }));
+      }
+      function addSubGroup(note, subNotes) {
+        return note.addModifier(0, vf.NoteSubGroup({ notes: subNotes }));
+      }
+
+      addAccidental(notes1[1], '#');
+
+      addSubGroup(notes1[1], [
+        vf.ClefNote({ type: 'bass', options: { size: 'small' } }),
+        new VF.BarNote(VF.Barline.type.REPEAT_BEGIN),
+        vf.TimeSigNote({ time: '3/4' }),
+      ]);
+      addSubGroup(notes2[2], [
+        vf.ClefNote({ type: 'alto', options: { size: 'small' } }),
+        vf.TimeSigNote({ time: '9/8' }),
+        new VF.BarNote(VF.Barline.type.DOUBLE),
+      ]);
+      addSubGroup(notes1[3], [
+        vf.ClefNote({ type: 'soprano', options: { size: 'small' } }),
+      ]);
+
+      addAccidental(notes1[2], 'b');
+      addAccidental(notes2[3], '#');
+
+      var voices = [
+        vf.Voice().addTickables(notes1),
+        vf.Voice().addTickables(notes2),
+      ];
+
+      vf.Formatter()
+        .joinVoices(voices)
+        .formatToStave(voices, stave);
+
+      vf.draw();
       vf.draw();
 
       notes1.forEach(function(note) {

--- a/tests/ornament_tests.js
+++ b/tests/ornament_tests.js
@@ -12,6 +12,7 @@ VF.Test.Ornament = (function() {
       runTests('Ornaments', Ornament.drawOrnaments);
       runTests('Ornaments Vertically Shifted', Ornament.drawOrnamentsDisplaced);
       runTests('Ornaments - Delayed turns', Ornament.drawOrnamentsDelayed);
+      runTests('Ornaments - Delayed turns, Multiple Draws', Ornament.drawOrnamentsDelayedMultipleDraws);
       runTests('Stacked', Ornament.drawOrnamentsStacked);
       runTests('With Upper/Lower Accidentals', Ornament.drawOrnamentsWithAccidentals);
     },
@@ -124,6 +125,32 @@ VF.Test.Ornament = (function() {
       notesBar1[3].addModifier(0, new VF.Ornament('turn').setDelayed(true));
 
       // Helper function to justify and draw a 4/4 voice
+      VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
+    },
+
+    drawOrnamentsDelayedMultipleDraws: function(options, contextBuilder) {
+      expect(0);
+
+      // Get the rendering context
+      var ctx = contextBuilder(options.elementId, 550, 195);
+
+      // bar 1
+      var staveBar1 = new VF.Stave(10, 30, 500);
+      staveBar1.setContext(ctx).draw();
+      var notesBar1 = [
+        new VF.StaveNote({ keys: ['a/4'], duration: '4', stem_direction: 1 }),
+        new VF.StaveNote({ keys: ['a/4'], duration: '4', stem_direction: 1 }),
+        new VF.StaveNote({ keys: ['a/4'], duration: '4', stem_direction: 1 }),
+        new VF.StaveNote({ keys: ['a/4'], duration: '4', stem_direction: 1 }),
+      ];
+
+      notesBar1[0].addModifier(0, new VF.Ornament('turn').setDelayed(true));
+      notesBar1[1].addModifier(0, new VF.Ornament('turn_inverted').setDelayed(true));
+      notesBar1[2].addModifier(0, new VF.Ornament('turn_inverted').setDelayed(true));
+      notesBar1[3].addModifier(0, new VF.Ornament('turn').setDelayed(true));
+
+      // Helper function to justify and draw a 4/4 voice
+      VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
       VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
     },
 


### PR DESCRIPTION
Before, NoteSubGroup x-offset was reapplied every render, similar to what was mentioned in #632:
```tick_context.setX(x + x_offset);```

This resulted in NoteSubGroups moving x-wise every draw():
![image](https://user-images.githubusercontent.com/33069673/43330515-b608e5f8-91c3-11e8-95eb-c2d4644c26aa.png)

I improved and reapplied the fix from #632. Now, GraceNoteGroups and NoteSubGroups use the same align function in modifier.js, whereas before they both had an align function that was duplicate code. I tried moving the alignment to a format method, because it should rather be there than in draw(), but when i tried it seemed like it was too early and didn't work.

In TickContext I added the possibility to represent x-positioning as base x plus offset, so we can simply overwrite the x-offset and not apply the x-offset of the previous draw()-call to the next one.

This could be a good method to use in general, though it'll still be possible to simply get and set x in TickContext.

This PR fixes both in-measure clef (as NoteSubGroup) and grace note rerender shift in [OSMD](github.com/opensheetmusicdisplay/opensheetmusicdisplay/).

All Qunit tests pass btw.