### PR TITLE
add some Vex.Flow.Fraction (number type argument) tests.

### DIFF
--- a/tests/fraction_tests.js
+++ b/tests/fraction_tests.js
@@ -12,43 +12,43 @@ VF.Test.Fraction = (function() {
 
     basic: function() {
       var f_1_2 = new Vex.Flow.Fraction(1, 2);
-      ok(f_1_2.equals(0.5), 'Fracetion: 1/2 equals 0.5');
-      ok(f_1_2.equals(new Vex.Flow.Fraction(1, 2)), 'Fracetion: 1/2 equals 1/2');
-      ok(f_1_2.equals(new Vex.Flow.Fraction(2, 4)), 'Fracetion: 1/2 equals 2/4');
+      ok(f_1_2.equals(0.5), 'Fraction: 1/2 equals 0.5');
+      ok(f_1_2.equals(new Vex.Flow.Fraction(1, 2)), 'Fraction: 1/2 equals 1/2');
+      ok(f_1_2.equals(new Vex.Flow.Fraction(2, 4)), 'Fraction: 1/2 equals 2/4');
 
-      notOk(f_1_2.greaterThan(1), 'Fracetion: ! 1/2 > 1');
-      ok(f_1_2.greaterThan(0.2), 'Fracetion: 1/2 > 0.2');
+      notOk(f_1_2.greaterThan(1), 'Fraction: ! 1/2 > 1');
+      ok(f_1_2.greaterThan(0.2), 'Fraction: 1/2 > 0.2');
 
-      ok(f_1_2.greaterThanEquals(0.2), 'Fracetion: 1/2 >= 0.2');
-      ok(f_1_2.greaterThanEquals(0.5), 'Fracetion: 1/2 >= 0.5');
-      notOk(f_1_2.greaterThanEquals(1), 'Fracetion: ! 1/2 >= 1');
+      ok(f_1_2.greaterThanEquals(0.2), 'Fraction: 1/2 >= 0.2');
+      ok(f_1_2.greaterThanEquals(0.5), 'Fraction: 1/2 >= 0.5');
+      notOk(f_1_2.greaterThanEquals(1), 'Fraction: ! 1/2 >= 1');
 
-      notOk(f_1_2.lessThan(0.5), 'Fracetion: ! 1/2 < 0.5');
-      ok(f_1_2.lessThan(1), 'Fracetion: 1/2 < 1');
+      notOk(f_1_2.lessThan(0.5), 'Fracion: ! 1/2 < 0.5');
+      ok(f_1_2.lessThan(1), 'Fraction: 1/2 < 1');
 
-      ok(f_1_2.lessThanEquals(0.6), 'Fracetion: 1/2 <= 0.6');
-      ok(f_1_2.lessThanEquals(0.5), 'Fracetion: 1/2 <= 0.5');
-      notOk(f_1_2.lessThanEquals(0.4), 'Fracetion: ! 1/2 <= 0.4');
+      ok(f_1_2.lessThanEquals(0.6), 'Fraction: 1/2 <= 0.6');
+      ok(f_1_2.lessThanEquals(0.5), 'Fraction: 1/2 <= 0.5');
+      notOk(f_1_2.lessThanEquals(0.4), 'Fraction: ! 1/2 <= 0.4');
 
       var f_05 = f_1_2.copy(0.5);
-      strictEqual(f_05, f_1_2, 'Fracetion: f_05 === f_1_2');
-      strictEqual(f_05.toString(), '0.5/1', 'Fracetion: f_05.toString() === "0.5/1"');
-      strictEqual(f_05.toSimplifiedString(), '1/2', 'Fracetion: f_05.toSimplifiedString() === "1/2"');
+      strictEqual(f_05, f_1_2, 'Fraction: f_05 === f_1_2');
+      strictEqual(f_05.toString(), '0.5/1', 'Fraction: f_05.toString() === "0.5/1"');
+      strictEqual(f_05.toSimplifiedString(), '1/2', 'Fraction: f_05.toSimplifiedString() === "1/2"');
 
       var tF_n = f_05.clone();
-      notStrictEqual(tF_n, f_05, 'Fracetion: tF_n !== f_05');
-      notEqual(tF_n, f_05, 'Fracetion: tF_n != f_05');
+      notStrictEqual(tF_n, f_05, 'Fraction: tF_n !== f_05');
+      notEqual(tF_n, f_05, 'Fraction: tF_n != f_05');
       deepEqual(tF_n, f_05, 'tF_n deepEqual f_05');
       notDeepEqual(tF_n, {}, 'tF_n notDeepEqual {}');
 
       tF_n.subtract(-0.5);
-      ok(tF_n.equals(1), 'Fracetion: 0.5 -(-0.5) equals 1');
+      ok(tF_n.equals(1), 'Fraction: 0.5 -(-0.5) equals 1');
       tF_n.add(1);
-      ok(tF_n.equals(2), 'Fracetion: 1 + 1 equals 2');
+      ok(tF_n.equals(2), 'Fraction: 1 + 1 equals 2');
       tF_n.multiply(2);
-      ok(tF_n.equals(4), 'Fracetion: 2 * 2 equals 4');
+      ok(tF_n.equals(4), 'Fraction: 2 * 2 equals 4');
       tF_n.divide(2);
-      ok(tF_n.equals(2), 'Fracetion: 4 / 2 equals 2');
+      ok(tF_n.equals(2), 'Fraction: 4 / 2 equals 2');
 
       // TODO: Add more detailed tests.
     },

--- a/tests/fraction_tests.js
+++ b/tests/fraction_tests.js
@@ -1,0 +1,59 @@
+/**
+ * VexFlow - Fraction Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ */
+
+VF.Test.Fraction = (function() {
+  var Fraction = {
+    Start: function() {
+      QUnit.module('Fraction');
+      test('Basic', VF.Test.Fraction.basic);
+    },
+
+    basic: function() {
+      var f_1_2 = new Vex.Flow.Fraction(1, 2);
+      ok(f_1_2.equals(0.5), 'Fracetion: 1/2 equals 0.5');
+      ok(f_1_2.equals(new Vex.Flow.Fraction(1, 2)), 'Fracetion: 1/2 equals 1/2');
+      ok(f_1_2.equals(new Vex.Flow.Fraction(2, 4)), 'Fracetion: 1/2 equals 2/4');
+
+      notOk(f_1_2.greaterThan(1), 'Fracetion: ! 1/2 > 1');
+      ok(f_1_2.greaterThan(0.2), 'Fracetion: 1/2 > 0.2');
+
+      ok(f_1_2.greaterThanEquals(0.2), 'Fracetion: 1/2 >= 0.2');
+      ok(f_1_2.greaterThanEquals(0.5), 'Fracetion: 1/2 >= 0.5');
+      notOk(f_1_2.greaterThanEquals(1), 'Fracetion: ! 1/2 >= 1');
+
+      notOk(f_1_2.lessThan(0.5), 'Fracetion: ! 1/2 < 0.5');
+      ok(f_1_2.lessThan(1), 'Fracetion: 1/2 < 1');
+
+      ok(f_1_2.lessThanEquals(0.6), 'Fracetion: 1/2 <= 0.6');
+      ok(f_1_2.lessThanEquals(0.5), 'Fracetion: 1/2 <= 0.5');
+      notOk(f_1_2.lessThanEquals(0.4), 'Fracetion: ! 1/2 <= 0.4');
+
+      var f_05 = f_1_2.copy(0.5);
+      strictEqual(f_05, f_1_2, 'Fracetion: f_05 === f_1_2');
+      strictEqual(f_05.toString(), '0.5/1', 'Fracetion: f_05.toString() === "0.5/1"');
+      strictEqual(f_05.toSimplifiedString(), '1/2', 'Fracetion: f_05.toSimplifiedString() === "1/2"');
+
+      var tF_n = f_05.clone();
+      notStrictEqual(tF_n, f_05, 'Fracetion: tF_n !== f_05');
+      notEqual(tF_n, f_05, 'Fracetion: tF_n != f_05');
+      deepEqual(tF_n, f_05, 'tF_n deepEqual f_05');
+      notDeepEqual(tF_n, {}, 'tF_n notDeepEqual {}');
+
+      tF_n.subtract(-0.5);
+      ok(tF_n.equals(1), 'Fracetion: 0.5 -(-0.5) equals 1');
+      tF_n.add(1);
+      ok(tF_n.equals(2), 'Fracetion: 1 + 1 equals 2');
+      tF_n.multiply(2);
+      ok(tF_n.equals(4), 'Fracetion: 2 * 2 equals 4');
+      tF_n.divide(2);
+      ok(tF_n.equals(2), 'Fracetion: 4 / 2 equals 2');
+
+      // TODO: Add more detailed tests.
+    },
+
+  };
+
+  return Fraction;
+})();

--- a/tests/run.js
+++ b/tests/run.js
@@ -9,6 +9,7 @@ VF.Test.run = function() {
   VF.Test.Dot.Start();
   VF.Test.Bend.Start();
   VF.Test.Formatter.Start();
+  VF.Test.Fraction.Start();
   VF.Test.Clef.Start();
   VF.Test.KeySignature.Start();
   VF.Test.TimeSignature.Start();

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -25,6 +25,10 @@ if (!window.QUnit) {
     expect: function() { return true; },
     throws: function() { return true; },
     notOk: function() { return true; },
+    notEqual: function() { return true; },
+    notDeepEqual: function() { return true; },
+    strictEqual: function() { return true; },
+    notStrictEqual: function() { return true; },
   };
 
   QUnit.module = function(name) {
@@ -45,6 +49,10 @@ if (!window.QUnit) {
   expect = QUnit.assertions.expect;
   throws = QUnit.assertions.throws;
   notOk = QUnit.assertions.notOk;
+  notEqual = QUnit.assertions.notEqual;
+  notDeepEqual = QUnit.assertions.notDeepEqual;
+  strictEqual = QUnit.assertions.strictEqual;
+  notStrictEqual = QUnit.assertions.notStrictEqual;
 }
 
 if (typeof require === 'function') {


### PR DESCRIPTION
https://github.com/0xfe/vexflow/pull/676#issuecomment-438295893
> Can we add a test for Fraction.subtract(2) etc. to make sure bug never reoccurs? Thanks!

This PR adds some Vex.Flow.Fraction (number type argument) tests (please add more detailed tests).

- npm test (with master): Success:

```shell
(670-676_add_Fraction_tests=)
$ git checkout master && npm start && git checkout @{-1} && npm test
...

Running "qunit:files" (qunit) task
Testing tests/flow.html
...
....................................OK

>> 666 tests completed with 0 failed, 0 skipped, and 0 todo. 
>> 2967 assertions (in 21372ms), passed: 2967, failed: 0

Done.

...
> npm run generate:current && npm run generate:blessed

...

Running 298 tests with threshold 0.01 (nproc=8)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

Success - All diffs under threshold!
```
