### PR TITLE
Stem not linking to note head at correct place

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -367,10 +367,11 @@ export class StaveNote extends StemmableNote {
   // Builds a `Stem` for the note
   buildStem() {
     const glyph = this.getGlyph();
-    const yExtend = glyph.code_head === 'v95' || glyph.code_head === 'v3e' ? -4 : 0;
+    // const yExtend = glyph.code_head === 'v95' || glyph.code_head === 'v3e' ? -4 : 0;
 
     this.setStem(new Stem({
-      yExtend,
+      stem_up_y_offset: glyph.stem_up_y_offset,
+      stem_down_y_offset: glyph.stem_down_y_offset,
       hide: !!this.isRest(),
     }));
   }

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -367,7 +367,6 @@ export class StaveNote extends StemmableNote {
   // Builds a `Stem` for the note
   buildStem() {
     const glyph = this.getGlyph();
-    // const yExtend = glyph.code_head === 'v95' || glyph.code_head === 'v3e' ? -4 : 0;
 
     this.setStem(new Stem({
       stem_up_y_offset: glyph.stem_up_y_offset,

--- a/src/stem.js
+++ b/src/stem.js
@@ -54,6 +54,10 @@ export class Stem extends Element {
     this.isStemlet = options.isStemlet || false;
     this.stemletHeight = options.stemletHeight || 0;
 
+    // Changing where the stem meets the head
+    this.stem_up_y_offset = options.stem_up_y_offset || 0;
+    this.stem_down_y_offset = options.stem_down_y_offset || 0;
+
     // Use to adjust the rendered height without affecting
     // the results of `.getExtents()`
     this.renderHeightAdjustment = 0;
@@ -84,8 +88,9 @@ export class Stem extends Element {
 
   // Gets the entire height for the stem
   getHeight() {
+    const y_offset = (this.stem_direction === Stem.UP) ? this.stem_up_y_offset : this.stem_down_y_offset; // eslint-disable-line max-len
     return ((this.y_bottom - this.y_top) * this.stem_direction) +
-           ((Stem.HEIGHT + this.stem_extension) * this.stem_direction);
+           ((Stem.HEIGHT - y_offset + this.stem_extension) * this.stem_direction);
   }
   getBoundingBox() {
     throw new Vex.RERR('NotImplemented', 'getBoundingBox() not implemented.');
@@ -128,11 +133,11 @@ export class Stem extends Element {
     if (stem_direction === Stem.DOWN) {
       // Down stems are rendered to the left of the head.
       stem_x = this.x_begin;
-      stem_y = this.y_top;
+      stem_y = this.y_top + this.stem_down_y_offset;
     } else {
       // Up stems are rendered to the right of the head.
       stem_x = this.x_end;
-      stem_y = this.y_bottom;
+      stem_y = this.y_bottom - this.stem_up_y_offset;
     }
 
     const stemHeight = this.getHeight();

--- a/src/tables.js
+++ b/src/tables.js
@@ -475,12 +475,11 @@ Flow.parseNoteData = noteData => {
 
     // If we have keys, try and check if we've got a custom glyph
     if (noteData.keys !== undefined) {
-      const regexp = /^([a-gx]?)\/(\d?)\/?([a-z][0-3])$/;
-      const result = regexp.exec(noteData.keys[0]);
+      const result = noteData.keys[0].split('/');
 
       // We have a custom glyph specified after the note eg. /X2
-      if (result && result.length === 4) {
-        type = result[3]; // Set the type to the custom note head
+      if (result && result.length === 3) {
+        type = result[2]; // Set the type to the custom note head
       }
     }
     if (!type) {

--- a/src/tables.js
+++ b/src/tables.js
@@ -185,16 +185,16 @@ Flow.keyProperties.note_glyph = {
   'D3': { code: 'v70', shift_right: -0.5 },
 
   /* Triangle */
-  'T0': { code: 'v49', shift_right: -2 },
-  'T1': { code: 'v93', shift_right: 0.5 },
-  'T2': { code: 'v40', shift_right: 0.5 },
-  'T3': { code: 'v7d', shift_right: 0.5 },
+  'T0': { code: 'v49', shift_right: -2, stem_up_y_offset: -4, stem_down_y_offset: 4 },
+  'T1': { code: 'v93', shift_right: 0.5, stem_up_y_offset: -4, stem_down_y_offset: 4 },
+  'T2': { code: 'v40', shift_right: 0.5, stem_up_y_offset: -4, stem_down_y_offset: 4 },
+  'T3': { code: 'v7d', shift_right: 0.5, stem_up_y_offset: -4, stem_down_y_offset: 4 },
 
   /* Cross */
-  'X0': { code: 'v92', shift_right: -2 },
-  'X1': { code: 'v95', shift_right: -0.5 },
-  'X2': { code: 'v3e', shift_right: 0.5 },
-  'X3': { code: 'v3b', shift_right: -2 },
+  'X0': { code: 'v92', shift_right: -2, stem_up_y_offset: 4, stem_down_y_offset: 4 },
+  'X1': { code: 'v95', shift_right: -0.5, stem_up_y_offset: 4, stem_down_y_offset: 4 },
+  'X2': { code: 'v3e', shift_right: 0.5, stem_up_y_offset: 4, stem_down_y_offset: 4 },
+  'X3': { code: 'v3b', shift_right: -2, stem_up_y_offset: 4, stem_down_y_offset: 4 },
 };
 
 Flow.integerToNote = integer => {
@@ -596,6 +596,8 @@ Flow.durationToGlyph = (duration, type) => {
     // Otherwise set it as the code_head value
     glyphTypeProperties = {
       code_head: customGlyphTypeProperties.code,
+      stem_up_y_offset: customGlyphTypeProperties.stem_up_y_offset,
+      stem_down_y_offset: customGlyphTypeProperties.stem_down_y_offset,
     };
   }
 

--- a/src/tables.js
+++ b/src/tables.js
@@ -194,7 +194,7 @@ Flow.keyProperties.note_glyph = {
   'X0': { code: 'v92', shift_right: -2, stem_up_y_offset: 4, stem_down_y_offset: 4 },
   'X1': { code: 'v95', shift_right: -0.5, stem_up_y_offset: 4, stem_down_y_offset: 4 },
   'X2': { code: 'v3e', shift_right: 0.5, stem_up_y_offset: 4, stem_down_y_offset: 4 },
-  'X3': { code: 'v3b', shift_right: -2, stem_up_y_offset: 4, stem_down_y_offset: 4 },
+  'X3': { code: 'v3b', shift_right: -2, stem_up_y_offset: 2, stem_down_y_offset: 2 },
 };
 
 Flow.integerToNote = integer => {


### PR DESCRIPTION
Added code to allow the stem to connect to the custom note head at the expected place.

`stem_up_y_offset` and `stem_down_y_offset` are both needed because the stem meets at the bottom of the note head for some, and bottom/top for others depending whether it's up or down.

Example from the tests:
![image](https://user-images.githubusercontent.com/1129284/44819392-9fff4500-abe4-11e8-8f72-ab058b7de33e.png)