### PR TITLE
#547: add StaveModifier.{get, set}LayoutMetrics to define Barline metrics to fix stave end modifier layout

### DIFF
--- a/src/stavebarline.js
+++ b/src/stavebarline.js
@@ -58,6 +58,49 @@ export class Barline extends StaveModifier {
     this.paddings[TYPE.REPEAT_BOTH] = 15;
     this.paddings[TYPE.NONE] = 0;
 
+    this.layoutMetricsMap = {};
+    this.layoutMetricsMap[TYPE.SINGLE] = {
+      xMin: 0,
+      xMax: 1,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.DOUBLE] = {
+      xMin: -3,
+      xMax: 1,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.END] = {
+      xMin: -5,
+      xMax: 1,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.REPEAT_END] = {
+      xMin: -10,
+      xMax: 1,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.REPEAT_BEGIN] = {
+      xMin: -2,
+      xMax: 10,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.REPEAT_BOTH] = {
+      xMin: -10,
+      xMax: 10,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
+    this.layoutMetricsMap[TYPE.NONE] = {
+      xMin: 0,
+      xMax: 0,
+      paddingLeft: 5,
+      paddingRight: 5,
+    };
     this.setPosition(StaveModifier.Position.BEGIN);
     this.setType(type);
   }
@@ -70,6 +113,7 @@ export class Barline extends StaveModifier {
 
     this.setWidth(this.widths[this.type]);
     this.setPadding(this.paddings[this.type]);
+    this.setLayoutMetrics(this.layoutMetricsMap[this.type]);
     return this;
   }
 

--- a/src/stavemodifier.js
+++ b/src/stavemodifier.js
@@ -23,6 +23,7 @@ export class StaveModifier extends Element {
 
     this.padding = 10;
     this.position = StaveModifier.Position.ABOVE;
+    this.layoutMetrics = null;
   }
 
   getPosition() { return this.position; }
@@ -54,4 +55,10 @@ export class StaveModifier extends Element {
     return (index !== undefined && index < 2 ? 0 : this.padding);
   }
   setPadding(padding) { this.padding = padding; return this; }
+  setLayoutMetrics(layoutMetrics) {
+    this.layoutMetrics = layoutMetrics; return this;
+  }
+  getLayoutMetrics() {
+    return this.layoutMetrics;
+  }
 }

