### PR TITLE
svgcontext.archHelper: generate {'M' + this.pen.{x,y}} command if this.pen is valid.

### DIFF
--- a/src/svgcontext.js
+++ b/src/svgcontext.js
@@ -46,7 +46,7 @@ export class SVGContext {
     this.parent = this.svg;
 
     this.path = '';
-    this.pen = { x: 0, y: 0 };
+    this.pen = { x: NaN, y: NaN };
     this.lineWidth = 1.0;
     this.state = {
       scale: { x: 1, y: 1 },
@@ -396,8 +396,8 @@ export class SVGContext {
 
   beginPath() {
     this.path = '';
-    this.pen.x = 0;
-    this.pen.y = 0;
+    this.pen.x = NaN;
+    this.pen.y = NaN;
     return this;
   }
 
@@ -494,7 +494,10 @@ export class SVGContext {
 
     this.path += 'M' + x1 + ' ' + y1 + ' A' +
       radius + ' ' + radius + ' 0 ' + largeArcFlag + ' ' + sweepFlag + ' ' +
-      x2 + ' ' + y2 + 'M' + this.pen.x + ' ' + this.pen.y;
+      x2 + ' ' + y2;
+    if (!isNaN(this.pen.x) && !isNaN(this.pen.y)) {
+      this.peth += 'M' + this.pen.x + ' ' + this.pen.y;
+    }
   }
 
   closePath() {


### PR DESCRIPTION
This PR checks the svgcontext.pen.{x, y} is valid (!NaN) or not to append {'M' pen.{x, y}} command to fix #650.

npm test: Success:
```shell
 (650-fix_svgcontext_arc_big_path=)
$ git checkout master && npm start && git checkout @{-1} && npm test
...
Running 295 tests with threshold 0.01...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

Success - All diffs under threshold!
```

test case:

<http://jsfiddle.net/q6avoh7e/>

![image](https://user-images.githubusercontent.com/3293067/48040111-ed86c800-e1ba-11e8-84bf-3aceefa52cf7.png)

```xml
before:
<path stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none"
  d="M369 65.5 A2 2 0 0 0 365 65.5M0 0M365 65.5 A2 2 0 0 0 369 65.5M0 0"></path>
↓
after:
<path stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none"
  d="M369 65.5 A2 2 0 0 0 365 65.5M365 65.5 A2 2 0 0 0 369 65.5"></path>
```
