### PR TITLE
refactor visual_regression script: warn if no pngs found,…

### DIFF
--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -72,7 +72,7 @@ totalCurrentImages=`ls -1 $CURRENT/$files | wc -l | xargs` # xargs trims spaces
 if [ $? -ne 0 ] || [ "$totalCurrentImages" -lt 1 ]
 then
   echo Missing images in $CURRENT.
-  echo Please run "npm run generate:current"
+  echo Please run \"npm run generate:current\"
   exit 1
 fi
 
@@ -80,7 +80,7 @@ totalBlessedImages=`ls -1 $BLESSED/$files | wc -l | xargs`
 if [ $? -ne 0 ] || [ "$totalBlessedImages" -lt 1 ]
 then
   echo Missing images in $BLESSED.
-  echo Please run "npm run generate:blessed"
+  echo Please run \"npm run generate:blessed\"
   exit 1
 fi
 # check that #currentImages == #blessedImages (will continue anyways)

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -61,7 +61,6 @@ fi
 
 
 ## Sanity checks: some simple checks that the script can run correctly (doesn't validate pngs)
-
 if [ "`basename $PWD`" == "tools" ]
 then
   echo Please run this script from the VexFlow base directory.
@@ -69,40 +68,19 @@ then
 fi
 
 # Check if some png files are in the right folders and warn if not. doesn't make sure there are actual, usable png images though.
-folderWarningStringMsg="Exiting without running visual regression tests."
-# check if current directory exists / started from base OSMD folder
-if [ ! -e "$CURRENT" ]
+totalCurrentImages=`ls -1 $CURRENT/$files | wc -l | xargs` # xargs trims spaces
+if [ $? -ne 0 ] || [ "$totalCurrentImages" -lt 1 ]
 then
-  echo "Warning: directory $CURRENT missing.
-    Please run npm run generate:current (and if necessary npm run generate:blessed) first.
-    $folderWarningStringMsg"
+  echo Missing images in $CURRENT.
+  echo Please run "npm run generate:current"
   exit 1
 fi
-# check if blessed directory exists / started from base OSMD folder
-if [ ! -e "$BLESSED" ]
+
+totalBlessedImages=`ls -1 $BLESSED/$files | wc -l | xargs`
+if [ $? -ne 0 ] || [ "$totalBlessedImages" -lt 1 ]
 then
-  echo "Warning: directory $BLESSED missing.
-    Please run npm run generate:blessed first (or otherwise get the blessed images).
-    $folderWarningStringMsg"
-  exit 1
-fi
-# note: ls returns errors if the directory doesn't exist (that's why we do the checks above)
-totalCurrentImages=`ls -l $CURRENT/$files | wc -l | sed 's/[[:space:]]//g'`
-totalBlessedImages=`ls -l $BLESSED/$files | wc -l | sed 's/[[:space:]]//g'`
-# check if there are some current images
-if [ "$totalCurrentImages" -lt 1 ]
-then
-  echo "Warning: Found no (matching) pngs in $CURRENT.
-    Please run npm run generate (and if necessary npm run blessed) first.
-    $folderWarningStringMsg"
-  exit 1
-fi
-# check if there are some blessed images
-if [ "$totalBlessedImages" -lt 1 ]
-then
-  echo "Warning: Found no (matching) pngs in $BLESSED.
-    Please run npm run blessed first (or otherwise produce images for comparison).
-    $folderWarningStringMsg"
+  echo Missing images in $BLESSED.
+  echo Please run "npm run generate:blessed"
   exit 1
 fi
 # check that #currentImages == #blessedImages (will continue anyways)


### PR DESCRIPTION
...and remove unused file results.txt.pass (prevent it from being created then deleted)

i added some checks that the necessary image directories exist and include png files.
When they don't, you get a warning and a hint that you probably forgot running npm run generate:current/blessed.

Before, when the images didn't exist and you can `npm run diff`, the script would output these errors, some of them unhelpful:
```sh
ls: ./build/images/blessed/*.png: No such file or directory
Running 0 tests with threshold 0.01 (nproc=2)...
./tools/visual_regression.sh: line 80: let: _progress=(1*100/0*100)/100: division by 0 (error token is "*100)/100")
./tools/visual_regression.sh: line 81: let: _done=(*4)/10: syntax error: operand expected (error token is "*4)/10")
./tools/visual_regression.sh: line 82: let: _left=40-: syntax error: operand expected (error token is "-")
Progress : [] %./tools/visual_regression.sh: line 98: ./build/images/current/*.png-temp.warn: No such file or directory

Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.


You have        1 warning(s):
  Warning: *.png missing in ./build/images/blessed.
Success - All diffs under threshold!
```

Now it outputs something like this:
```bash
Warning: directory ./build/images/current missing.
    Please run npm run generate:current (and if necessary npm run generate:blessed) first.
    Exiting without running visual regression tests.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! vexflow@1.2.90 diff: `./tools/visual_regression.sh`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the vexflow@1.2.90 diff script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/simon/.npm/_logs/2020-02-20T19_04_45_103Z-debug.log
```

The npm error output is a bit excessive in my opinion, but i'm not sure it's better to exit with 0 when there was nothing to test.

I can of course make some adjustments to the PR if suggested.