### PR TITLE
689: fix accidental staff line placement

### DIFF
--- a/tests/keysignature_tests.js
+++ b/tests/keysignature_tests.js
@@ -56,6 +56,7 @@ VF.Test.KeySignature = (function() {
       VF.Test.runTests('Minor Key Test', VF.Test.KeySignature.minorKeys);
       VF.Test.runTests('Stave Helper', VF.Test.KeySignature.staveHelper);
       VF.Test.runTests('Cancelled key test', VF.Test.KeySignature.majorKeysCanceled);
+      VF.Test.runTests('Cancelled key (for each clef) test', VF.Test.KeySignature.keysCanceledForEachClef);
       VF.Test.runTests('Altered key test', VF.Test.KeySignature.majorKeysAltered);
       VF.Test.runTests('End key with clef test', VF.Test.KeySignature.endKeyWithClef);
       VF.Test.runTests('Key Signature Change test', VF.Test.KeySignature.changeKey);
@@ -162,6 +163,35 @@ VF.Test.KeySignature = (function() {
       stave3.draw();
       stave4.setContext(ctx);
       stave4.draw();
+
+      ok(true, 'all pass');
+    },
+
+    keysCanceledForEachClef: function(options, contextBuilder) {
+      var ctx = new contextBuilder(options.elementId, 600, 380);
+      ctx.scale(0.8, 0.8);
+      var keys = [
+        'C#',
+        'Cb'
+      ];
+
+      var x = 20;
+      var y = 20;
+      var tx = x;
+      ['bass', 'tenor', 'soprano', 'mezzo-soprano', 'baritone-f'].forEach(function(clef) {
+        keys.forEach(function(key) {
+          var cancelKey = key === keys[0] ? keys[1] : keys[0];
+          var vStave = new Vex.Flow.Stave(tx, y, 350);
+          vStave.setClef(clef);
+          vStave.addKeySignature(cancelKey);
+          vStave.addKeySignature(key, cancelKey);
+          vStave.addKeySignature(key);
+          vStave.setContext(ctx).draw();
+          tx += 350;
+        });
+        tx = x;
+        y += 80;
+      });
 
       ok(true, 'all pass');
     },


### PR DESCRIPTION
This PR fixes #689. Several clefs defining 'customLines' had been the subject of this problem. Apply the accidental staff line placement to cancelKey and key separately to solve the problem:

https://github.com/0xfe/vexflow/blob/3920d50c95ec0e1a8d4bc96387e9ea2a1735319e/src/keysignature.js#L180

```shell
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (689-fix-cancel-keysig-2 *$%)
$ git log --oneline 
a4e5933 fix lines of accidencals to cancel.
8405983 *{WIP}: add VF.Test.KeySignature.keysCanceledForEachClef.
d5759da Merge pull request #703 from panarch/master
3920d50 Fix dotted-beamed-displaced chord note rendering bug,
...
---
# master...8405983
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow ((8405983...) $)
$ git checkout master && npm start && git checkout @{-1} && npm test
...

You have 1 warning(s):
  Warning: KeySignature.Cancelled_key__for_each_clef__test.png missing in ./build/images/blessed.
Success - All diffs under threshold!

# OK: new test KeySignature.Cancelled_key__for_each_clef__test.png.
---

# 8405983...a4e5933
(base) sug1no@ubuntu ~/work/github/sug1no/vexflow (689-fix-cancel-keysig-2 *$%)
$ grunt clean && git checkout 8405983 && npm start && git checkout @{-1} && npm test

...
You have 1 fail(s):
KeySignature.Cancelled_key__for_each_clef__test 2.27381

# OK: pls refer to the followings:
```

https://github.com/sug1no/vexflow/commit/8405983bc804ba3729e105cef03571121f5874e1#diff-b8e1c5d715c3c0eb833dc191eaf62f9aR185
```js
vStave.setClef(clef);
vStave.addKeySignature(cancelKey);
vStave.addKeySignature(key, cancelKey);
vStave.addKeySignature(key);
vStave.setContext(ctx).draw();
```

![image](https://user-images.githubusercontent.com/3293067/59089895-3451c180-8946-11e9-959e-dfdaa00c4ba4.png)

a4e5933 is ready for review.