### PR TITLE
#692: apply modifier styles

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -53,6 +53,7 @@ export class Element {
     return this;
   }
 
+  // draw with style of an element.
   drawWithStyle() {
     this.checkContext();
     this.applyStyle();

--- a/src/element.js
+++ b/src/element.js
@@ -53,6 +53,13 @@ export class Element {
     return this;
   }
 
+  drawWithStyle() {
+    this.checkContext();
+    this.applyStyle();
+    this.draw();
+    this.restoreStyle();
+  }
+
   // An element can have multiple class labels.
   hasClass(className) { return (this.attrs.classes[className] === true); }
   addClass(className) {

--- a/src/factory.js
+++ b/src/factory.js
@@ -347,7 +347,7 @@ export class Factory {
     const multimeasurerest = new MultiMeasureRest(params.number_of_measures, params);
     multimeasurerest.setContext(this.context);
     this.renderQ.push(multimeasurerest);
-    return  multimeasurerest;
+    return multimeasurerest;
   }
 
   Voice(params) {

--- a/src/ghostnote.js
+++ b/src/ghostnote.js
@@ -56,7 +56,7 @@ export class GhostNote extends StemmableNote {
     for (let i = 0; i < this.modifiers.length; ++i) {
       const modifier = this.modifiers[i];
       modifier.setContext(this.context);
-      modifier.draw();
+      modifier.drawWithStyle();
     }
   }
 }

--- a/src/notesubgroup.js
+++ b/src/notesubgroup.js
@@ -89,6 +89,6 @@ export class NoteSubGroup extends Modifier {
     this.alignSubNotesWithNote(this.subNotes, note); // Modifier function
 
     // Draw notes
-    this.subNotes.forEach(subNote => subNote.setContext(this.context).draw());
+    this.subNotes.forEach(subNote => subNote.setContext(this.context).drawWithStyle());
   }
 }

--- a/src/stave.js
+++ b/src/stave.js
@@ -558,7 +558,9 @@ export class Stave extends Element {
     for (let i = 0; i < this.modifiers.length; i++) {
       // Only draw modifier if it has a draw function
       if (typeof this.modifiers[i].draw === 'function') {
+        this.modifiers[i].applyStyle(this.context);
         this.modifiers[i].draw(this, this.getModifierXShift(i));
+        this.modifiers[i].restoreStyle(this.context);
       }
     }
 

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1042,7 +1042,7 @@ export class StaveNote extends StemmableNote {
       const noteheadStyle = notehead.getStyle();
       notehead.applyStyle(ctx, noteheadStyle);
       modifier.setContext(ctx);
-      modifier.draw();
+      modifier.drawWithStyle();
       notehead.restoreStyle(ctx, noteheadStyle);
     }
     ctx.closeGroup();

--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -386,7 +386,7 @@ export class TabNote extends StemmableNote {
       if (modifier.getCategory() === 'dots' && !this.render_options.draw_dots) return;
 
       modifier.setContext(this.context);
-      modifier.draw();
+      modifier.drawWithStyle();
     });
   }
 

--- a/src/voice.js
+++ b/src/voice.js
@@ -235,7 +235,7 @@ export class Voice extends Element {
       }
 
       tickable.setContext(context);
-      tickable.draw();
+      tickable.drawWithStyle();
     }
 
     this.boundingBox = boundingBox;

