### PR TITLE
Stem length to middle line

### DIFF
--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -81,7 +81,7 @@ export class StaveNote extends StemmableNote {
       let minL = props[props.length - 1].line;
       const stemDirection = notes[i].getStemDirection();
       const stemMax = notes[i].getStemLength() / 10;
-      const stemMin = notes[i].getStemMinumumLength() / 10;
+      const stemMin = notes[i].getStemMinimumLength() / 10;
 
       let maxL;
       if (notes[i].isRest()) {
@@ -439,6 +439,10 @@ export class StaveNote extends StemmableNote {
 
   // Automatically sets the stem direction based on the keys in the note
   autoStem() {
+    this.setStemDirection(this.calculateOptimalStemDirection());
+  }
+
+  calculateOptimalStemDirection() {
     // Figure out optimal stem direction based on given notes
     this.minLine = this.keyProps[0].line;
     this.maxLine = this.keyProps[this.keyProps.length - 1].line;
@@ -447,7 +451,7 @@ export class StaveNote extends StemmableNote {
     const decider = (this.minLine + this.maxLine) / 2;
     const stemDirection = decider < MIDDLE_LINE ? Stem.UP : Stem.DOWN;
 
-    this.setStemDirection(stemDirection);
+    return stemDirection;
   }
 
   // Calculates and stores the properties for each key in the note
@@ -561,8 +565,8 @@ export class StaveNote extends StemmableNote {
     return new BoundingBox(x, minY, w, maxY - minY);
   }
 
-  // Gets the line number of the top or bottom note in the chord.
-  // If `isTopNote` is `true` then get the top note
+  // Gets the line number of the bottom note in the chord.
+  // If `isTopNote` is `true` then get the top note's line number instead
   getLineNumber(isTopNote) {
     if (!this.keyProps.length) {
       throw new Vex.RERR(
@@ -1104,6 +1108,44 @@ export class StaveNote extends StemmableNote {
     this.context.openGroup('stem', null, { pointerBBox: true });
     this.stem.setContext(this.context).draw();
     this.context.closeGroup();
+  }
+
+
+  /**
+   * Override stemmablenote stem extension to adjust for distance from middle line.
+   */
+  getStemExtension() {
+    const super_stem_extension = super.getStemExtension();
+    const stem_direction = this.getStemDirection();
+    if (stem_direction !== this.calculateOptimalStemDirection()) {
+      return super_stem_extension;  // no adjustment for manually set stem direction.
+    }
+    let mid_line_distance;
+    const MIDDLE_LINE = 3;
+    if (stem_direction === Stem.UP) {
+      // Note that the use of maxLine here instead of minLine might
+      // seem counterintuitive, but in the case of (say) treble clef
+      // chord(F2, E4) stem up, we do not want to extend the stem because
+      // of F2, when a normal octave-length stem above E4 is fine.
+      //
+      // maxLine and minLine are set in calculateOptimalStemDirection() so
+In      // will be known.
+      mid_line_distance = MIDDLE_LINE - this.maxLine;
+    } else {
+      mid_line_distance = this.minLine - MIDDLE_LINE;
+    }
+
+    // how many lines more than an octave is the relevant notehead?
+    const lines_over_octave_from_mid_line = mid_line_distance - 3.5;
+    if (lines_over_octave_from_mid_line <= 0) {
+      return super_stem_extension;
+    }
+    const stave = this.getStave();
+    let spacing_between_lines = 10;
+    if (stave != null) {
+      spacing_between_lines = stave.getSpacingBetweenLines();
+    }
+    return super_stem_extension + (lines_over_octave_from_mid_line * spacing_between_lines);
   }
 
   // Draws all the `StaveNote` parts. This is the main drawing method.

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1116,6 +1116,10 @@ export class StaveNote extends StemmableNote {
    */
   getStemExtension() {
     const super_stem_extension = super.getStemExtension();
+    if (!this.glyph.stem) {
+      return super_stem_extension;
+    }
+
     const stem_direction = this.getStemDirection();
     if (stem_direction !== this.calculateOptimalStemDirection()) {
       return super_stem_extension;  // no adjustment for manually set stem direction.
@@ -1129,7 +1133,7 @@ export class StaveNote extends StemmableNote {
       // of F2, when a normal octave-length stem above E4 is fine.
       //
       // maxLine and minLine are set in calculateOptimalStemDirection() so
-In      // will be known.
+      // will be known.
       mid_line_distance = MIDDLE_LINE - this.maxLine;
     } else {
       mid_line_distance = this.minLine - MIDDLE_LINE;

--- a/src/stem.js
+++ b/src/stem.js
@@ -93,10 +93,16 @@ export class Stem extends Element {
 
   // Gets the entire height for the stem
   getHeight() {
-    const y_offset = (this.stem_direction === Stem.UP) ? this.stem_up_y_offset : this.stem_down_y_offset; // eslint-disable-line max-len
-    return ((this.y_bottom - this.y_top) * this.stem_direction) +
-           ((Stem.HEIGHT - y_offset + this.stem_extension) * this.stem_direction);
+    const y_offset = (this.stem_direction === Stem.UP)
+      ? this.stem_up_y_offset
+      : this.stem_down_y_offset;
+    const unsigned_height = (
+      (this.y_bottom - this.y_top)
+      + (Stem.HEIGHT - y_offset + this.stem_extension)
+    );  // parentheses just for grouping.
+    return unsigned_height * this.stem_direction;
   }
+
   getBoundingBox() {
     throw new Vex.RERR('NotImplemented', 'getBoundingBox() not implemented.');
   }

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -70,7 +70,7 @@ export class StemmableNote extends Note {
   }
 
   // Get the minimum length of stem
-  getStemMinumumLength() {
+  getStemMinimumLength() {
     const frac = Flow.durationToFraction(this.duration);
     let length = frac.value() <= 1 ? 0 : 20;
     // if note is flagged, cannot shorten beam
@@ -158,7 +158,7 @@ export class StemmableNote extends Note {
     }
 
     if (glyph) {
-      return this.getStemDirection() === 1
+      return this.getStemDirection() === Stem.UP
         ? glyph.stem_up_extension
         : glyph.stem_down_extension;
     }

--- a/src/stemmablenote.js
+++ b/src/stemmablenote.js
@@ -16,7 +16,7 @@ export class StemmableNote extends Note {
     this.setAttribute('type', 'StemmableNote');
 
     this.stem = null;
-    this.stemExtensionOverride = null;
+    this.stem_extension_override = null;
     this.beam = null;
   }
 
@@ -153,8 +153,8 @@ export class StemmableNote extends Note {
   getStemExtension() {
     const glyph = this.getGlyph();
 
-    if (this.stemExtensionOverride != null) {
-      return this.stemExtensionOverride;
+    if (this.stem_extension_override != null) {
+      return this.stem_extension_override;
     }
 
     if (glyph) {
@@ -168,7 +168,7 @@ export class StemmableNote extends Note {
 
   // Set the stem length to a specific. Will override the default length.
   setStemLength(height) {
-    this.stemExtensionOverride = (height - Stem.HEIGHT);
+    this.stem_extension_override = (height - Stem.HEIGHT);
     return this;
   }
 

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -13,6 +13,7 @@ VF.Test.StaveNote = (function() {
       test('Tick - New API', StaveNote.ticksNewApi);
       test('Stem', StaveNote.stem);
       test('Automatic Stem Direction', StaveNote.autoStem);
+      test('Stem Extension Pitch', StaveNote.stemExtensionPitch);
       test('Displacement after calling setStemDirection', StaveNote.setStemDirectionDisplacement);
       test('StaveLine', StaveNote.staveLine);
       test('Width', StaveNote.width);
@@ -31,6 +32,7 @@ VF.Test.StaveNote = (function() {
       runTests('StaveNote Draw - Bass 2', StaveNote.drawBass);
       runTests('StaveNote Draw - Key Styles', StaveNote.drawKeyStyles);
       runTests('StaveNote Draw - StaveNote Stem Styles', StaveNote.drawNoteStemStyles);
+      runTests('StaveNote Draw - StaveNote Stem Lengths', StaveNote.drawNoteStemLengths);
       runTests('StaveNote Draw - StaveNote Flag Styles', StaveNote.drawNoteStylesWithFlag);
       runTests('StaveNote Draw - StaveNote Styles', StaveNote.drawNoteStyles);
       runTests('Stave, Ledger Line, Beam, Stem and Flag Styles', StaveNote.drawBeamStyles);
@@ -156,9 +158,57 @@ VF.Test.StaveNote = (function() {
           var keys = testData[0];
           var expectedStemDirection = testData[1];
           var note = new VF.StaveNote({ keys: keys, auto_stem: true, duration: '8' });
-          equal(note.getStemDirection(), expectedStemDirection, 'Stem must be' + (expectedStemDirection === VF.StaveNote.STEM_UP ? 'up' : 'down'));
+          equal(note.getStemDirection(), expectedStemDirection, 'Stem must be ' + (expectedStemDirection === VF.StaveNote.STEM_UP ? 'up' : 'down'));
         });
     },
+
+    stemExtensionPitch: function() {
+      [
+        // [keys, expectedStemExtension, override stem direction]
+        [['c/5', 'e/5', 'g/5'], 0, 0],
+        [['e/4', 'g/4', 'c/5'], 0, 0],
+        [['c/5'], 0, 0],
+        [['f/3'], 15, 0],
+        [['f/3'], 15, VF.Stem.UP],
+        [['f/3'], 0, VF.Stem.DOWN],
+        [['f/3', 'e/5'], 0, 0],
+        [['g/6'], 25, 0],
+        [['g/6'], 25, VF.Stem.DOWN],
+        [['g/6'], 0, VF.Stem.UP],
+      ]
+        .forEach(function(testData) {
+          var keys = testData[0];
+          var expectedStemExtension = testData[1];
+          var overrideStemDirection = testData[2];
+          var note;
+          if (overrideStemDirection === 0) {
+            note = new VF.StaveNote({ keys: keys, auto_stem: true, duration: '4' });
+          } else {
+            note = new VF.StaveNote({ keys: keys, duration: '4', stem_direction: overrideStemDirection });
+          }
+          equal(
+            note.getStemExtension(),
+            expectedStemExtension,
+            'For ' + keys.toString() + ' StemExtension must be ' + expectedStemExtension
+          );
+          // set to weird Stave
+          var stave = new VF.Stave(10, 10, 300, { spacing_between_lines_px: 20 });
+          note.setStave(stave)
+          equal(
+            note.getStemExtension(),
+            expectedStemExtension * 2,
+            'For wide staff ' + keys.toString() + ' StemExtension must be ' + expectedStemExtension * 2
+          );
+
+          var whole_note = new VF.StaveNote({ keys: keys, duration: 'w' });
+          equal(
+            whole_note.getStemExtension(),
+            -1 * VF.STEM_HEIGHT,
+            'For ' + keys.toString() + ' whole_note StemExtension must always be -1 * VF.STEM_HEIGHT'
+          );
+        });
+    },
+
 
     setStemDirectionDisplacement: function() {
       function getDisplacements(note) {
@@ -262,15 +312,15 @@ VF.Test.StaveNote = (function() {
         { clef: clef, keys: higherKeys, duration: '32' },
         { clef: clef, keys: higherKeys, duration: '64' },
         { clef: clef, keys: higherKeys, duration: '128' },
-        { clef: clef, keys: lowerKeys, duration: '1/2', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'w', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'h', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'q', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '8', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '16', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '32', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '64', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '128', stem_direction: -1 },
+        { clef: clef, keys: lowerKeys, duration: '1/2', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'w', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'h', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'q', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '8', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '16', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '32', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '64', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '128', stem_direction: VF.Stem.DOWN },
 
         { clef: clef, keys: restKeys, duration: '1/2r' },
         { clef: clef, keys: restKeys, duration: 'wr' },
@@ -341,14 +391,14 @@ VF.Test.StaveNote = (function() {
         { clef: clef, keys: higherKeys, duration: '32' },
         { clef: clef, keys: higherKeys, duration: '64' },
         { clef: clef, keys: higherKeys, duration: '128' },
-        { clef: clef, keys: lowerKeys, duration: '1/2', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'w', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'h', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: 'q', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '8', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '16', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '32', stem_direction: -1 },
-        { clef: clef, keys: lowerKeys, duration: '64', stem_direction: -1 },
+        { clef: clef, keys: lowerKeys, duration: '1/2', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'w', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'h', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: 'q', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '8', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '16', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '32', stem_direction: VF.Stem.DOWN },
+        { clef: clef, keys: lowerKeys, duration: '64', stem_direction: VF.Stem.DOWN },
         { clef: clef, keys: lowerKeys, duration: '128' },
 
         { clef: clef, keys: restKeys, duration: '1/2r' },
@@ -390,11 +440,11 @@ VF.Test.StaveNote = (function() {
         { clef: 'bass', keys: ['c/3', 'e/3', 'a/3'], duration: '8' },
         { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '16' },
         { clef: 'bass', keys: ['c/3', 'e/3', 'a/3'], duration: '32' },
-        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: 'h', stem_direction: -1 },
-        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: 'q', stem_direction: -1 },
-        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '8', stem_direction: -1 },
-        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '16', stem_direction: -1 },
-        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '32', stem_direction: -1 },
+        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: 'h', stem_direction: VF.Stem.DOWN },
+        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: 'q', stem_direction: VF.Stem.DOWN },
+        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '8', stem_direction: VF.Stem.DOWN },
+        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '16', stem_direction: VF.Stem.DOWN },
+        { clef: 'bass', keys: ['c/2', 'e/2', 'a/2'], duration: '32', stem_direction: VF.Stem.DOWN },
 
         { keys: ['r/4'], duration: '1/2r' },
         { keys: ['r/4'], duration: 'wr' },
@@ -435,12 +485,12 @@ VF.Test.StaveNote = (function() {
         { keys: ['a/3', 'c/4', 'e/4', 'g/4', 'a/4', 'b/4'], duration: '16' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: '32' },
         { keys: ['c/4', 'e/4', 'a/4', 'a/4'], duration: '64' },
-        { keys: ['g/3', 'c/4', 'd/4', 'e/4'], duration: 'h', stem_direction: -1 },
-        { keys: ['d/4', 'e/4', 'f/4'], duration: 'q', stem_direction: -1 },
-        { keys: ['f/4', 'g/4', 'a/4', 'b/4'], duration: '8', stem_direction: -1 },
-        { keys: ['c/4', 'd/4', 'e/4', 'f/4', 'g/4', 'a/4'], duration: '16', stem_direction: -1 },
-        { keys: ['b/3', 'c/4', 'e/4', 'a/4', 'b/5', 'c/6', 'e/6'], duration: '32', stem_direction: -1 },
-        { keys: ['b/3', 'c/4', 'e/4', 'a/4', 'b/5', 'c/6', 'e/6', 'e/6'], duration: '64', stem_direction: -1 },
+        { keys: ['g/3', 'c/4', 'd/4', 'e/4'], duration: 'h', stem_direction: VF.Stem.DOWN },
+        { keys: ['d/4', 'e/4', 'f/4'], duration: 'q', stem_direction: VF.Stem.DOWN },
+        { keys: ['f/4', 'g/4', 'a/4', 'b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'd/4', 'e/4', 'f/4', 'g/4', 'a/4'], duration: '16', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/3', 'c/4', 'e/4', 'a/4', 'b/5', 'c/6', 'e/6'], duration: '32', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/3', 'c/4', 'e/4', 'a/4', 'b/5', 'c/6', 'e/6', 'e/6'], duration: '64', stem_direction: VF.Stem.DOWN },
       ];
       expect(notes.length * 2);
 
@@ -470,15 +520,15 @@ VF.Test.StaveNote = (function() {
         { keys: ['c/4', 'e/4', 'a/4'], duration: '32h' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: '64h' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: '128h' },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2h', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'wh', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'hh', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'qh', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '8h', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '16h', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '32h', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '64h', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '128h', stem_direction: -1 },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2h', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'wh', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'hh', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'qh', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '8h', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '16h', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '32h', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '64h', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '128h', stem_direction: VF.Stem.DOWN },
 
         { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2m' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: 'wm' },
@@ -489,15 +539,15 @@ VF.Test.StaveNote = (function() {
         { keys: ['c/4', 'e/4', 'a/4'], duration: '32m' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: '64m' },
         { keys: ['c/4', 'e/4', 'a/4'], duration: '128m' },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2m', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'wm', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'hm', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: 'qm', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '8m', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '16m', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '32m', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '64m', stem_direction: -1 },
-        { keys: ['c/4', 'e/4', 'a/4'], duration: '128m', stem_direction: -1 },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2m', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'wm', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'hm', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: 'qm', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '8m', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '16m', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '32m', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '64m', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/4', 'e/4', 'a/4'], duration: '128m', stem_direction: VF.Stem.DOWN },
       ];
       expect(notes.length * 2);
 
@@ -517,31 +567,31 @@ VF.Test.StaveNote = (function() {
       stave.draw();
 
       var notes = [
-        { keys: ['b/4'], duration: '1/2s', stem_direction: -1 },
-        { keys: ['b/4'], duration: 'ws', stem_direction: -1 },
-        { keys: ['b/4'], duration: 'hs', stem_direction: -1 },
-        { keys: ['b/4'], duration: 'qs', stem_direction: -1 },
-        { keys: ['b/4'], duration: '8s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '16s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '32s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '64s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '128s', stem_direction: -1 },
+        { keys: ['b/4'], duration: '1/2s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: 'ws', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: 'hs', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: 'qs', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '16s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '32s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '64s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '128s', stem_direction: VF.Stem.DOWN },
 
-        { keys: ['b/4'], duration: '1/2s', stem_direction: 1 },
-        { keys: ['b/4'], duration: 'ws', stem_direction: 1 },
-        { keys: ['b/4'], duration: 'hs', stem_direction: 1 },
-        { keys: ['b/4'], duration: 'qs', stem_direction: 1 },
-        { keys: ['b/4'], duration: '8s', stem_direction: 1 },
-        { keys: ['b/4'], duration: '16s', stem_direction: 1 },
-        { keys: ['b/4'], duration: '32s', stem_direction: 1 },
-        { keys: ['b/4'], duration: '64s', stem_direction: 1 },
-        { keys: ['b/4'], duration: '128s', stem_direction: 1 },
+        { keys: ['b/4'], duration: '1/2s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: 'ws', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: 'hs', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: 'qs', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '16s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '32s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '64s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '128s', stem_direction: VF.Stem.UP },
 
         // Beam
-        { keys: ['b/4'], duration: '8s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '8s', stem_direction: -1 },
-        { keys: ['b/4'], duration: '8s', stem_direction: 1 },
-        { keys: ['b/4'], duration: '8s', stem_direction: 1 },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '8s', stem_direction: VF.Stem.UP },
       ];
 
       var stave_notes = notes.map(function(note) { return new VF.StaveNote(note); });
@@ -624,6 +674,54 @@ VF.Test.StaveNote = (function() {
       ok('Note Stem Style');
     },
 
+    drawNoteStemLengths: function(options, contextBuilder) {
+      var ctx = new contextBuilder(options.elementId, 975, 280);
+      var stave = new VF.Stave(10, 10, 975);
+      stave.setContext(ctx).draw();
+
+      var keys = [
+        'e/3', 'f/3', 'g/3', 'a/3', 'b/3', 'c/4',
+        'd/4', 'e/4', 'f/4', 'g/4',
+        'f/5', 'g/5', 'a/5', 'b/5', 'c/6', 'd/6',
+        'e/6', 'f/6', 'g/6', 'a/6',
+      ];
+      var stave_notes = [];
+      var note;
+      var i;
+
+      for (i = 0; i < keys.length; i++) {
+        var duration = 'q';
+        if (i % 2 === 1) {
+          duration = '8';
+        }
+        note = new VF.StaveNote({ keys: [keys[i]], duration, auto_stem: true })
+          .setStave(stave);
+
+        new VF.TickContext()
+          .addTickable(note);
+
+        note.setContext(ctx);
+        stave_notes.push(note);
+      }
+
+      var whole_keys = [
+        'e/3', 'a/3', 'f/5', 'a/5', 'd/6', 'a/6'
+      ]
+      for (i = 0; i < whole_keys.length; i++) {
+        note = new VF.StaveNote({ keys: [whole_keys[i]], duration: 'w' })
+          .setStave(stave);
+
+        new VF.TickContext()
+          .addTickable(note);
+
+        note.setContext(ctx);
+        stave_notes.push(note);
+      }
+      VF.Formatter.FormatAndDraw(ctx, stave, stave_notes);
+
+      ok('Note Stem Length');
+    },
+
     drawNoteStylesWithFlag: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
@@ -659,29 +757,29 @@ VF.Test.StaveNote = (function() {
 
       var notes = [
         // beam1
-        { keys: ['b/4'], duration: '8', stem_direction: -1 },
-        { keys: ['b/4'], duration: '8', stem_direction: -1 },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
 
         // should be unstyled...
-        { keys: ['b/4'], duration: '8', stem_direction: -1 },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
 
         // beam2 should also be unstyled
-        { keys: ['b/4'], duration: '8', stem_direction: -1 },
-        { keys: ['b/4'], duration: '8', stem_direction: -1 },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.DOWN },
 
         // beam3
-        { keys: ['b/4'], duration: '8', stem_direction: 1 },
-        { keys: ['b/4'], duration: '8', stem_direction: 1 },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.UP },
+        { keys: ['b/4'], duration: '8', stem_direction: VF.Stem.UP },
 
         // beam4
-        { keys: ['d/6'], duration: '8', stem_direction: -1 },
-        { keys: ['c/6', 'd/6'], duration: '8', stem_direction: -1 },
+        { keys: ['d/6'], duration: '8', stem_direction: VF.Stem.DOWN },
+        { keys: ['c/6', 'd/6'], duration: '8', stem_direction: VF.Stem.DOWN },
 
         // unbeamed
-        { keys: ['d/6', 'e/6'], duration: '8', stem_direction: -1 },
+        { keys: ['d/6', 'e/6'], duration: '8', stem_direction: VF.Stem.DOWN },
 
         // unbeamed, unstyled
-        { keys: ['e/6', 'f/6'], duration: '8', stem_direction: -1 },
+        { keys: ['e/6', 'f/6'], duration: '8', stem_direction: VF.Stem.DOWN },
 
       ];
 
@@ -751,18 +849,18 @@ VF.Test.StaveNote = (function() {
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
 
       var notes = [
-        newNote({ keys: ['f/4'], duration: '4', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '8', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '16', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '32', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '64', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '128', stem_direction: 1 }).addDotToAll().addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '4', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '8', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '16', stem_direction: 1 }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '4', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '8', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '16', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '32', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '64', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '128', stem_direction: VF.Stem.UP }).addDotToAll().addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '4', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '8', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '16', stem_direction: VF.Stem.UP }).addDotToAll(),
         newNote({ keys: ['g/4'], duration: '32' }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '64', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '128', stem_direction: 1 }).addDotToAll().addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '64', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '128', stem_direction: VF.Stem.UP }).addDotToAll().addDotToAll(),
       ];
 
       stave.setContext(ctx).draw();
@@ -786,18 +884,18 @@ VF.Test.StaveNote = (function() {
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
 
       var notes = [
-        newNote({ keys: ['e/5'], duration: '4', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '8', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '16', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '32', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '64', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '128', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '4', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '8', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '16', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '32', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '64', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '128', stem_direction: -1 }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '4', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '8', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '16', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '32', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '64', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '128', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '4', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '8', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '16', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '32', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '64', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '128', stem_direction: VF.Stem.DOWN }).addDotToAll(),
       ];
 
       stave.setContext(ctx).draw();
@@ -820,16 +918,18 @@ VF.Test.StaveNote = (function() {
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
 
       var notes = [
-        newNote({ keys: ['f/4'], duration: '8', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '16', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '32', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '64', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['f/4'], duration: '128', stem_direction: 1 }).addDotToAll().addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '8', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '16', stem_direction: 1 }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '8', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '16', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '32', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '64', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['f/4'], duration: '128', stem_direction: VF.Stem.UP })
+          .addDotToAll().addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '8', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '16', stem_direction: VF.Stem.UP }).addDotToAll(),
         newNote({ keys: ['g/4'], duration: '32' }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '64', stem_direction: 1 }).addDotToAll(),
-        newNote({ keys: ['g/4'], duration: '128', stem_direction: 1 }).addDotToAll().addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '64', stem_direction: VF.Stem.UP }).addDotToAll(),
+        newNote({ keys: ['g/4'], duration: '128', stem_direction: VF.Stem.UP })
+          .addDotToAll().addDotToAll(),
       ];
 
       var beam = new VF.Beam(notes);
@@ -856,16 +956,16 @@ VF.Test.StaveNote = (function() {
       function newNote(note_struct) { return new VF.StaveNote(note_struct); }
 
       var notes = [
-        newNote({ keys: ['e/5'], duration: '8', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '16', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '32', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '64', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['e/5'], duration: '128', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '8', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '16', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '32', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '64', stem_direction: -1 }).addDotToAll(),
-        newNote({ keys: ['d/5'], duration: '128', stem_direction: -1 }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '8', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '16', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '32', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '64', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['e/5'], duration: '128', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '8', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '16', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '32', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '64', stem_direction: VF.Stem.DOWN }).addDotToAll(),
+        newNote({ keys: ['d/5'], duration: '128', stem_direction: VF.Stem.DOWN }).addDotToAll(),
       ];
 
       var beam = new VF.Beam(notes);

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -675,7 +675,7 @@ VF.Test.StaveNote = (function() {
     },
 
     drawNoteStemLengths: function(options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 975, 280);
+      var ctx = new contextBuilder(options.elementId, 975, 150);
       var stave = new VF.Stave(10, 10, 975);
       stave.setContext(ctx).draw();
 


### PR DESCRIPTION
Behind Bars, p. 14: Stems for notes on more than one ledger line extend to the middle stave-line.

Subclasses getStemExtension on stavenote to account for the height of the note.  As notes get further from Mid line (b/4 in t.c.) stems get longer (unless they go the opposite direction).  Does nothing to non-stem notes like whole notes.

Adds new test and visual test:
![StaveNote StaveNote_Draw___StaveNote_Stem_Lengths](https://user-images.githubusercontent.com/3521479/91670380-e5fc8580-eaea-11ea-8175-97a5b9b3e0ec.png)

Fixes behavior in about 18 tests.  Example:

Blessed:
![Clef Clef_Change_Test_Blessed](https://user-images.githubusercontent.com/3521479/91670258-b39e5880-eae9-11ea-8164-512c5a7a6d96.png)

New:
![Clef Clef_Change_Test_Current](https://user-images.githubusercontent.com/3521479/91670259-b436ef00-eae9-11ea-93b2-39387a4dfa20.png)

Diff:
![Clef Clef_Change_Test](https://user-images.githubusercontent.com/3521479/91670260-b4cf8580-eae9-11ea-934b-9f8e801c550d.png)

Improves beam angles in several tests:

Blessed:
![Curve Simple_Curve_Blessed](https://user-images.githubusercontent.com/3521479/91670271-d16bbd80-eae9-11ea-8333-e17005f88b3d.png)

New:
![Curve Simple_Curve_Current](https://user-images.githubusercontent.com/3521479/91670272-d2045400-eae9-11ea-90a9-c35af187065a.png)

Diff:
![Curve Simple_Curve](https://user-images.githubusercontent.com/3521479/91670273-d29cea80-eae9-11ea-889b-5a46071d3358.png)


It makes more obvious an existing bug in a current test.  The accent mark and the fermata on the last note of the first measure here appear to be on top of each other, but actually they are separated by 1/2 line space, similar to the staccato and accent on blessed g/5 in m. 1.  Solution will come in another PR: while the first articulation can appear in a half-line-space, all additional ones on the same side need a minimum of 1 line space (or need to take glyph-size into account). 

![Articulation Articulation___Inline_Multiple_Blessed](https://user-images.githubusercontent.com/3521479/91670296-1263d200-eaea-11ea-9c09-a80f139a38e7.png)
![Articulation Articulation___Inline_Multiple_Current](https://user-images.githubusercontent.com/3521479/91670297-12fc6880-eaea-11ea-8a2d-ff1428beb951.png)
![Articulation Articulation___Inline_Multiple](https://user-images.githubusercontent.com/3521479/91670298-1394ff00-eaea-11ea-9c96-a76964c50210.png)

I believe that this is a fundamental enough improvement to put in first and fix 3-auto-positioned articulations later?