### PR TITLE
Add `!` to Banner comment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = (grunt) => {
   const BANNER = [
-    '/**',
+    '/**!',
     ' * VexFlow <%= pkg.version %> built on <%= grunt.template.today("yyyy-mm-dd") %>.',
     ' * Copyright (c) 2010 Mohit Muthanna Cheppudira <mohit@muthanna.com>',
     ' *',


### PR DESCRIPTION
Many code minimizers will retain comments that begin with `/**!` or `/*!` so if the code goes through a minimizer (even a minimizer of a minimizer) this will help others keep their license obligations.