### PR TITLE
Double thickness of Ledger Lines

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1018,9 +1018,9 @@ export class StaveNote extends StemmableNote {
     // if lineWidth is not specified in getLedgerLineStyle will use
     // twice stave.getStyle() lineWidth
     if (ledger_line_style.lineWidth === undefined && style.lineWidth !== undefined) {
-      style.lineWidth *= 2;
+      style.lineWidth *= Flow.LEDGER_LINE_THICKNESS_MULTIPLIER;
     } else if (style.lineWidth === undefined) {
-      style.lineWidth = Flow.STAVE_LEDGER_LINE_THICKNESS;
+      style.lineWidth = Flow.STAVE_LINE_THICKNESS * Flow.LEDGER_LINE_THICKNESS_MULTIPLIER;
     }
 
     this.applyStyle(ctx, style);

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -81,7 +81,7 @@ export class StaveNote extends StemmableNote {
       let minL = props[props.length - 1].line;
       const stemDirection = notes[i].getStemDirection();
       const stemMax = notes[i].getStemLength() / 10;
-      const stemMin = notes[i].getStemMinumumLength() / 10;
+      const stemMin = notes[i].getStemMinimumLength() / 10;
 
       let maxL;
       if (notes[i].isRest()) {
@@ -327,6 +327,9 @@ export class StaveNote extends StemmableNote {
     // Drawing
     this.note_heads = [];
     this.modifiers = [];
+
+    // Default ledger line style. If lineWidth not specified will set to double stave width
+    this.ledgerLineStyle = {};
 
     Vex.Merge(this.render_options, {
       // font size for note heads and rests
@@ -835,7 +838,7 @@ export class StaveNote extends StemmableNote {
   // Get the width of the note if it is displaced. Used for `Voice`
   // formatting
   getVoiceShiftWidth() {
-    // TODO: may need to accomodate for dot here.
+    // TODO: may need to accommodate for dot here.
     return this.getGlyphWidth() * (this.displaced ? 2 : 1);
   }
 
@@ -1009,7 +1012,17 @@ export class StaveNote extends StemmableNote {
       ctx.stroke();
     };
 
-    const style = { ...stave.getStyle() || {}, ...this.getLedgerLineStyle() || {} };
+    const ledger_line_style = this.getLedgerLineStyle();
+    const style = { ...stave.getStyle() || {}, ...ledger_line_style };
+
+    // if lineWidth is not specified in getLedgerLineStyle will use
+    // twice stave.getStyle() lineWidth
+    if (ledger_line_style.lineWidth === undefined && style.lineWidth !== undefined) {
+      style.lineWidth *= 2;
+    } else if (style.lineWidth === undefined) {
+      style.lineWidth = Flow.STAVE_LEDGER_LINE_THICKNESS;
+    }
+
     this.applyStyle(ctx, style);
 
     // Draw ledger lines below the staff:

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -70,7 +70,7 @@ export class StemmableNote extends Note {
   }
 
   // Get the minimum length of stem
-  getStemMinumumLength() {
+  getStemMinimumLength() {
     const frac = Flow.durationToFraction(this.duration);
     let length = frac.value() <= 1 ? 0 : 20;
     // if note is flagged, cannot shorten beam

--- a/src/tables.js
+++ b/src/tables.js
@@ -11,6 +11,7 @@ const Flow = {
   STEM_WIDTH: 1.5,
   STEM_HEIGHT: 35,
   STAVE_LINE_THICKNESS: 1,
+  STAVE_LEDGER_LINE_THICKNESS: 2,  // Gould, Behind Bars: "about twice as thick"
   RESOLUTION: 16384,
 
   DEFAULT_FONT_STACK: DefaultFontStack,

--- a/src/tables.js
+++ b/src/tables.js
@@ -11,7 +11,7 @@ const Flow = {
   STEM_WIDTH: 1.5,
   STEM_HEIGHT: 35,
   STAVE_LINE_THICKNESS: 1,
-  STAVE_LEDGER_LINE_THICKNESS: 2,  // Gould, Behind Bars: "about twice as thick"
+  LEDGER_LINE_THICKNESS_MULTIPLIER: 2.0,  // Gould, Behind Bars: "about twice as thick"
   RESOLUTION: 16384,
 
   DEFAULT_FONT_STACK: DefaultFontStack,


### PR DESCRIPTION
Elaine Gould in "Behind Bars" notes: "Ledger lines are an extension of the stave. They are spaced the same distance apart as stave—lines, but *they are about twice as thick*"  Ledger lines in Vexflow have always been too thin for my tastes.

Makes default ledge lineWidth double the default staff width.

Obviously breaks many visual regression tests.  Here is a pretty normal change:

Blessed:
![Accidental Automatic_Accidentals___Multi_Voice_Inline_Blessed](https://user-images.githubusercontent.com/3521479/91667721-9f9c2c00-ead4-11ea-8e73-0c27fd0b2955.png)

Current:
![Accidental Automatic_Accidentals___Multi_Voice_Inline_Current](https://user-images.githubusercontent.com/3521479/91667723-a0cd5900-ead4-11ea-9d33-5999f87127dd.png)

Diff:
![Accidental Automatic_Accidentals___Multi_Voice_Inline](https://user-images.githubusercontent.com/3521479/91667724-a165ef80-ead4-11ea-830f-2a7b333571d9.png)


On some lineStyles and scales, the rounding in making the PNG makes the line change more obvious:

Blessed:
![Annotation Bottom_Annotations_with_Beams_Blessed](https://user-images.githubusercontent.com/3521479/91667741-c9ede980-ead4-11ea-89f0-62aeae7bfd94.png)

Current:
![Annotation Bottom_Annotations_with_Beams_Current](https://user-images.githubusercontent.com/3521479/91667744-cb1f1680-ead4-11ea-99eb-1ccc16e9f517.png)

Diff:
![Annotation Bottom_Annotations_with_Beams](https://user-images.githubusercontent.com/3521479/91667745-cb1f1680-ead4-11ea-99fe-18e68e6542db.png)


This was the only test that explicitly called setLedgerLine style (on the second to last eighth note) -- its ledger line style is respected.  However the stave.lineWidth = 3 -- which is already almost ridiculously thick -- makes even more ridiculous ledger line widths.  Should we set a maximum width above which we do not double ledger line thickness?  Or do people get what they ask for?  I think it looks okay in context.

Blessed:
![StaveNote Stave__Ledger_Line__Beam__Stem_and_Flag_Styles_Blessed](https://user-images.githubusercontent.com/3521479/91667758-e12cd700-ead4-11ea-8d25-8ffe50d4dc66.png)

Current:
![StaveNote Stave__Ledger_Line__Beam__Stem_and_Flag_Styles_Current](https://user-images.githubusercontent.com/3521479/91667760-e1c56d80-ead4-11ea-9026-d8237bf81a93.png)

Diff:
![StaveNote Stave__Ledger_Line__Beam__Stem_and_Flag_Styles](https://user-images.githubusercontent.com/3521479/91667761-e25e0400-ead4-11ea-8975-1a17733f2c3a.png)


Other visual regression test failures have to do with placement of articulations which changed in a recent PR, not this one.