--- a/tests/run.js
+++ b/tests/run.js
@@ -51,6 +51,7 @@ VF.Test.run = function() {
   VF.Test.TextBracket.Start();
   VF.Test.StaveModifier.Start();
   VF.Test.GhostNote.Start();
+  VF.Test.Style.Start();
   VF.Test.Factory.Start();
   VF.Test.Parser.Start();
   VF.Test.EasyScore.Start();

--- a/tests/style_tests.js
+++ b/tests/style_tests.js
@@ -1,0 +1,107 @@
+/**
+ * VexFlow - Style Tests
+ * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
+ */
+
+VF.Test.Style = (function() {
+  var runTests = VF.Test.runTests;
+  function FS(fill, stroke) {
+    var ret = { fillStyle: fill };
+    if (stroke) {
+      ret.strokeStyle = stroke;
+    }
+    return ret;
+  }
+
+  var Style = {
+    Start: function() {
+      QUnit.module('Style');
+      runTests('Basic Style', Style.stave);
+      runTests('TabNote modifiers Style', Style.tab);
+    },
+
+    stave: function(options) {
+      var vf = VF.Test.makeFactory(options, 600, 150);
+      var stave = vf.Stave({ x: 25, y: 20, width: 500 });
+
+      // Stave modifiers test.
+      var keySig = new VF.KeySignature('D');
+      keySig.addToStave(stave);
+      keySig.setStyle(FS('blue'));
+      stave.addTimeSignature('4/4');
+      var timeSig = stave.getModifiers(VF.StaveModifier.Position.BEGIN, VF.TimeSignature.CATEGORY);
+      timeSig[0].setStyle(FS('brown'));
+
+      var notes = [
+        vf.StaveNote({ keys: ['c/4', 'e/4', 'a/4'], stem_direction: 1, duration: '4' })
+          .addAccidental(0, vf.Accidental({ type: 'b' }))
+          .addAccidental(1, vf.Accidental({ type: '#' })),
+        vf.StaveNote({ keys: ['c/4', 'e/4', 'a/4'], stem_direction: 1, duration: '4' })
+          .addAccidental(0, vf.Accidental({ type: 'b' }))
+          .addAccidental(1, vf.Accidental({ type: '#' })),
+        vf.StaveNote({ keys: ['e/4'], stem_direction: 1, duration: '4' }),
+        vf.StaveNote({ keys: ['f/4'], stem_direction: 1, duration: '8' }),
+
+        // voice.draw() test.
+        vf.TextDynamics({ text: 'sfz', duration: '16' }).setStyle(FS('blue')),
+
+        // GhostNote modifiers test.
+        vf.GhostNote({ duration: '16' }).addModifier(new VF.Annotation('GhostNote green text').setStyle(FS('green'))),
+      ];
+
+      notes[0].setKeyStyle(0, FS('red'));
+      notes[1].setKeyStyle(0, FS('red'));
+
+      // StaveNote modifiers test.
+      var mods1 = notes[1].getModifiers();
+      mods1[0].setStyle(FS('green'));
+      notes[0].addArticulation(0, new VF.Articulation('a.').setPosition(4).setStyle(FS('green')));
+      notes[0].addModifier(0, new VF.Ornament('mordent').setStyle(FS('lightgreen')));
+
+      notes[1].addModifier(0, new VF.Annotation('blue').setStyle(FS('blue')));
+      notes[1].addModifier(0,
+        new VF.NoteSubGroup([vf.ClefNote({ options: { size: 'small' } }).setStyle(FS('blue'))]));
+
+      var voice = vf.Voice().addTickables(notes);
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+      ok(true, 'Basic Style');
+    },
+
+    tab: function(options, contextBuilder) {
+      var ctx = contextBuilder(options.elementId, 500, 140);
+      ctx.fillStyle = '#221'; ctx.strokeStyle = '#221';
+      ctx.font = ' 10pt Arial';
+      var stave = new VF.TabStave(10, 10, 450)
+        .addTabGlyph();
+      stave.getModifiers()[2].setStyle(FS('blue'));
+      stave.setContext(ctx).draw();
+
+      function newNote(tab_struct) { return new VF.TabNote(tab_struct); }
+      function newBend(text) { return new VF.Bend(text); }
+      function newAnnotation(text) { return new VF.Annotation(text); }
+
+      // TabNote modifiers test.
+      var notes = [
+        newNote({
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h',
+        })
+          .addModifier(newAnnotation('green text').setStyle(FS('green')), 0),
+        newNote({
+          positions: [{ str: 2, fret: 10 }, { str: 4, fret: 9 }], duration: 'h',
+        })
+          .addModifier(newBend('Full').setStyle(FS('brown')), 0)
+          .addStroke(0, new VF.Stroke(1, { all_voices: false }).setStyle(FS('blue'))),
+      ];
+
+      VF.Formatter.FormatAndDraw(ctx, stave, notes, 200);
+      ok(true, 'TabNote modifiers Style');
+    },
+  };
+
+  return Style;
+})();


### PR DESCRIPTION
This PR fixes #692.


```shell

(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (692-apply-modifier-styles $=)
$ git log --oneline
f745604 {WIP}: add Element.drawWithStyle() to apply styles on draw {modifiers, tickables, subNotes}.
78ed810 {WIP}: add style_tests.js.
8a4b0c8 {WIP}: fix space.
0793189 Committing release binaries for new version: 1.2.88
29b550b Release v1.2.88
4040ea2 Merge pull request #690 from sschmidTU/master
...
###############################################
# diff: {master} and {78ed810 {WIP}: add style_tests.js.}
###############################################
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow ((78ed810...) *$%)
$ git checkout master && npm start && git checkout @{-1} && npm test
Previous HEAD position was 78ed810... {WIP}: add style_tests.js.
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
...
Running 299 tests with threshold 0.01 (nproc=8)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 2 warning(s):
  Warning: Style.Basic_Style.svg missing in ./build/images/blessed.
  Warning: Style.TabNote_modifiers_Style.svg missing in ./build/images/blessed.
Success - All diffs under threshold!

###############################################
# diff {78ed810 {WIP}: add style_tests.js.} and {f745604 {WIP}: add Element.drawWithStyle() to apply styles on draw {modifiers, tickables, subNotes}.}
###############################################
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (692-apply-modifier-styles $=)
$ git checkout 78ed810021faaffd738b49a0822159f2de7e360a && npm start && git checkout @{-1} && npm test
Note: checking out '78ed810021faaffd738b49a0822159f2de7e360a'.

...

> vexflow@1.2.88 diff /home/sug1no/work/github/sug1no/vexflow
> ./tools/visual_regression.sh

Running 301 tests with threshold 0.01 (nproc=8)...
Progress : [#################################-------] 84%
Test: Style.TabNote_modifiers_Style
  PHASH value exceeds threshold: 2984.52 > 0.01
  Image diff stored in ./build/images/diff/Style.TabNote_modifiers_Style.png
Progress : [##################################------] 85%
Test: Style.Basic_Style
  PHASH value exceeds threshold: 1376.42 > 0.01
  Image diff stored in ./build/images/diff/Style.Basic_Style.png
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 2 fail(s):
Style.TabNote_modifiers_Style 2984.52
Style.Basic_Style 1376.42

```
![image](https://user-images.githubusercontent.com/3293067/54017155-7abd4600-41c8-11e9-82ed-c654d94abe65.png)
