### PR TITLE
parallelly execute 'rsvg-convert' and 'compare' to reduce execution time

### DIFF
--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -75,7 +75,7 @@ fi
 
 total=`ls -l $BLESSED/$files | wc -l | sed 's/[[:space:]]//g'`
 
-echo "Running $total tests with threshold $THRESHOLD..."
+echo "Running $total tests with threshold $THRESHOLD (nproc=$nproc)..."
 
 function ProgressBar {
     let _progress=(${1}*100/${2}*100)/100

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -136,8 +136,12 @@ function diff_image() {
 
 function wait_jobs () {
   local n=$1
-  while [[ "$(jobs | grep -v Done | wc -l)" -ge "$n" ]] ; do
-     sleep 0.12
+  while [[ "$(jobs -r | wc -l)" -ge "$n" ]] ; do
+     # echo ===================================== && jobs -lr
+     # wait the oldest job.
+     local pid_to_wait=`jobs -rp | head -1`
+     # echo wait $pid_to_wait
+     wait $pid_to_wait  &> /dev/null
   done
 }
 

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -96,7 +96,7 @@ function diff_image() {
 
   if [ ! -e "$current" ]
   then
-    echo "Warning: $name.svg missing in $CURRENT." >>$WARNINGS
+    echo "Warning: $name.svg missing in $CURRENT." >$diff.warn
     return
   fi
 
@@ -154,6 +154,9 @@ do
   diff_image $image &
 done
 wait
+
+cat $CURRENT/*.warn 1> $WARNINGS 2> /dev/null
+rm -f $CURRENT/*.warn
 
 ## Check for files newly built that are not yet blessed.
 for image in $CURRENT/$files

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -116,7 +116,7 @@ function diff_image() {
   if [ "$isGT" == "1" ]
   then
     # Add the result to results.text
-    echo $name $hash >>$RESULTS.fail
+    echo $name $hash >$diff.fail
     # Threshold exceeded, save the diff and the original, current
     cp $diff-diff.png $DIFF/$name.png
     cp $diff-a.png $DIFF/$name'_'Blessed.png
@@ -129,7 +129,7 @@ function diff_image() {
     # echo 'Hit return to process next image...'
     # read
   else
-    echo $name $hash >>$RESULTS.pass
+    echo $name $hash >$diff.pass
   fi
   rm -f $diff-a.png $diff-b.png $diff-diff.png
 }
@@ -155,7 +155,7 @@ do
 done
 wait
 
-cat $CURRENT/*.warn 1> $WARNINGS 2> /dev/null
+cat $CURRENT/*.warn 1>$WARNINGS 2>/dev/null
 rm -f $CURRENT/*.warn
 
 ## Check for files newly built that are not yet blessed.
@@ -172,12 +172,15 @@ do
 done
 
 num_warnings=`cat $WARNINGS | wc -l`
+
+cat $CURRENT/*.fail 1>$RESULTS.fail 2>/dev/null
 num_fails=`cat $RESULTS.fail | wc -l`
+rm -f  $CURRENT/*.fail
 
 # Sort results by PHASH
 sort -r -n -k 2 $RESULTS.fail >$RESULTS
-sort -r -n -k 2 $RESULTS.pass >>$RESULTS
-rm $RESULTS.fail $RESULTS.pass
+sort -r -n -k 2 $CURRENT/*.pass 1>>$RESULTS 2>/dev/null
+rm -f $CURRENT/*.pass $RESULTS.fail $RESULTS.pass
 
 echo
 echo Results stored in $DIFF/results.txt

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -112,7 +112,7 @@ function diff_image() {
   # Calculate the difference metric and store the composite diff image.
   local hash=`compare -metric PHASH -highlight-color '#ff000050' $diff-b.png $diff-a.png $diff-diff.png 2>&1`
 
-  isGT=`echo "$hash > $THRESHOLD" | bc -l`
+  local isGT=`echo "$hash > $THRESHOLD" | bc -l`
   if [ "$isGT" == "1" ]
   then
     # Add the result to results.text


### PR DESCRIPTION
This PR parallelly execute 'rsvg-convert' and 'compare' to reduce execution time as follows:

on my ubuntu vm on w10:

master: 
```shell
$ time  ./tools/visual_regression.sh
...
real	1m15.138s
user	2m36.060s
sys	0m20.897s
```
current:
```shell
$ time  ./tools/visual_regression.sh
Running 293 tests with threshold 0.01 (nproc=8)...
...
real	0m32.919s
user	3m30.496s
sys	0m31.862s
```
- environment variable
  - NPROC: specify number of simultaneous jobs

```
$ NPROC=1 npm test  # limit to 1 process
```

Since, SlimerJs only supports the old Firefox, npm test on my MBP(osx 10.13.6 + Firefox 62) was failed and i gave up.
