### PR TITLE
Feature: Allow getting all staff modifiers by category, without position

### DIFF
--- a/src/stave.js
+++ b/src/stave.js
@@ -337,9 +337,6 @@ export class Stave extends Element {
       clefs[0].setType(clefSpec, size, annotation);
     }
 
-    const keySignatures = this.getModifiers(position, KeySignature.CATEGORY);
-    keySignatures.forEach(key => key.format())
-
     return this;
   }
 

--- a/src/stave.js
+++ b/src/stave.js
@@ -337,6 +337,9 @@ export class Stave extends Element {
       clefs[0].setType(clefSpec, size, annotation);
     }
 
+    const keySignatures = this.getModifiers(position, KeySignature.CATEGORY);
+    keySignatures.forEach(key => key.format())
+
     return this;
   }
 
@@ -427,10 +430,10 @@ export class Stave extends Element {
   }
 
   getModifiers(position, category) {
-    if (position === undefined) return this.modifiers;
+    if (position === undefined && category === undefined) return this.modifiers;
 
     return this.modifiers.filter(modifier =>
-      position === modifier.getPosition() &&
+      (position === undefined || position === modifier.getPosition()) &&
       (category === undefined || category === modifier.getCategory())
     );
   }


### PR DESCRIPTION
currently, if you want to getModifiers by category, you HAVE to have a position. This seems silly. 