### PR TITLE
changed to save and restore svgcontext.lineWidth.

### DIFF
--- a/src/svgcontext.js
+++ b/src/svgcontext.js
@@ -646,6 +646,7 @@ export class SVGContext {
         width: this.shadow_attributes.width,
         color: this.shadow_attributes.color,
       },
+      lineWidth: this.lineWidth,
     });
     return this;
   }
@@ -670,6 +671,8 @@ export class SVGContext {
 
     this.shadow_attributes.width = state.shadow_attributes.width;
     this.shadow_attributes.color = state.shadow_attributes.color;
+
+    this.lineWidth = state.lineWidth;
     return this;
   }
 }


### PR DESCRIPTION
* this PR {save/restore} svgcontext.lineWidth to fix #656.

<img src="https://user-images.githubusercontent.com/3293067/46325570-d7be3a00-c633-11e8-80d7-a567fc43b9c7.png" height="300">

* Previously, stroke results of {svg and canvas} context were different, but now they are similar.
* many tests are affected by this PR as follows (is an excerpt): 

![image](https://user-images.githubusercontent.com/3293067/46325221-37b3e100-c632-11e8-9f94-68004ab2a536.png)

