### PR TITLE
Fix beam direction in partial beam cases

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -35,6 +35,10 @@ const getStemSlope = (firstNote, lastNote) => {
   return (lastStemTipY - firstStemTipY) / (lastStemX - firstStemX);
 };
 
+const BEAM_LEFT = 'L';
+const BEAM_RIGHT = 'R';
+const BEAM_BOTH = 'B';
+
 export class Beam extends Element {
   // Gets the default beam groups for a provided time signature.
   // Attempts to guess if the time signature is not found in table.
@@ -652,10 +656,10 @@ export class Beam extends Element {
     }
   }
 
-  // return upper level beam direction. L for Left, R for Right, B for Both
+  // return upper level beam direction.
   lookupBeamDirection(duration, prev_tick, tick, next_tick) {
     if (duration === '4') {
-      return 'L';
+      return BEAM_LEFT;
     }
 
     const lookup_duration =  `${Flow.durationToNumber(duration) / 2}`;
@@ -664,11 +668,11 @@ export class Beam extends Element {
     const note_gets_beam = tick < Flow.durationToTicks(lookup_duration);
 
     if (prev_note_gets_beam && next_note_gets_beam && note_gets_beam) {
-      return 'B';
+      return BEAM_BOTH;
     } else if (prev_note_gets_beam && !next_note_gets_beam && note_gets_beam) {
-      return 'L';
+      return BEAM_LEFT;
     } else if (!prev_note_gets_beam && next_note_gets_beam && note_gets_beam) {
-      return 'R';
+      return BEAM_RIGHT;
     }
 
     return this.lookupBeamDirection(lookup_duration, prev_tick, tick, next_tick);
@@ -746,7 +750,7 @@ export class Beam extends Element {
             const tick = note.getIntrinsicTicks();
             const beam_direction = this.lookupBeamDirection(duration, prev_tick, tick, next_tick);
 
-            if (['L', 'B'].includes(beam_direction)) {
+            if ([BEAM_LEFT, BEAM_BOTH].includes(beam_direction)) {
               current_beam.end = current_beam.start - partial_beam_length;
             } else {
               current_beam.end = current_beam.start + partial_beam_length;

--- a/src/beam.js
+++ b/src/beam.js
@@ -652,8 +652,31 @@ export class Beam extends Element {
     }
   }
 
+  // return upper level beam direction. L for Left, R for Right, B for Both
+  lookupBeamDirection(duration, prev_tick, tick, next_tick) {
+    if (duration === '4') {
+      return 'L';
+    }
+
+    const lookup_duration =  `${Flow.durationToNumber(duration) / 2}`;
+    const prev_note_gets_beam = prev_tick < Flow.durationToTicks(lookup_duration);
+    const next_note_gets_beam = next_tick < Flow.durationToTicks(lookup_duration);
+    const note_gets_beam = tick < Flow.durationToTicks(lookup_duration);
+
+    if (prev_note_gets_beam && next_note_gets_beam && note_gets_beam) {
+      return 'B';
+    } else if (prev_note_gets_beam && !next_note_gets_beam && note_gets_beam) {
+      return 'L';
+    } else if (!prev_note_gets_beam && next_note_gets_beam && note_gets_beam) {
+      return 'R';
+    }
+
+    return this.lookupBeamDirection(lookup_duration, prev_tick, tick, next_tick);
+  }
+
   // Get the x coordinates for the beam lines of specific `duration`
   getBeamLines(duration) {
+    const tick_of_duration = Flow.durationToTicks(duration);
     const beam_lines = [];
     let beam_started = false;
     let current_beam = null;
@@ -681,7 +704,7 @@ export class Beam extends Element {
           should_break = true;
         }
       }
-      const note_gets_beam = note.getIntrinsicTicks() < Flow.durationToTicks(duration);
+      const note_gets_beam = note.getIntrinsicTicks() < tick_of_duration;
 
       const stem_x = note.getStemX() - (Stem.WIDTH / 2);
 
@@ -689,10 +712,11 @@ export class Beam extends Element {
       //  level. This will help to inform the partial beam logic below.
       const prev_note = this.notes[i - 1];
       const next_note = this.notes[i + 1];
-      const beam_prev_above = (
-        prev_note && (prev_note.getIntrinsicTicks() / Flow.durationToTicks(duration)) < 2
-      );
-      const beam_next = next_note && next_note.getIntrinsicTicks() < Flow.durationToTicks(duration);
+      const next_note_gets_beam = next_note && next_note.getIntrinsicTicks() < tick_of_duration;
+      const prev_note_gets_beam = prev_note && prev_note.getIntrinsicTicks() < tick_of_duration;
+      const beam_alone = prev_note && next_note &&
+      note_gets_beam && !prev_note_gets_beam && !next_note_gets_beam;
+      // const beam_alone = note_gets_beam && !prev_note_gets_beam && !next_note_gets_beam;
       if (note_gets_beam) {
         // This note gets a beam at the current level
         if (beam_started) {
@@ -704,7 +728,7 @@ export class Beam extends Element {
           // If a secondary beam break is set up, end the beam right now.
           if (should_break) {
             beam_started = false;
-            if (next_note && !beam_next && current_beam.end === null) {
+            if (next_note && !next_note_gets_beam && current_beam.end === null) {
               // This note gets a beam,.but the next one does not. This means
               //  we need a partial pointing right.
               current_beam.end = current_beam.start - partial_beam_length;
@@ -714,9 +738,22 @@ export class Beam extends Element {
           // No beam started yet. Start a new one.
           current_beam = { start: stem_x, end: null };
           beam_started = true;
-          if (!beam_next) {
+
+          if (beam_alone) {
+            // previous and next beam exists and does not get a beam but current gets it.
+            const prev_tick = prev_note.getIntrinsicTicks();
+            const next_tick = next_note.getIntrinsicTicks();
+            const tick = note.getIntrinsicTicks();
+            const beam_direction = this.lookupBeamDirection(duration, prev_tick, tick, next_tick);
+
+            if (['L', 'B'].includes(beam_direction)) {
+              current_beam.end = current_beam.start - partial_beam_length;
+            } else {
+              current_beam.end = current_beam.start + partial_beam_length;
+            }
+          } else if (!next_note_gets_beam) {
             // The next note doesn't get a beam. Draw a partial.
-            if ((previous_should_break || i === 0 || !beam_prev_above) && next_note) {
+            if ((previous_should_break || i === 0) && next_note) {
               // This is the first note (but not the last one), or it is
               //  following a secondary break. Draw a partial to the right.
               current_beam.end = current_beam.start + partial_beam_length;

--- a/tests/beam_tests.js
+++ b/tests/beam_tests.js
@@ -316,13 +316,14 @@ VF.Test.Beam = (function() {
       var score = vf.EasyScore();
 
       var voice = score.voice(score.notes(
-        'd4/8, b3/32, c4/16., d4/16., e4/8, c4/64, c4/32, a3/8., b3/32., c4/8, e4/64, b3/16., b3/64'
-      ), { time: '4/4' });
+        'd4/8, b3/32, c4/16., d4/16., e4/8, c4/64, c4/32, a3/8., b3/32., c4/8, e4/64, b3/16., b3/64, f4/8, e4/8, g4/64, e4/8'
+      ), { time: '89/64' });
 
       var notes = voice.getTickables();
       vf.Beam({ notes: notes.slice(0, 3) });
       vf.Beam({ notes: notes.slice(3, 9) });
       vf.Beam({ notes: notes.slice(9, 13) });
+      vf.Beam({ notes: notes.slice(13, 17) });
 
       vf.Formatter()
         .joinVoices([voice])


### PR DESCRIPTION
Hi, I am GeunYeong Cheon and I found that beam direction is slightly different as I thought in specific partial beam case. I added one test case in `partial_beam` test.

To get a correct beam direction, looking up the upper level beam lines'
direction is needed. Therefore, I made lookupBeamDirection to check
direction.

I tested using `npm test` with `release version` and `build version` - build version includes my modification -.  Also after running `npm test` and it shows that all test cases are passed except the one that I added.

Before
![Beam Partial_Beam_Blessed](https://user-images.githubusercontent.com/34280965/59652988-2b28e600-91cb-11e9-984d-979ed8192fea.png)

Current
![Beam Partial_Beam_Current](https://user-images.githubusercontent.com/34280965/59652992-2f550380-91cb-11e9-9e22-e14b8d292d15.png)

Difference
![Beam Partial_Beam](https://user-images.githubusercontent.com/34280965/59653193-ee112380-91cb-11e9-97fa-0038611d4495.png)


Thanks!