### PR TITLE
Added support for fingerings in EasyScore

### DIFF
--- a/src/easyscore.js
+++ b/src/easyscore.js
@@ -9,6 +9,7 @@ import { Vex } from './vex';
 import { StaveNote } from './stavenote';
 import { Parser } from './parser';
 import { Articulation } from './articulation';
+import { FretHandFinger } from './frethandfinger';
 
 // To enable logging for this class. Set `Vex.Flow.EasyScore.DEBUG` to `true`.
 function L(...args) { if (EasyScore.DEBUG) Vex.L('Vex.Flow.EasyScore', args); }
@@ -313,6 +314,7 @@ export class EasyScore {
         setId,
         setClass,
         Articulation.easyScoreHook,
+        FretHandFinger.easyScoreHook,
       ],
       throwOnError: false, ...options
     };

--- a/src/frethandfinger.js
+++ b/src/frethandfinger.js
@@ -91,6 +91,19 @@ export class FretHandFinger extends Modifier {
     return true;
   }
 
+  static easyScoreHook({ fingerings }, note, builder) {
+    if (!fingerings) return;
+
+    fingerings.split(',')
+      .map(fingeringString => fingeringString.trim().split('.'))
+      .map(([number, position]) => {
+        const params = { number };
+        if (position) params.position = position;
+        return builder.getFactory().Fingering(params);
+      })
+      .map((fingering, index) => note.addModifier(index, fingering));
+  }
+
   constructor(number) {
     super();
     this.setAttribute('type', 'FretHandFinger');

--- a/tests/easyscore_tests.js
+++ b/tests/easyscore_tests.js
@@ -20,6 +20,7 @@ Vex.Flow.Test.EasyScore = (function() {
       VFT.runTests('Draw Tuplets', VFT.EasyScore.drawTupletsTest);
       VFT.runTests('Draw Dots',  VFT.EasyScore.drawDotsTest);
       VFT.runTests('Draw Options', VFT.EasyScore.drawOptionsTest);
+      VFT.runTests('Draw Fingerings', VFT.EasyScore.drawFingeringsTest);
     },
 
     basic: function(assert) {
@@ -269,6 +270,40 @@ Vex.Flow.Test.EasyScore = (function() {
       assert.equal(notes[1].modifiers[0].type, 'a>');
       assert.equal(notes[1].modifiers[0].position, VF.Modifier.Position.ABOVE);
       assert.equal(notes[2].getStemDirection(), VF.StaveNote.STEM_DOWN);
+    },
+
+    drawFingeringsTest: function(options) {
+      var vf = VF.Test.makeFactory(options, 500, 200);
+      const score = vf.EasyScore();
+      const system = vf.System();
+
+      const notes = score.notes('C4/q[fingerings="1"], E4[fingerings="3.above"], G4[fingerings="5.below"], (C4 E4 G4)[fingerings="1,3,5"]');
+
+      system.addStave({
+        voices: [score.voice(notes)],
+      });
+
+      vf.draw();
+
+      const assert = options.assert;
+      assert.equal(notes[0].modifiers[0].getCategory(), 'frethandfinger');
+      assert.equal(notes[0].modifiers[0].finger, '1');
+      assert.equal(notes[0].modifiers[0].position, VF.Modifier.Position.LEFT);
+      assert.equal(notes[1].modifiers[0].getCategory(), 'frethandfinger');
+      assert.equal(notes[1].modifiers[0].finger, '3');
+      assert.equal(notes[1].modifiers[0].position, VF.Modifier.Position.ABOVE);
+      assert.equal(notes[2].modifiers[0].getCategory(), 'frethandfinger');
+      assert.equal(notes[2].modifiers[0].finger, '5');
+      assert.equal(notes[2].modifiers[0].position, VF.Modifier.Position.BELOW);
+      assert.equal(notes[3].modifiers[0].getCategory(), 'frethandfinger');
+      assert.equal(notes[3].modifiers[0].finger, '1');
+      assert.equal(notes[3].modifiers[0].position, VF.Modifier.Position.LEFT);
+      assert.equal(notes[3].modifiers[1].getCategory(), 'frethandfinger');
+      assert.equal(notes[3].modifiers[1].finger, '3');
+      assert.equal(notes[3].modifiers[1].position, VF.Modifier.Position.LEFT);
+      assert.equal(notes[3].modifiers[2].getCategory(), 'frethandfinger');
+      assert.equal(notes[3].modifiers[2].finger, '5');
+      assert.equal(notes[3].modifiers[2].position, VF.Modifier.Position.LEFT);
     },
   };
 

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -193,7 +193,7 @@ VF.Test.StaveNote = (function() {
           );
           // set to weird Stave
           var stave = new VF.Stave(10, 10, 300, { spacing_between_lines_px: 20 });
-          note.setStave(stave)
+          note.setStave(stave);
           equal(
             note.getStemExtension(),
             expectedStemExtension * 2,
@@ -706,7 +706,7 @@ VF.Test.StaveNote = (function() {
 
       var whole_keys = [
         'e/3', 'a/3', 'f/5', 'a/5', 'd/6', 'a/6'
-      ]
+      ];
       for (i = 0; i < whole_keys.length; i++) {
         note = new VF.StaveNote({ keys: [whole_keys[i]], duration: 'w' })
           .setStave(stave);


### PR DESCRIPTION
I added support to specify fingerings using EasyScore and followed the same pattern previously established with articulations (see `easyScoreHook` in `articulation.js` for comparison).  Before this change, I was adding fingerings by doing something like this:

```
system.addStave({
  voices: [
    score.voice(score.notes('C4/q, E4, G4, C4'))
  ]
}).addClef('treble').addTimeSignature('4/4');

system.parts[0].voices[0].tickables[0].addModifier(0, vf.Fingering({ number: '1' }));
```

Now it can be specified directly in EasyScore:

```
system.addStave({
  voices: [
    score.voice(score.notes('C4/q[fingerings="1"], E4, G4, C4')),
  ]
}).addClef('treble').addTimeSignature('4/4');
```
