### PR TITLE
Fix a note, which was an octave to high

### DIFF
--- a/tests/bach_tests.js
+++ b/tests/bach_tests.js
@@ -129,7 +129,7 @@ VF.Test.BachDemo = (function() {
       system.addStave({
         voices: [
           voice([
-            notes('B5/q'),
+            notes('B4/q'),
             beam(notes('C5/8, B4, A4, G4[id="m6a"]', { stem: 'up' })),
           ].reduce(concat)),
         ],


### PR DESCRIPTION
In measure 6 of the Bach Minuet Demo test, the B natural was written as "B5/q", whereas it should be "B4/q".