### PR TITLE
Prevent System.addStave from swallowing passed options

### DIFF
--- a/src/system.js
+++ b/src/system.js
@@ -62,16 +62,15 @@ export class System extends Element {
       spaceAbove: 0, // stave spaces
       spaceBelow: 0, // stave spaces
       debugNoteMetrics: false,
-      options: {},
+      options: { left_bar: false }
     });
 
     if (!params.stave) {
-      const options = { left_bar: false };
       params.stave = this.factory.Stave({
         x: this.options.x,
         y: this.options.y,
         width: this.options.width,
-        options,
+        options: params.options,
       });
     }
 

--- a/src/system.js
+++ b/src/system.js
@@ -62,7 +62,7 @@ export class System extends Element {
       spaceAbove: 0, // stave spaces
       spaceBelow: 0, // stave spaces
       debugNoteMetrics: false,
-      options: { left_bar: false }
+      options: { left_bar: false },
     });
 
     if (!params.stave) {


### PR DESCRIPTION
For example, if `right_bar: false` was passed in the `options` object, it wasn't being respected. This PR fixes that.

I'm using this change successfully in code. However, I'm not set up to be able to run the tests yet.

Please let me know if I'm missing something here. This is my first PR to VexFlow. It seemed a bit obvious that the existing options should be used rather than defining a new `const options`, so I may be missing some context that a more experienced contributor will see.

This is a fantastic project. I've started using it only in some still experimental/unreleased code on SightReadingMastery, but I am super impressed so far. Cheers to Mohit and everyone who has worked hard to make it so great!