### PR TITLE
fix(tremolo): offsets depending on stem direction, scale for grace notes

### DIFF
--- a/src/tremolo.js
+++ b/src/tremolo.js
@@ -6,9 +6,14 @@
 import { Vex } from './vex';
 import { Modifier } from './modifier';
 import { Glyph } from './glyph';
+import { GraceNote } from './gracenote';
 
 export class Tremolo extends Modifier {
   static get CATEGORY() { return 'tremolo'; }
+  static get YOFFSETSTEMUP() { return -9; }
+  static get YOFFSETSTEMDOWN() { return -21; }
+  static get XOFFSETSTEMUP() { return 6; }
+  static get XOFFSETSTEMDOWN() { return -2; }
   constructor(num) {
     super();
     this.setAttribute('type', 'Tremolo');
@@ -18,20 +23,6 @@ export class Tremolo extends Modifier {
     this.index = null;
     this.position = Modifier.Position.CENTER;
     this.code = 'v74';
-    this.shift_right = -2;
-    this.y_spacing = 4;
-
-    this.render_options = {
-      font_scale: 35,
-      stroke_px: 3,
-      stroke_spacing: 10,
-    };
-
-    this.font = {
-      family: 'Arial',
-      size: 16,
-      weight: '',
-    };
   }
 
   getCategory() { return Tremolo.CATEGORY; }
@@ -44,11 +35,31 @@ export class Tremolo extends Modifier {
     }
 
     this.setRendered();
+    const stemDirection = this.note.getStemDirection();
+    this.y_spacing = 4 * stemDirection;
     const start = this.note.getModifierStartXY(this.position, this.index);
     let x = start.x;
-    let y = start.y;
+    let y = this.note.stem.getExtents().topY;
+    const scale = this.note.getCategory() === 'gracenotes' ? GraceNote.SCALE : 1;
+    if (stemDirection < 0) {
+      y += Tremolo.YOFFSETSTEMDOWN * scale;
+    } else {
+      y += Tremolo.YOFFSETSTEMUP * scale;
+    }
 
-    x += this.shift_right;
+    this.font = {
+      family: 'Arial',
+      size: 16 * scale,
+      weight: '',
+    };
+
+    this.render_options = {
+      font_scale: 35 * scale,
+      stroke_px: 3,
+      stroke_spacing: 10 * scale,
+    };
+
+    x += stemDirection < 0 ? Tremolo.XOFFSETSTEMDOWN : Tremolo.XOFFSETSTEMUP;
     for (let i = 0; i < this.num; ++i) {
       Glyph.renderGlyph(this.context, x, y, this.render_options.font_scale, this.code);
       y += this.y_spacing;

--- a/tests/percussion_tests.js
+++ b/tests/percussion_tests.js
@@ -140,12 +140,25 @@ VF.Test.Percussion = (function() {
       run('Percussion Snare2', createSingleMeasureTest(function(vf) {
         vf.Voice().addTickables([
           vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
-            .addArticulation(0, new VF.Tremolo(0)),
-          vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
+            .addArticulation(0, new VF.Tremolo(1)),
+          vf.GraceNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
             .addArticulation(0, new VF.Tremolo(1)),
           vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
             .addArticulation(0, new VF.Tremolo(3)),
           vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
+            .addArticulation(0, new VF.Tremolo(5)),
+        ]);
+      }));
+
+      run('Percussion Snare3', createSingleMeasureTest(function(vf) {
+        vf.Voice().addTickables([
+          vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: 1 })
+            .addArticulation(0, new VF.Tremolo(2)),
+          vf.GraceNote({ keys: ['c/5'], duration: '4', stem_direction: 1 })
+            .addArticulation(0, new VF.Tremolo(2)),
+          vf.GraceNote({ keys: ['c/5'], duration: '4', stem_direction: 1 })
+            .addArticulation(0, new VF.Tremolo(3)),
+          vf.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: 1 })
             .addArticulation(0, new VF.Tremolo(5)),
         ]);
       }));


### PR DESCRIPTION
Tremolo x and y offsets were only set for stem down, which the test Snare2 only uses.
Now they depend on stem direction, and size is scaled for grace notes.

add test Percussion Snare3, modify test Snare2 for more tremolo variety
![image](https://user-images.githubusercontent.com/33069673/47200705-7c03e880-d377-11e8-82e8-86504526c38a.png)

The offset were also off, here's a comparison [Before](https://user-images.githubusercontent.com/33069673/47200613-2596aa00-d377-11e8-91ca-74c97e25f736.png) and [After](https://user-images.githubusercontent.com/33069673/47200580-0730ae80-d377-11e8-986a-26285d8cf210.png).
(ignore weird use of the tremolo, this should only show consistency of the offset)
