### PR TITLE
Added support for accent articulations in EasyScore

### DIFF
--- a/src/articulation.js
+++ b/src/articulation.js
@@ -209,6 +209,7 @@ export class Articulation extends Modifier {
     const articNameToCode = {
       staccato: 'a.',
       tenuto: 'a-',
+      accent: 'a>'
     };
 
     articulations

--- a/tests/easyscore_tests.js
+++ b/tests/easyscore_tests.js
@@ -225,7 +225,7 @@ Vex.Flow.Test.EasyScore = (function() {
       const score = vf.EasyScore();
       const system = vf.System();
 
-      const notes = score.notes('B4/h[id="foobar", class="red,bold", stem="up", articulations="staccato.below,tenuto"], B4/h[stem="down"]');
+      const notes = score.notes('B4/h[id="foobar", class="red,bold", stem="up", articulations="staccato.below,tenuto"], B4/q[articulations="accent.above"], B4/q[stem="down"]');
 
       system.addStave({
         voices: [score.voice(notes)],
@@ -244,7 +244,10 @@ Vex.Flow.Test.EasyScore = (function() {
       assert.equal(notes[0].modifiers[1].type, 'a-');
       assert.equal(notes[0].modifiers[1].position, VF.Modifier.Position.ABOVE);
       assert.equal(notes[0].getStemDirection(), VF.StaveNote.STEM_UP);
-      assert.equal(notes[1].getStemDirection(), VF.StaveNote.STEM_DOWN);
+      assert.equal(notes[1].modifiers[0].getCategory(), 'articulations');
+      assert.equal(notes[1].modifiers[0].type, 'a>');
+      assert.equal(notes[1].modifiers[0].position, VF.Modifier.Position.ABOVE);
+      assert.equal(notes[2].getStemDirection(), VF.StaveNote.STEM_DOWN);
     },
   };
 


### PR DESCRIPTION
I found the EasyScore hook in `articulation.js` was only allowing staccato and tenuto, so I added support for accents as well and updated the test for it.