### PR TITLE
VF.Test.MultiMeasureRest: fix number_line option.

### DIFF
--- a/src/multimeasurerest.js
+++ b/src/multimeasurerest.js
@@ -50,7 +50,7 @@ export class MultiMeasureRest extends Element {
 
     this.render_options = {
       show_number: true,
-      number_line: -0.5 + fontLineShift,
+      number_line: -0.5,
       number_glyph_point: point, // same as TimeSignature.
 
       padding_left: undefined,
@@ -70,6 +70,8 @@ export class MultiMeasureRest extends Element {
       semibrave_rest_glyph_scale: Flow.DEFAULT_NOTATION_FONT_SCALE,
     };
     Vex.Merge(this.render_options, options);
+
+    this.render_options.number_line += fontLineShift;
 
     this.number_of_measures = number_of_measures;
     this.xs = {


### PR DESCRIPTION
fix MultiMeasureRest with `number_line` options:

https://github.com/0xfe/vexflow/blob/be50e3b9fb6788b9f8a32e48bb333d4c04cdbc38/tests/multimeasurerest_tests.js#L34

![image](https://user-images.githubusercontent.com/59550999/78614059-7cb07780-78a8-11ea-9896-f7118edf1fab.png)

```
$ git checkout master && npm start && git checkout fix-multi-rest-test2 && npm test
...
You have 1 fail(s):
MultiMeasureRest.Simple_Test 5.53174
```

