### PR TITLE
Fix link to the "build" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ stave.setContext(context).draw();
 
 To learn and contribute, check out the [VexFlow Wiki](https://github.com/0xfe/vexflow/wiki).
 
-To build VexFlow from scratch, read the [Build Instructions](https://github.com/0xfe/vexflow/wiki/Build-Instructions).
+To build VexFlow from scratch, read the [Build Instructions](https://github.com/0xfe/vexflow/wiki/Build-And-Release-Instructions).
 
 ## MIT License
 


### PR DESCRIPTION
The link to the build instructions lead to an empty wiki page. I assume it should point to the "build and Release" page, right? If not, please delete this PR.