### PR TITLE
#670: Fraction.copy: support 'number' type argument to fix Fraction.equls(number).

### DIFF
--- a/src/fraction.js
+++ b/src/fraction.js
@@ -220,6 +220,9 @@ export class Fraction {
 
   // Copies value of another Fraction into itself.
   copy(copy) {
+    if (typeof copy === 'number') {
+      return this.set(copy || 0, 1);
+    }
     return this.set(copy.numerator, copy.denominator);
   }
 


### PR DESCRIPTION
This PR fixes #670.

@dolphinxx san: Thank you for your detailed comment!

- Since `Fraction.subtract` supports numeric argument, changed to support numeric argument with `Fraction.copy` (not `Fraction.equals`).

- npm test (with master):
```shell
 (670-fix_durationToFraction=)
$ git checkout master && npm start && git checkout @{-1} && npm test
...
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 4 fail(s):
StaveNote.StaveNote_Draw___Slash 0.50734
Rhythm.Rhythm_Draw___slash_notes 0.426776
StaveNote.StaveNote_BoundingBoxes___Treble 0.201863
Rhythm.Rhythm_Draw___beamed_slash_notes__some_rests 0.191847
```

- {1/2, 1} slash note head now correctly rendered.
- StaveNote.StaveNote_BoundingBoxes: half rest boundingBox is better than before.
  https://github.com/0xfe/vexflow/blob/58d6e1a420ab0cdb545e461432f15b15eff107c0/src/stavenote.js#L529

![image](https://user-images.githubusercontent.com/3293067/48394655-c0588d80-e757-11e8-9404-bce2f3856286.png)

<http://jsfiddle.net/eo47gvmc/4/> :
![image](https://user-images.githubusercontent.com/3293067/48395466-b5532c80-e75a-11e8-8096-cf5754ebf062.png)

