### PR TITLE
svgcontext.fillText: ignore empty text to fix large bbox of StaveLine (or others with empty text)

### DIFF
--- a/src/svgcontext.js
+++ b/src/svgcontext.js
@@ -614,6 +614,9 @@ export class SVGContext {
   }
 
   fillText(text, x, y) {
+    if (!text || text.length <= 0) {
+      return;
+    }
     const attributes = {};
     Vex.Merge(attributes, this.attributes);
     attributes.stroke = 'none';


### PR DESCRIPTION
safari(12.0.1(13606.2.104.1.2)): `getBBox()` returns too large bbox with empty text element as follows:

![image](https://user-images.githubusercontent.com/3293067/49050743-264d1680-f228-11e8-930e-60fdccb8dba9.png)

To avoid this quirk, ignore empty text in svgcontext.fillText.

<http://jsfiddle.net/h84ekn3c/>

![image](https://user-images.githubusercontent.com/3293067/49046180-9a7ebe80-f216-11e8-885f-785edd4eb637.png)

npm test (with master):

```shell
sug1no@ubuntu ~/work/github/sug1no/vexflow (svgcontext_ignore_empty_text $=)
$ grunt clean && git checkout master && npm start && git checkout @{-1} && npm test
Running "clean:0" (clean) task
>> 1 path cleaned.

Done.
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
...
Running 298 tests with threshold 0.01 (nproc=8)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

Success - All diffs under threshold!
sug1no@ubuntu ~/work/github/sug1no/vexflow (svgcontext_ignore_empty_text *$%=)
```
