### PR TITLE
[tests]: fix unsorted keys error.

### DIFF
--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -274,7 +274,7 @@ VF.Test.Formatter = (function() {
         width: stave21.width,
       });
 
-      var notes22 = score.notes('(eb4 ab4)/4., (eb4 ab4 c4)/4, db5/8', { stem: 'up' });
+      var notes22 = score.notes('(eb4 ab4)/4., (c4 eb4 ab4)/4, db5/8', { stem: 'up' });
       var voice22 = score.voice(notes22, { time: '6/8' });
 
       vf.Stave({


### PR DESCRIPTION
This PR fixes `Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details.` on `{npm|grunt} test`:

master:

```
$ npm test
...
Running "qunit:files" (qunit) task
Testing tests/flow.html .....................................................................................................................................Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details. undefined
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................OK
>> 659 tests completed with 0 failed, 0 skipped, and 0 todo. 
>> 2877 assertions (in 10698ms), passed: 2877, failed: 0

Done.
...
Running 293 tests with threshold 0.01...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.


You have 2 warning(s):
  Warning: Grace_Notes.Grace_Note_Slash.svg missing in ./build/images/blessed.
  Warning: Grace_Notes.Grace_Note_Slash_with_Beams.svg missing in ./build/images/blessed.
Success - All diffs under threshold!
```

current: 

```
$ npm test
...
Running "qunit:files" (qunit) task
Testing tests/flow.html ...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................OK
>> 659 tests completed with 0 failed, 0 skipped, and 0 todo. 
>> 2877 assertions (in 10460ms), passed: 2877, failed: 0

Done.
...
Running 293 tests with threshold 0.01...
...
You have 2 warning(s):
  Warning: Grace_Notes.Grace_Note_Slash.svg missing in ./build/images/blessed.
  Warning: Grace_Notes.Grace_Note_Slash_with_Beams.svg missing in ./build/images/blessed.
You have 3 fail(s):
Formatter.Multiple_Staves___No_Justification 2.08092
Formatter.Multiple_Staves___Justified___6_Iterations 0.265311
Formatter.Multiple_Staves___Justified 0.0545326
```
* no `Warning:  Unsorted keys in note will be sorted. See https://github.com/0xfe/vexflow/issues/104 for details.`
* `Formatter.Multiple_Staves___*`: flat lines are fixed as follows:

![image](https://user-images.githubusercontent.com/3293067/47051982-868c7980-d1e1-11e8-9213-84cb66529224.png)
