### PR TITLE
Limit CanvasContext to max browser width/height, warn

### DIFF
--- a/src/canvascontext.js
+++ b/src/canvascontext.js
@@ -19,10 +19,10 @@ export class CanvasContext {
     return 32767; // Chrome/Firefox. Could be determined more precisely by npm module canvas-size
   }
 
-  static CheckCanvasDimensionsForBrowserLimit(width, height) {
+  static SanitizeCanvasDims(width, height) {
     if (Math.max(width, height) > this.CANVAS_BROWSER_SIZE_LIMIT) {
       Vex.W(
-        'canvas dimensions exceed browser limit. reducing/cropping to ' +
+        'Canvas dimensions exceed browser limit. Cropping to ' +
         this.CANVAS_BROWSER_SIZE_LIMIT
       );
       if (width > this.CANVAS_BROWSER_SIZE_LIMIT) {
@@ -120,9 +120,7 @@ export class CanvasContext {
   }
 
   resize(width, height) {
-    width = parseInt(width, 10);
-    height = parseInt(height, 10);
-    [width, height] = this.CheckCanvasDimensionsForBrowserLimit(width, height);
+    [width, height] = this.SanitizeCanvasDims(parseInt(width, 10), parseInt(height, 10));
     return this.vexFlowCanvasContext.resize(width, height);
   }
 

--- a/src/canvascontext.js
+++ b/src/canvascontext.js
@@ -5,6 +5,8 @@
 //
 // Copyright Mohit Cheppudira 2010
 
+import { Vex } from './vex';
+
 /** @constructor */
 export class CanvasContext {
   static get WIDTH() {
@@ -12,6 +14,26 @@ export class CanvasContext {
   }
   static get HEIGHT() {
     return 400;
+  }
+  static get CANVAS_BROWSER_SIZE_LIMIT() {
+    return 32767; // Chrome/Firefox. Could be determined more precisely by npm module canvas-size
+  }
+
+  static CheckCanvasDimensionsForBrowserLimit(width, height) {
+    if (Math.max(width, height) > this.CANVAS_BROWSER_SIZE_LIMIT) {
+      Vex.W(
+        'canvas dimensions exceed browser limit. reducing/cropping to ' +
+        this.CANVAS_BROWSER_SIZE_LIMIT
+      );
+      if (width > this.CANVAS_BROWSER_SIZE_LIMIT) {
+        width = this.CANVAS_BROWSER_SIZE_LIMIT;
+        // note: Math.min return 0 for undefined, NaN for null. Would change inputs.
+      }
+      if (height > this.CANVAS_BROWSER_SIZE_LIMIT) {
+        height = this.CANVAS_BROWSER_SIZE_LIMIT;
+      }
+    }
+    return [width, height];
   }
 
   constructor(context) {
@@ -98,7 +120,10 @@ export class CanvasContext {
   }
 
   resize(width, height) {
-    return this.vexFlowCanvasContext.resize(parseInt(width, 10), parseInt(height, 10));
+    width = parseInt(width, 10);
+    height = parseInt(height, 10);
+    [width, height] = this.CheckCanvasDimensionsForBrowserLimit(width, height);
+    return this.vexFlowCanvasContext.resize(width, height);
   }
 
   rect(x, y, width, height) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -46,9 +46,6 @@ export class Renderer {
   static buildContext(elementId, backend, width, height, background) {
     const renderer = new Renderer(elementId, backend);
     if (width && height) {
-      if (backend === Renderer.Backends.CANVAS) {
-        [width, height] = CanvasContext.CheckCanvasDimensionsForBrowserLimit(width, height);
-      }
       renderer.resize(width, height);
     }
 
@@ -158,7 +155,7 @@ export class Renderer {
           'BadElement', `Can't get canvas context from element: ${this.elementId}`
         );
       }
-      [width, height] = CanvasContext.CheckCanvasDimensionsForBrowserLimit(width, height);
+      [width, height] = CanvasContext.SanitizeCanvasDims(width, height);
 
       const devicePixelRatio = window.devicePixelRatio || 1;
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -45,7 +45,12 @@ export class Renderer {
 
   static buildContext(elementId, backend, width, height, background) {
     const renderer = new Renderer(elementId, backend);
-    if (width && height) { renderer.resize(width, height); }
+    if (width && height) {
+      if (backend === Renderer.Backends.CANVAS) {
+        [width, height] = CanvasContext.CheckCanvasDimensionsForBrowserLimit(width, height);
+      }
+      renderer.resize(width, height);
+    }
 
     if (!background) background = '#FFF';
     const ctx = renderer.getContext();
@@ -153,6 +158,7 @@ export class Renderer {
           'BadElement', `Can't get canvas context from element: ${this.elementId}`
         );
       }
+      [width, height] = CanvasContext.CheckCanvasDimensionsForBrowserLimit(width, height);
 
       const devicePixelRatio = window.devicePixelRatio || 1;
 


### PR DESCRIPTION
fix #742

old behavior:
browser canvas element crashes when width or height > 32767 used on renderer.resize()
https://jsfiddle.net/2Lsme8yd/

new behavior:
renderer.resize() automatically crops dimensions to 32767 and gives warning
https://jsfiddle.net/tm9qaLzb/

npm test ran without fails.

(note that this only applies to CanvasContext, not SVGContext)