### PR TITLE
is#720 Move npm from package.json dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "qunit": "^2.8.0",
     "raphael": "^2.2.7",
     "webpack": "^4.28.3",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.1.14",
+    "npm": "^6.5.0"
   },
   "scripts": {
     "start": "grunt stage",
@@ -66,8 +67,5 @@
     "notation",
     "guitar",
     "tablature"
-  ],
-  "dependencies": {
-    "npm": "^6.5.0"
-  }
+  ]
 }


### PR DESCRIPTION
This implements solution 2 from #720 

This change was made because the npm version used by vexflow (^6.5.0) has a security vulnerability.
npm ^6.50 relies on an old version of a package called 'https-proxy-agent'.
When a user adds vexflow to his project (npm install vexflow), he'll get a message that his project has 21 security vulnerabilities.

This change aims to fix those vulnerabilities by moving npm to devDependencies, which are not downloaded during `npm install vexflow`