### PR TITLE
{Clef, TimeSig, Bar}Note.getBoundingBox: changed to call Note.getBoundingBox() to fix large voice bbox.

### DIFF
--- a/src/barnote.js
+++ b/src/barnote.js
@@ -11,7 +11,6 @@
 import { Vex } from './vex';
 import { Note } from './note';
 import { Barline } from './stavebarline';
-import { BoundingBox } from './boundingbox';
 
 // To enable logging for this class. Set `Vex.Flow.BarNote.DEBUG` to `true`.
 function L(...args) { if (BarNote.DEBUG) Vex.L('Vex.Flow.BarNote', args); }
@@ -54,7 +53,7 @@ export class BarNote extends Note {
   }
 
   getBoundingBox() {
-    return new BoundingBox(0, 0, 0, 0);
+    return super.getBoundingBox();
   }
 
   addToModifierContext() {

--- a/src/clefnote.js
+++ b/src/clefnote.js
@@ -4,7 +4,6 @@
 // Author Taehoon Moon 2014
 
 import { Vex } from './vex';
-import { BoundingBox } from './boundingbox';
 import { Note } from './note';
 import { Clef } from './clef';
 import { Glyph } from './glyph';
@@ -43,7 +42,7 @@ export class ClefNote extends Note {
   }
 
   getBoundingBox() {
-    return new BoundingBox(0, 0, 0, 0);
+    return super.getBoundingBox();
   }
 
   addToModifierContext() {

--- a/src/timesignote.js
+++ b/src/timesignote.js
@@ -1,7 +1,6 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Taehoon Moon 2014
 
-import { BoundingBox } from './boundingbox';
 import { Note } from './note';
 import { TimeSignature } from './timesignature';
 
@@ -19,7 +18,7 @@ export class TimeSigNote extends Note {
   }
 
   getBoundingBox() {
-    return new BoundingBox(0, 0, 0, 0);
+    return super.getBoundingBox();
   }
 
   addToModifierContext() {


### PR DESCRIPTION
* this PR fix large voice bbox by implementing  https://github.com/0xfe/vexflow/issues/343#issuecomment-232233429 :
>Looks like ClefNote.getBoundingBox() is not implemented, so calling it dispatches Note.getBoundingBox() which returns null. This should be an easy fix.

* test case: <http://jsfiddle.net/184sthee/57/>

![image](https://user-images.githubusercontent.com/3293067/45333792-deb4d800-b5b2-11e8-8484-63412e84261e.png)

```text
old:
...
ClefNote:  Object { x: 0, y: 0, w: 0, h: 0 }
TimeSigNoteNote:  Object { x: 0, y: 0, w: 0, h: 0 }
BarNote:  Object { x: 0, y: 0, w: 0, h: 0 }

new:
...
ClefNote:  null
TimeSigNoteNote:  null
BarNote:  null
```

* the followings are not affected by this PR:

```
$ npm test
...

You have 1 warning(s):
  Warning: NoteHead.Various_Heads.svg missing in ./build/images/blessed.
You have 5 fail(s):
Percussion.Percussion_Notes 8.58544
Percussion.Percussion_Snare1 6.38658
Percussion.Percussion_Basic2 6.1767
Percussion.Percussion_Basic1 4.75721
Percussion.Percussion_Basic0 0.940895
```
