### PR TITLE
699 fix tuplet number glyph order

### DIFF
--- a/src/tuplet.js
+++ b/src/tuplet.js
@@ -195,14 +195,14 @@ export class Tuplet extends Element {
     this.num_glyphs = [];
     let n = this.num_notes;
     while (n >= 1) {
-      this.num_glyphs.push(new Glyph('v' + (n % 10), this.point));
+      this.num_glyphs.unshift(new Glyph('v' + (n % 10), this.point));
       n = parseInt(n / 10, 10);
     }
 
     this.denom_glyphs = [];
     n = this.notes_occupied;
     while (n >= 1) {
-      this.denom_glyphs.push(new Glyph('v' + (n % 10), this.point));
+      this.denom_glyphs.unshift(new Glyph('v' + (n % 10), this.point));
       n = parseInt(n / 10, 10);
     }
   }

--- a/src/tuplet.js
+++ b/src/tuplet.js
@@ -192,10 +192,10 @@ export class Tuplet extends Element {
   }
 
   resolveGlyphs() {
-    this.num_glyphs = [];
+    this.numerator_glyphs = [];
     let n = this.num_notes;
     while (n >= 1) {
-      this.num_glyphs.unshift(new Glyph('v' + (n % 10), this.point));
+      this.numerator_glyphs.unshift(new Glyph('v' + (n % 10), this.point));
       n = parseInt(n / 10, 10);
     }
 
@@ -298,7 +298,7 @@ export class Tuplet extends Element {
     const addGlyphWidth = (width, glyph) => width + glyph.getMetrics().width;
 
     // calculate total width of tuplet notation
-    let width = this.num_glyphs.reduce(addGlyphWidth, 0);
+    let width = this.numerator_glyphs.reduce(addGlyphWidth, 0);
     if (this.ratioed) {
       width = this.denom_glyphs.reduce(addGlyphWidth, width);
       width += this.point * 0.32;
@@ -337,7 +337,7 @@ export class Tuplet extends Element {
 
     // draw numerator glyphs
     let x_offset = 0;
-    this.num_glyphs.forEach(glyph => {
+    this.numerator_glyphs.forEach(glyph => {
       glyph.render(this.context, notation_start_x + x_offset, this.y_pos + (this.point / 3) - 2);
       x_offset += glyph.getMetrics().width;
     });

--- a/tests/tuplet_tests.js
+++ b/tests/tuplet_tests.js
@@ -236,7 +236,7 @@ VF.Test.Tuplet = (function() {
     },
 
     awkward: function(options) {
-      var vf = VF.Test.makeFactory(options, 350, 160);
+      var vf = VF.Test.makeFactory(options, 370, 160);
       var stave = vf.Stave({ x: 10, y: 10 });
 
       var notes = [
@@ -251,14 +251,15 @@ VF.Test.Tuplet = (function() {
         { keys: ['g/4'], duration: '16' },
         { keys: ['a/4'], duration: '16' },
         { keys: ['f/4'], duration: '16' },
+        { keys: ['e/4'], duration: '16' },
         { keys: ['c/4'], duration: '8' },
         { keys: ['d/4'], duration: '8' },
         { keys: ['e/4'], duration: '8' },
       ].map(stemUp).map(vf.StaveNote.bind(vf));
 
-      vf.Beam({ notes: notes.slice(0, 11) });
+      vf.Beam({ notes: notes.slice(0, 12) });
       vf.Tuplet({
-        notes: notes.slice(0, 11),
+        notes: notes.slice(0, 12),
         options: {
           notes_occupied: 142,
           ratioed: true,
@@ -266,7 +267,7 @@ VF.Test.Tuplet = (function() {
       });
 
       vf.Tuplet({
-        notes: notes.slice(11, 14),
+        notes: notes.slice(12, 15),
         options: {
           ratioed: true,
         },


### PR DESCRIPTION
fix #699:

```shell
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (699-fix-tuplet-number-glyph-order $)
$ git log --oneline
00d5c75 Tuplet: rename num_glyphs to numerator_glyphs.
56476c7 Tuplet: fix order of the glyphs.
d58cfce Tuplet.awkward: changed number of notes from 11 to 12.
b6a3748 Merge pull request #688 from mvolganli/fix-repeat-barline-alignment
...

(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (699-fix-tuplet-number-glyph-order $)
$ git checkout master && npm start && git checkout @{-1} && npm test
...
> vexflow@1.2.89 diff /home/sug1no/work/github/sug1no/vexflow
> ./tools/visual_regression.sh

Running 303 tests with threshold 0.01 (nproc=8)...
Progress : [######################################--] 96%
Test: Tuplet.Awkward_Tuplet
  PHASH value exceeds threshold: 3.43239 > 0.01
  Image diff stored in ./build/images/diff/Tuplet.Awkward_Tuplet.png
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 1 fail(s):
Tuplet.Awkward_Tuplet 3.43239
```
![image](https://user-images.githubusercontent.com/3293067/56551525-8d96a900-65c3-11e9-83ab-94a0ab21f6fc.png)


00d5c75 is ready for review.