### PR TITLE
add context/svg group for tabnote

### DIFF
--- a/src/tabnote.js
+++ b/src/tabnote.js
@@ -470,6 +470,7 @@ export class TabNote extends StemmableNote {
     this.setRendered();
     const render_stem = this.beam == null && this.render_options.draw_stem;
 
+    this.context.openGroup('tabnote', null, { pointerBBox: true });
     this.drawPositions();
     this.drawStemThrough();
 
@@ -485,5 +486,6 @@ export class TabNote extends StemmableNote {
 
     this.drawFlag();
     this.drawModifiers();
+    this.context.closeGroup();
   }
 }


### PR DESCRIPTION
This makes it so that a tabnote can be found as a group in the svg DOM.

The same was already possible for stavenote (shown as `<g class="vf-stavenote"...`).

![image](https://user-images.githubusercontent.com/33069673/89210388-4ff33f00-d5c0-11ea-8ebc-f8f710458ef1.png)

`npm test` passes except for one visual diff in EasyScore.Draw_Options, which i don't think i affected.
