### PR TITLE
Fix repeat barline alignment

### DIFF
--- a/src/stave.js
+++ b/src/stave.js
@@ -76,9 +76,11 @@ export class Stave extends Element {
     if (!this.formatted) this.format();
 
     this.start_x = x;
-    const begBarline = this.modifiers[0];
-    if (begBarline.getType() === Barline.type.REPEAT_BEGIN) {
-      begBarline.setX(this.start_x - begBarline.getWidth());
+    if (this.modifiers.length > 0) {
+      const begBarline = this.modifiers[0];
+      if (begBarline.getType() === Barline.type.REPEAT_BEGIN) {
+        begBarline.setX(this.start_x - begBarline.getWidth());
+      }
     }
     return this;
   }

--- a/src/stave.js
+++ b/src/stave.js
@@ -76,6 +76,10 @@ export class Stave extends Element {
     if (!this.formatted) this.format();
 
     this.start_x = x;
+    const begBarline = this.modifiers[0];
+    if (begBarline.getType() === Barline.type.REPEAT_BEGIN) {
+      begBarline.setX(this.start_x - begBarline.getWidth());
+    }
     return this;
   }
   getNoteStartX() {

--- a/tests/factory_tests.js
+++ b/tests/factory_tests.js
@@ -56,30 +56,30 @@ Vex.Flow.Test.Factory = (function() {
         .setKeySignature('C#')
         .setBegBarType(Vex.Flow.Barline.type.REPEAT_BEGIN);
 
-      var voice = new VF.Voice(VF.Test.TIME4_4);
-
-      voice.addTickables([
-        new VF.StaveNote({ keys: ['c/4'], duration: 'w' })
-      ]);
+      var voices = [
+        vf.Voice().addTickables([
+          vf.GhostNote({ duration: 'w' })
+        ])
+      ];
 
       system.addStave({
         stave: stave,
-        voices: [voice]
+        voices: voices
       });
 
       var tabStave = vf.TabStave()
         .setClef('tab')
         .setBegBarType(Vex.Flow.Barline.type.REPEAT_BEGIN);
 
-      var tabVoice = new VF.Voice(VF.Test.TIME4_4);
-
-      tabVoice.addTickables([
-        new VF.TabNote({ positions: [{ str: 2, fret: 5 }], duration: 'w' })
-      ]);
+      var tabVoices = [
+        vf.Voice().addTickables([
+          vf.GhostNote({ duration: 'w' })
+        ])
+      ];
 
       system.addStave({
         stave: tabStave,
-        voices: [tabVoice]
+        voices: tabVoices
       });
 
       vf.draw();

--- a/tests/factory_tests.js
+++ b/tests/factory_tests.js
@@ -11,6 +11,7 @@ Vex.Flow.Test.Factory = (function() {
 
       QUnit.test('Defaults', VFT.Factory.defaults);
       VFT.runSVGTest('Draw', VFT.Factory.draw);
+      VFT.runSVGTest('Draw Tab (repeat barlines must be aligned)', VFT.Factory.drawTab);
     },
 
     defaults: function(assert) {
@@ -43,6 +44,47 @@ Vex.Flow.Test.Factory = (function() {
       vf.Stave().setClef('treble');
       vf.draw();
       expect(0);
+    },
+
+    drawTab: function(options) {
+      var vf = VF.Test.makeFactory(options, 500, 400);
+
+      var system = vf.System();
+
+      var stave = vf.Stave()
+        .setClef('treble')
+        .setKeySignature('C#')
+        .setBegBarType(Vex.Flow.Barline.type.REPEAT_BEGIN);
+
+      var voice = new VF.Voice(VF.Test.TIME4_4);
+
+      voice.addTickables([
+        new VF.StaveNote({ keys: ['c/4'], duration: 'w' })
+      ]);
+
+      system.addStave({
+        stave: stave,
+        voices: [voice]
+      });
+
+      var tabStave = vf.TabStave()
+        .setClef('tab')
+        .setBegBarType(Vex.Flow.Barline.type.REPEAT_BEGIN);
+
+      var tabVoice = new VF.Voice(VF.Test.TIME4_4);
+
+      tabVoice.addTickables([
+        new VF.TabNote({ positions: [{ str: 2, fret: 5 }], duration: 'w' })
+      ]);
+
+      system.addStave({
+        stave: tabStave,
+        voices: [tabVoice]
+      });
+
+      vf.draw();
+      equal(stave.getModifiers()[0].getX(), tabStave.getModifiers()[0].getX());
+      expect(1);
     },
   };
 


### PR DESCRIPTION
This change ensure that REPEAT_BEGIN barlines are correctly aligned in a system with multiple staves.

Before:

![before](https://user-images.githubusercontent.com/3492071/54830975-c9cfa480-4cb9-11e9-97b1-ea11c73cb36c.png)

After:

![after](https://user-images.githubusercontent.com/3492071/54830993-d5bb6680-4cb9-11e9-9761-a2902f0c2ff7.png)