--- a/src/stavemodifier.js
+++ b/src/stavemodifier.js
@@ -56,7 +56,8 @@ export class StaveModifier extends Element {
   }
   setPadding(padding) { this.padding = padding; return this; }
   setLayoutMetrics(layoutMetrics) {
-    this.layoutMetrics = layoutMetrics; return this;
+    this.layoutMetrics = layoutMetrics; 
+    return this;
   }
   getLayoutMetrics() {
     return this.layoutMetrics;

--- a/src/stavemodifier.js
+++ b/src/stavemodifier.js
@@ -56,7 +56,7 @@ export class StaveModifier extends Element {
   }
   setPadding(padding) { this.padding = padding; return this; }
   setLayoutMetrics(layoutMetrics) {
-    this.layoutMetrics = layoutMetrics; 
+    this.layoutMetrics = layoutMetrics;
     return this;
   }
   getLayoutMetrics() {

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -14,6 +14,7 @@ VF.Test.Stave = (function() {
       runTests('Vertical Bar Test', Stave.drawVerticalBar);
       runTests('Multiple Stave Barline Test', Stave.drawMultipleMeasures);
       runTests('Multiple Stave Repeats Test', Stave.drawRepeats);
+      runTests('Stave End Modifiers Test', Stave.drawEndModifiersTest);
       runTests('Multiple Staves Volta Test', Stave.drawVoltaTest);
       runTests('Tempo Test', Stave.drawTempo);
       runTests('Single Line Configuration Test', Stave.configureSingleLine);
@@ -261,6 +262,141 @@ VF.Test.Stave = (function() {
 
       // Helper function to justify and draw a 4/4 voice
       VF.Formatter.FormatAndDraw(ctx, staveBar4, notesBar4);
+    },
+
+    drawEndModifiersTest: function(options, contextBuilder) {
+      expect(0);
+
+      var staveWidth = 230;
+      var blockHeight = 80;
+      var x = 10;
+      var y = 0;
+
+      function drawAStaves(endBarLine) {
+        function drawAStave(ctx, x, y, width, begMods, endMods) {
+          var staveBar = new VF.Stave(x, y, width - 10);
+          if (begMods) {
+            if (begMods.barLine !== undefined) {
+              staveBar.setBegBarType(begMods.barLine);
+            }
+            if (begMods.clef !== undefined) {
+              staveBar.addClef(begMods.clef);
+            }
+            if (begMods.keySig  !== undefined) {
+              staveBar.addKeySignature(begMods.keySig);
+            }
+            if (begMods.timeSig !== undefined) {
+              staveBar.setTimeSignature(begMods.timeSig);
+            }
+          }
+
+          if (endMods) {
+            if (endMods.barLine !== undefined) {
+              staveBar.setEndBarType(endMods.barLine);
+            }
+            if (endMods.clef !== undefined) {
+              staveBar.addEndClef(endMods.clef);
+            }
+            if (endMods.keySig  !== undefined) {
+              staveBar.setEndKeySignature(endMods.keySig);
+            }
+            if (endMods.timeSig !== undefined) {
+              staveBar.setEndTimeSignature(endMods.timeSig);
+            }
+          }
+
+          staveBar.setContext(ctx).draw();
+          var notesBar = [
+            new VF.StaveNote({ keys: ['c/4'], duration: 'q' }),
+            new VF.StaveNote({ keys: ['d/4'], duration: 'q' }),
+            new VF.StaveNote({ keys: ['b/4'], duration: 'qr' }),
+            new VF.StaveNote({ keys: ['c/4', 'e/4', 'g/4'], duration: 'q' }),
+          ];
+
+          VF.Formatter.FormatAndDraw(ctx, staveBar, notesBar);
+        }
+
+        drawAStave(ctx, x, y, staveWidth + 50, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+          clef: 'treble',
+          keySig: 'A',
+        },
+        {
+          barLine: endBarLine,
+          clef: 'bass',
+        });
+        x += staveWidth + 50;
+
+        drawAStave(ctx, x, y, staveWidth, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+        },
+        {
+          barLine: endBarLine,
+          keySig: 'E',
+        });
+        x += staveWidth;
+
+        drawAStave(ctx, x, y, staveWidth, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+        },
+        {
+          barLine: endBarLine,
+          timeSig: '2/4',
+        });
+        x += staveWidth;
+
+        x = 10;
+        y += blockHeight;
+
+        drawAStave(ctx, x, y, staveWidth, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+        },
+        {
+          barLine: endBarLine,
+          clef: 'bass',
+          timeSig: '2/4',
+        });
+        x += staveWidth;
+
+        drawAStave(ctx, x, y, staveWidth, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+        },
+        {
+          barLine: endBarLine,
+          clef: 'treble',
+          keySig: 'Ab',
+        });
+        x += staveWidth;
+
+        drawAStave(ctx, x, y, staveWidth, {
+          barLine: VF.Barline.type.REPEAT_BEGIN,
+        },
+        {
+          barLine: endBarLine,
+          clef: 'bass',
+          keySig: 'Ab',
+          timeSig: '2/4',
+        });
+        x += staveWidth;
+      }
+
+      var ctx = contextBuilder(options.elementId, 800, 700);
+
+      y = 0;
+      x = 10;
+      drawAStaves(VF.Barline.type.SINGLE);
+
+      y += blockHeight + 10;
+      x = 10;
+      drawAStaves(VF.Barline.type.DOUBLE);
+
+      y += blockHeight + 10;
+      x = 10;
+      drawAStaves(VF.Barline.type.REPEAT_END);
+
+      y += blockHeight + 10;
+      x = 10;
+      drawAStaves(VF.Barline.type.REPEAT_BOTH);
     },
 
     drawVoltaTest: function(options, contextBuilder) {


### PR DESCRIPTION
This PR fixes #547.

<https://jsfiddle.net/0ogxdft3/> :

![image](https://user-images.githubusercontent.com/3293067/48999454-0ff87980-f19a-11e8-824f-5462cb1c6c12.png)

npm tests:

```shell
sug1no@ubuntu ~/work/github/sug1no/vexflow (547-fix_end_repeat_barline_width-2 $=)
$ git log --oneline | head
218a85d add StaveModifier.{get, set}LayoutMetrics to define Barline metrics to fix stave end modifier layout.
3deef24 {WIP}: add Stave End Modifiers Test.
0bdefaf Merge pull request #676 from sug1no/670-fix_durationToFraction
ff3b4b8 Merge pull request #677 from sug1no/672-restore_note_colors
...
# -------------------------------------------------------------------
# diff with master and 3deef24 (Stave_End_Modifiers_Test added):

sug1no@ubuntu ~/work/github/sug1no/vexflow ((3deef24...))
$ grunt clean && git checkout master && npm start && git checkout @{-1} && npm test
Running "clean:0" (clean) task
...

Running 298 tests with threshold 0.01 (nproc=8)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.
...
You have 1 warning(s):
  Warning: Stave.Stave_End_Modifiers_Test.svg missing in ./build/images/blessed.
Success - All diffs under threshold!

# ---------------------------------------------------------------------------
# diff with 3deef24 (Stave_End_Modifiers_Test added) and 547-fix_end_repeat_barline_width-2:

sug1no@ubuntu ~/work/github/sug1no/vexflow (547-fix_end_repeat_barline_width-2 $=)
$ grunt clean && git checkout 3deef24 && npm start && git checkout @{-1} && npm test
Running "clean:0" (clean) task
>> 1 path cleaned.

Done.
Note: checking out '3deef24'.
...


Running 299 tests with threshold 0.01 (nproc=8)...
Progress : [##########################--------------] 67%
Test: StaveModifier.Begin___End_StaveModifier_Test
  PHASH value exceeds threshold: 5.317 > 0.01
  Image diff stored in ./build/images/diff/StaveModifier.Begin___End_StaveModifier_Test.png
Progress : [###############################---------] 78%
Test: Stave.Stave_End_Modifiers_Test
  PHASH value exceeds threshold: 0.291849 > 0.01
  Image diff stored in ./build/images/diff/Stave.Stave_End_Modifiers_Test.png
Progress : [######################################--] 95%
Test: TimeSignature.Basic_Time_Signatures
  PHASH value exceeds threshold: 0.0931374 > 0.01
  Image diff stored in ./build/images/diff/TimeSignature.Basic_Time_Signatures.png
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 3 fail(s):
StaveModifier.Begin___End_StaveModifier_Test 5.317
Stave.Stave_End_Modifiers_Test 0.291849
TimeSignature.Basic_Time_Signatures 0.0931374
```

![image](https://user-images.githubusercontent.com/3293067/48999008-a330af80-f198-11e8-8598-1f706c50e282.png)

- The relationship between the drawing position Barline.x and the object to be drawn is as follows. To define this, added StaveModifier.{Get, set}LayoutMetrics.{xMin, xMax, padding{Left, Right}}：

<img src="https://user-images.githubusercontent.com/3293067/48599654-fdb55900-e9ab-11e8-96dd-10fe49888f9b.png" height="300">
