### PR TITLE
Fix dotted-beamed-displaced chord note rendering bug,

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -362,6 +362,12 @@ export class StaveNote extends StemmableNote {
     this.calcExtraPx();
   }
 
+  setBeam(beam) {
+    this.beam = beam;
+    this.calcExtraPx();
+    return this;
+  }
+
   getCategory() { return StaveNote.CATEGORY; }
 
   // Builds a `Stem` for the note

--- a/tests/dot_tests.js
+++ b/tests/dot_tests.js
@@ -83,7 +83,13 @@ VF.Test.Dot = (function() {
           .addDotToAll(),
         new VF.StaveNote({ keys: ['e/4', 'g/4', 'a/4', 'b/4', 'c/5', 'e/5', 'f/5'], duration: '16', stem_direction: 1 })
           .addDotToAll(),
+        new VF.StaveNote({ keys: ['e/4', 'g/4', 'a/4', 'b/4', 'c/5'], duration: '16', stem_direction: 1 })
+          .addDotToAll(),
+        new VF.StaveNote({ keys: ['e/4', 'a/4', 'b/4', 'c/5'], duration: '16', stem_direction: 1 })
+          .addDotToAll(),
       ];
+
+      var beam = new VF.Beam(notes.slice(notes.length - 2));
 
       for (var i = 0; i < notes.length; i++) {
         showNote(notes[i], stave, ctx, 30 + (i * 65));
@@ -95,7 +101,9 @@ VF.Test.Dot = (function() {
         }
       }
 
-      VF.Test.plotLegendForNoteWidth(ctx, 770, 140);
+      beam.setContext(ctx).draw();
+
+      VF.Test.plotLegendForNoteWidth(ctx, 890, 140);
 
       ok(true, 'Full Dot');
     },


### PR DESCRIPTION
Dots are rendered incorrectly on the specific condition below:
=> Displaced (ex. c/4 + d/4 in treble clef) chord note has dot and "beam".

Update StaveNote setBeam function to re-calculate extra px to ignore flag and consider beam properly

I simply updated Dot.Basic test case to also consider beamed chord note case.

Before
![IMG_0160](https://user-images.githubusercontent.com/2025065/57146086-1c42cb80-6df7-11e9-8528-d598522a68cc.jpeg)

Current
![IMG_0161](https://user-images.githubusercontent.com/2025065/57146097-21077f80-6df7-11e9-9b01-a303f3de083d.jpeg)

Thanks!