### PR TITLE
fix(articulation): Grace notes can now have articulation

### DIFF
--- a/src/articulation.js
+++ b/src/articulation.js
@@ -55,8 +55,9 @@ const getTopY = (note, textLine) => {
   const stave = note.getStave();
   const stemDirection = note.getStemDirection();
   const { topY: stemTipY, baseY: stemBaseY } = note.getStemExtents();
+  const noteCategory = note.getCategory();
 
-  if (note.getCategory() === 'stavenotes') {
+  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemTipY;
@@ -66,7 +67,7 @@ const getTopY = (note, textLine) => {
     } else {
       return Math.min(...note.getYs());
     }
-  } else if (note.getCategory() === 'tabnotes') {
+  } else if (noteCategory === 'tabnotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemTipY;
@@ -87,8 +88,9 @@ const getBottomY = (note, textLine) => {
   const stave = note.getStave();
   const stemDirection = note.getStemDirection();
   const { topY: stemTipY, baseY: stemBaseY } = note.getStemExtents();
+  const noteCategory = note.getCategory();
 
-  if (note.getCategory() === 'stavenotes') {
+  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemBaseY;
@@ -98,7 +100,7 @@ const getBottomY = (note, textLine) => {
     } else {
       return Math.max(...note.getYs());
     }
-  } else if (note.getCategory() === 'tabnotes') {
+  } else if (noteCategory === 'tabnotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stave.getYForBottomText(textLine);
@@ -125,8 +127,9 @@ const getInitialOffset = (note, position) => {
     (position === ABOVE && note.getStemDirection() === Stem.UP) ||
     (position === BELOW && note.getStemDirection() === Stem.DOWN)
   );
+  const noteCategory = note.getCategory();
 
-  if (note.getCategory() === 'stavenotes') {
+  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
     if (note.hasStem() && isOnStemTip) {
       return 0.5;
     } else {

--- a/src/articulation.js
+++ b/src/articulation.js
@@ -51,13 +51,17 @@ const snapLineToStaff = (canSitBetweenLines, line, position, offsetDirection) =>
   }
 };
 
+const isStaveNote = (note) => {
+  const noteCategory = note.getCategory();
+  return noteCategory === 'stavenotes' || noteCategory === 'gracenotes';
+};
+
 const getTopY = (note, textLine) => {
   const stave = note.getStave();
   const stemDirection = note.getStemDirection();
   const { topY: stemTipY, baseY: stemBaseY } = note.getStemExtents();
-  const noteCategory = note.getCategory();
 
-  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
+  if (isStaveNote(note)) {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemTipY;
@@ -67,7 +71,7 @@ const getTopY = (note, textLine) => {
     } else {
       return Math.min(...note.getYs());
     }
-  } else if (noteCategory === 'tabnotes') {
+  } else if (note.getCategory() === 'tabnotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemTipY;
@@ -88,9 +92,8 @@ const getBottomY = (note, textLine) => {
   const stave = note.getStave();
   const stemDirection = note.getStemDirection();
   const { topY: stemTipY, baseY: stemBaseY } = note.getStemExtents();
-  const noteCategory = note.getCategory();
 
-  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
+  if (isStaveNote(note)) {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stemBaseY;
@@ -100,7 +103,7 @@ const getBottomY = (note, textLine) => {
     } else {
       return Math.max(...note.getYs());
     }
-  } else if (noteCategory === 'tabnotes') {
+  } else if (note.getCategory() === 'tabnotes') {
     if (note.hasStem()) {
       if (stemDirection === Stem.UP) {
         return stave.getYForBottomText(textLine);
@@ -127,9 +130,8 @@ const getInitialOffset = (note, position) => {
     (position === ABOVE && note.getStemDirection() === Stem.UP) ||
     (position === BELOW && note.getStemDirection() === Stem.DOWN)
   );
-  const noteCategory = note.getCategory();
 
-  if (noteCategory === 'stavenotes' || noteCategory === 'gracenotes') {
+  if (isStaveNote(note)) {
     if (note.hasStem() && isOnStemTip) {
       return 0.5;
     } else {


### PR DESCRIPTION
GraceNotes weren't able to have articulation before, because articulation.js only checked whether the note's category is 'stavenotes', not 'gracenotes'. GraceNote extends StaveNote.

Of course it would be ideal to check whether something is a superclass of StaveNote, but Javascript isn't good enough with type detection and inheritance, right?

Now we can have some funky grace note articulations:
![image](https://user-images.githubusercontent.com/33069673/46533724-f592d580-c8a5-11e8-9ca5-9bbd62c2cdc4.png)

Tests pass.