### PR TITLE
Fix easyscore dots

### DIFF
--- a/src/easyscore.js
+++ b/src/easyscore.js
@@ -84,7 +84,7 @@ class Grammar {
     return {
       expect: [this.DOT],
       zeroOrMore: true,
-      run: (state) => this.builder.setNoteDots(state.matches[0]),
+      run: (state) => this.builder.setNoteDots(state.matches),
     };
   }
   TYPE() {

--- a/tests/easyscore_tests.js
+++ b/tests/easyscore_tests.js
@@ -233,7 +233,7 @@ Vex.Flow.Test.EasyScore = (function() {
         voices: [
           voice(
             notes('(c4 e4 g4)/8., (c4 e4 g4)/8.., (c4 e4 g4)/8..., (c4 e4 g4)/8...., (c4 e4 g4)/16...')
-          ).setMode(VF.Voice.Mode.SOFT)
+          )
         ],
       }).addClef('treble');
 

--- a/tests/easyscore_tests.js
+++ b/tests/easyscore_tests.js
@@ -18,6 +18,7 @@ Vex.Flow.Test.EasyScore = (function() {
       VFT.runTests('Draw Accidentals', VFT.EasyScore.drawAccidentalsTest);
       VFT.runTests('Draw Beams', VFT.EasyScore.drawBeamsTest);
       VFT.runTests('Draw Tuplets', VFT.EasyScore.drawTupletsTest);
+      VFT.runTests('Draw Dots',  VFT.EasyScore.drawDotsTest);
       VFT.runTests('Draw Options', VFT.EasyScore.drawOptionsTest);
     },
 
@@ -213,6 +214,26 @@ Vex.Flow.Test.EasyScore = (function() {
             notes('c#5/h.', { stem: 'up' })
               .concat(tuplet(beam(notes('cb5/8, cn5/8, c5/8', { stem: 'up' }))))
           ),
+        ],
+      }).addClef('treble');
+
+      vf.draw();
+      expect(0);
+    },
+
+    drawDotsTest: function(options) {
+      var vf = VF.Test.makeFactory(options, 600, 250);
+      const score = vf.EasyScore();
+      const system = vf.System();
+
+      var voice = score.voice.bind(score);
+      var notes = score.notes.bind(score);
+
+      system.addStave({
+        voices: [
+          voice(
+            notes('(c4 e4 g4)/8., (c4 e4 g4)/8.., (c4 e4 g4)/8..., (c4 e4 g4)/8...., (c4 e4 g4)/16...')
+          ).setMode(VF.Voice.Mode.SOFT)
         ],
       }).addClef('treble');
 


### PR DESCRIPTION
This PR fixes #782.

```
2) commit 252050a09b2010733eb6899c68fa1cb0a0e227fd (HEAD -> fix-easyscore-dots3)
Author: h-sug1no <59550999+h-sug1no@users.noreply.github.com>
Date:   Mon Apr 27 14:06:23 2020 +0900

    drawDotsTest: remove setMode(VF.Voice.Mode.SOFT).

commit 5a58d2bb77b5a31fe1eb5ac74e95425b80d76f1f
Author: h-sug1no <59550999+h-sug1no@users.noreply.github.com>
Date:   Mon Apr 27 14:05:41 2020 +0900

    {WIP}: fix easyScore DOTS.

1) commit 58c16a068f2236aa8cbe3e3cc464d9823fd437c9
Author: h-sug1no <59550999+h-sug1no@users.noreply.github.com>
Date:   Mon Apr 27 14:04:55 2020 +0900

    {WIP}: add VFT.EasyScore.drawDotsTest(Temporarily with Voice.Mode.SOFT).

0) commit bcf9e7c8386a73c143e714e72bcf66641fdc0f2a (upstream/master, origin/master, origin/HEAD, master)
Merge: 05cec53 c649f20
Author: Mohit Muthanna Cheppudira <0xfe@users.noreply.github.com>
Date:   Wed Apr 29 19:20:03 2020 -0400

    Merge pull request #785 from jeroenlammerts/master
    
    Merge note_struct options for GraceNote

```
```
# ===================================================
# diff: 0 and 1
$ git checkout bcf9e7c8386a73c143e714e72bcf66641fdc0f2a && npm start && git checkout 58c16a068f2236aa8cbe3e3cc464d9823fd437c9 && npm test


Warning: Number of (matching) current images (309) is not the same as blessed images (308). Continuing anyways.
Running 308 tests with threshold 0.01 (nproc=4)...
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.


You have 2 warning(s): (OK)
Warning: EasyScore.Draw_Dots.png missing in ./build/images/blessed.
  Warning: EasyScore.Draw_Dots.png missing in ./build/images/blessed.
Success - All diffs under threshold!

# ===================================================
# diff: 1 and 2
$ git checkout 58c16a068f2236aa8cbe3e3cc464d9823fd437c9 && npm start && git checkout 252050a09b2010733eb6899c68fa1cb0a0e227fd && npm test

Running 309 tests with threshold 0.01 (nproc=4)...
Progress : [##############--------------------------] 36%
Test: EasyScore.Draw_Dots
  PHASH value exceeds threshold: 2.11391 > 0.01
  Image diff stored in ./build/images/diff/EasyScore.Draw_Dots.png
Progress : [########################################] 100%
Results stored in ./build/images/diff/results.txt
All images with a difference over threshold, 0.01, are
available in ./build/images/diff, sorted by perceptual hash.

You have 1 fail(s):  (OK)
EasyScore.Draw_Dots 2.11391
```

![image](https://user-images.githubusercontent.com/59550999/80770802-4a82f480-8b8c-11ea-9bf0-aeef45dbceeb.png)

The problem looked like a simple typo, but I also suspected it might be a parser bug. Is this the correct fix?  > @0xfe san.