### PR TITLE
#672: changed to remove unnecessary ctx.save call.

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1040,15 +1040,10 @@ export class StaveNote extends StemmableNote {
       const modifier = this.modifiers[i];
       const notehead = this.note_heads[modifier.getIndex()];
       const noteheadStyle = notehead.getStyle();
-      if (noteheadStyle) {
-        ctx.save();
-        notehead.applyStyle(ctx);
-      }
+      notehead.applyStyle(ctx, noteheadStyle);
       modifier.setContext(ctx);
       modifier.draw();
-      if (noteheadStyle) {
-        notehead.restoreStyle(ctx);
-      }
+      notehead.restoreStyle(ctx, noteheadStyle);
     }
     ctx.closeGroup();
   }


### PR DESCRIPTION
This PR fixes #672.

- npm test:
```shell
silk@ubuntu ~/work/github/sug1no/vexflow (672-restore_note_colors=)
$ git checkout master && npm start && git checkout @{-1} && npm test
...
Running 298 tests with threshold 0.01 (nproc=8)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

Success - All diffs under threshold!
```
- <http://jsfiddle.net/s5cg3fq2/4/> :
![image](https://user-images.githubusercontent.com/3293067/48399287-922e7a00-e766-11e8-97f3-3b529bf54efc.png)
