### PR TITLE
Fix beam.js partial beam rendering bug,

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -687,7 +687,11 @@ export class Beam extends Element {
 
       // Check to see if the next note in the group will get a beam at this
       //  level. This will help to inform the partial beam logic below.
+      const prev_note = this.notes[i - 1];
       const next_note = this.notes[i + 1];
+      const beam_prev_above = (
+        prev_note && (prev_note.getIntrinsicTicks() / Flow.durationToTicks(duration)) < 2
+      );
       const beam_next = next_note && next_note.getIntrinsicTicks() < Flow.durationToTicks(duration);
       if (note_gets_beam) {
         // This note gets a beam at the current level
@@ -712,7 +716,7 @@ export class Beam extends Element {
           beam_started = true;
           if (!beam_next) {
             // The next note doesn't get a beam. Draw a partial.
-            if ((previous_should_break || i === 0) && next_note) {
+            if ((previous_should_break || i === 0 || !beam_prev_above) && next_note) {
               // This is the first note (but not the last one), or it is
               //  following a secondary break. Draw a partial to the right.
               current_beam.end = current_beam.start + partial_beam_length;

--- a/tests/beam_tests.js
+++ b/tests/beam_tests.js
@@ -30,6 +30,7 @@ VF.Test.Beam = (function() {
       runTests('Mixed Beam 1', Beam.mixed);
       runTests('Mixed Beam 2', Beam.mixed2);
       runTests('Dotted Beam', Beam.dotted);
+      runTests('Partial Beam', Beam.partial);
       runTests('Close Trade-offs Beam', Beam.tradeoffs);
       runTests('Insane Beam', Beam.insane);
       runTests('Lengthy Beam', Beam.lenghty);
@@ -307,6 +308,29 @@ VF.Test.Beam = (function() {
       vf.draw();
 
       ok(true, 'Dotted Test');
+    },
+
+    partial: function(options) {
+      var vf = VF.Test.makeFactory(options);
+      var stave = vf.Stave();
+      var score = vf.EasyScore();
+
+      var voice = score.voice(score.notes(
+        'd4/8, b3/32, c4/16., d4/16., e4/8, c4/64, c4/32, a3/8., b3/32., c4/8, e4/64, b3/16., b3/64'
+      ), { time: '4/4' });
+
+      var notes = voice.getTickables();
+      vf.Beam({ notes: notes.slice(0, 3) });
+      vf.Beam({ notes: notes.slice(3, 9) });
+      vf.Beam({ notes: notes.slice(9, 13) });
+
+      vf.Formatter()
+        .joinVoices([voice])
+        .formatToStave([voice], stave);
+
+      vf.draw();
+
+      ok(true, 'Partial Test');
     },
 
     tradeoffs: function(options) {


### PR DESCRIPTION
Fix to render properly on the case, [8th - 32nd - 16th] beam(32nd partial beam is rendered incorrectly).
Add a partial beam test case.
——
I added a new test case for verifying this, and all existing test cases are passed.

Previous:
![IMG_0151](https://user-images.githubusercontent.com/2025065/56719237-4d7a2680-677b-11e9-90f2-c44d1a57fc2b.jpeg)

Current:
![IMG_0152](https://user-images.githubusercontent.com/2025065/56719244-52d77100-677b-11e9-9122-9625571c6a18.jpeg)

Thanks!