### PR TITLE
Put drawLedgerLines() within stavenotegroup

### DIFF
--- a/src/beam.js
+++ b/src/beam.js
@@ -336,7 +336,6 @@ export class Beam extends Element {
       return uniqueTuplets;
     }
 
-
     // Using closures to store the variables throughout the various functions
     // IMO Keeps it this process lot cleaner - but not super consistent with
     // the rest of the API's style - Silverwolf90 (Cyril)

--- a/src/chordsymbol.js
+++ b/src/chordsymbol.js
@@ -40,7 +40,6 @@ export class ChordSymbol extends Modifier {
     };
   }
 
-
   static get verticalJustify() {
     return {
       TOP: 1,
@@ -442,7 +441,6 @@ export class ChordSymbol extends Modifier {
     const kernConst = ChordSymbol.kerningOffset * this.pointsToPixels;
     const prevSymbol = j > 0 ? this.symbolBlocks[j - 1] : null;
     let rv = 0;
-
 
     // Move things into the '/' over bar
     if (symbol.symbolType === ChordSymbol.symbolTypes.GLYPH &&

--- a/src/easyscore.js
+++ b/src/easyscore.js
@@ -280,7 +280,6 @@ function setId({ id }, note) {
   note.setAttribute('id', id);
 }
 
-
 function setClass(options, note) {
   if (!options.class) return;
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -606,7 +606,6 @@ export class Factory {
     return textFont;
   }
 
-
   draw() {
     this.systems.forEach(i => i.setContext(this.context).format());
     this.staves.forEach(i => i.setContext(this.context).draw());

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -488,7 +488,6 @@ export class Formatter {
     // No justification needed. End formatting.
     if (justifyWidth <= 0) return this.evaluate();
 
-
     // Start justification. Subtract the right extra pixels of the final context because the formatter
     // justifies based on the context's X position, which is the left-most part of the note head.
     const firstContext = contextMap[contextList[0]];

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -78,7 +78,6 @@ export class Glyph extends Element {
     return { glyph, font };
   }
 
-
   static loadMetrics(fontStack, code, category = null) {
     const { glyph, font } = Glyph.lookupGlyph(fontStack, code);
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,6 @@ import { TextFont } from './textfont';
 import { PetalumaScriptTextMetrics } from './fonts/petalumascript_textmetrics';
 import { RobotoSlabTextMetrics } from './fonts/robotoslab_textmetrics';
 
-
 import { Font, Fonts, DefaultFontStack } from './smufl';
 
 Vex.Flow = Flow;

--- a/src/note.js
+++ b/src/note.js
@@ -94,7 +94,6 @@ export class Note extends Tickable {
     let type = noteStruct.type;
     if (type && !Flow.getGlyphProps.validTypes[type]) { return null; }
 
-
     // If no type specified, check duration or custom types
     if (!type) {
       type = durationProps.type || 'n';
@@ -134,7 +133,6 @@ export class Note extends Tickable {
       ticks,
     };
   }
-
 
   // Every note is a tickable, i.e., it can be mutated by the `Formatter` class for
   // positioning and layout.

--- a/src/staveline.js
+++ b/src/staveline.js
@@ -275,7 +275,6 @@ export class StaveLine extends Element {
       start_position.x += first_note.getMetrics().modRightPx + render_options.padding_left;
       end_position.x -= last_note.getMetrics().modLeftPx + render_options.padding_right;
 
-
       // Adjust first `x` coordinates for displacements
       const notehead_width = first_note.getGlyph().getWidth();
       const first_displaced = first_note.getKeyProps()[first_index].displaced;

--- a/src/stavenote.js
+++ b/src/stavenote.js
@@ -1110,7 +1110,6 @@ export class StaveNote extends StemmableNote {
     this.context.closeGroup();
   }
 
-
   /**
    * Override stemmablenote stem extension to adjust for distance from middle line.
    */
@@ -1176,12 +1175,10 @@ export class StaveNote extends StemmableNote {
 
     L('Rendering ', this.isChord() ? 'chord :' : 'note :', this.keys);
 
-    // Draw each part of the note
-    this.drawLedgerLines();
-
     // Apply the overall style -- may be contradicted by local settings:
     this.applyStyle();
     this.setAttribute('el', this.context.openGroup('stavenote', this.getAttribute('id')));
+    this.drawLedgerLines();
     this.context.openGroup('note', null, { pointerBBox: true });
     if (shouldRenderStem) this.drawStem();
     this.drawNoteHeads();

--- a/src/tables.js
+++ b/src/tables.js
@@ -31,7 +31,6 @@ const Flow = {
   IsKerned: true,
 };
 
-
 Flow.clefProperties = clef => {
   if (!clef) throw new Vex.RERR('BadArgument', 'Invalid clef: ' + clef);
 
@@ -177,7 +176,6 @@ Flow.keyProperties.note_values = {
     shift_right: 5.5,
   },
 };
-
 
 Flow.integerToNote = integer => {
   if (typeof (integer) === 'undefined') {
@@ -677,7 +675,6 @@ Flow.keySignature.accidentalList = (acc) => {
 
   return patterns[acc];
 };
-
 
 // Used to convert duration aliases to the number based duration.
 // If the input isn't an alias, simply return the input.

--- a/src/tickable.js
+++ b/src/tickable.js
@@ -93,7 +93,6 @@ export class Tickable extends Element {
     return this.tickContext.getX() + this.x_shift;
   }
 
-
   getFormatterMetrics() { return this.formatterMetrics; }
 
   getCenterXShift() {

--- a/tests/accidental_tests.js
+++ b/tests/accidental_tests.js
@@ -296,7 +296,6 @@ Vex.Flow.Test.Accidental = (function() {
       Vex.Flow.Test.Accidental.showNotes(note1, note2, stave, ctx, 250);
       Vex.Flow.Test.plotLegendForNoteWidth(ctx, 350, 150);
 
-
       ok(true, 'Full Accidental');
     },
 

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -316,10 +316,8 @@ VF.Test.Annotation = (function() {
       voice.addTickables(notes2);
       voice.addTickables(notes3);
 
-
       new VF.Formatter().joinVoices([voice])
         .formatToStave([voice], stave);
-
 
       voice.draw(ctx, stave);
 

--- a/tests/beam_tests.js
+++ b/tests/beam_tests.js
@@ -3,7 +3,6 @@
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
 
-
 /*
 eslint-disable
 no-var,
@@ -507,7 +506,6 @@ VF.Test.Beam = (function() {
 
       ok(true, 'All objects have been drawn');
     },
-
 
     autoTabBeams: function(options) {
       var vf = VF.Test.makeFactory(options, 600, 200);

--- a/tests/clef_tests.js
+++ b/tests/clef_tests.js
@@ -64,7 +64,6 @@ VF.Test.Clef = (function() {
       ok(true, 'all pass');
     },
 
-
     drawSmall: function(options) {
       var vf = VF.Test.makeFactory(options, 800, 120);
 

--- a/tests/formatter/tests.js
+++ b/tests/formatter/tests.js
@@ -258,7 +258,6 @@ function multistave(el, iterations, params) {
     formatter.tune({ alpha: options.alpha });
   }
 
-
   vf.Beam({ notes: notes32.slice(0, 3) });
   vf.Beam({ notes: notes32.slice(3, 6) });
 

--- a/tests/keysignature_tests.js
+++ b/tests/keysignature_tests.js
@@ -104,7 +104,6 @@ VF.Test.KeySignature = (function() {
         keySig.addToStave(stave2);
       }
 
-
       stave.setContext(ctx);
       stave.draw();
       stave2.setContext(ctx);

--- a/tests/multimeasurerest_tests.js
+++ b/tests/multimeasurerest_tests.js
@@ -87,7 +87,6 @@ VF.Test.MultiMeasureRest = (function() {
       context.fillText(str, xs.left + ((xs.right - xs.left) * 0.5) - (metrics.width * 0.5), strY);
       context.restore();
 
-
       ok(true, 'Simple Test');
     },
     staveWithModifiers: function(options) {

--- a/tests/ornament_tests.js
+++ b/tests/ornament_tests.js
@@ -181,7 +181,6 @@ VF.Test.Ornament = (function() {
       notesBar1[2].addModifier(0, new VF.Ornament('upmordent'));
       notesBar1[3].addModifier(0, new VF.Ornament('lineprall'));
 
-
       // Helper function to justify and draw a 4/4 voice
       VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
     },

--- a/tests/rhythm_tests.js
+++ b/tests/rhythm_tests.js
@@ -80,7 +80,6 @@ VF.Test.Rhythm = (function() {
       // Helper function to justify and draw a 4/4 voice
       VF.Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
 
-
       // bar 3 - juxtaposing second bar next to first bar
       var staveBar3 = new VF.Stave(staveBar2.width + staveBar2.x,
         staveBar2.y, 170);
@@ -167,7 +166,6 @@ VF.Test.Rhythm = (function() {
       staveBar1.addTimeSignature('4/4');
       staveBar1.addKeySignature('C');
       staveBar1.setContext(ctx).draw();
-
 
       // bar 4
       var notesBar1_part1 = [
@@ -371,14 +369,12 @@ VF.Test.Rhythm = (function() {
       VF.Formatter.FormatAndDraw(ctx, staveBar1,
         notesBar1_part1.concat(notesBar1_part2));
 
-
       // Render beams
       beam1.setContext(ctx).draw();
       beam2.setContext(ctx).draw();
 
       expect(0);
     },
-
 
     drawThirtySecondWithScratches: function(options,
       contextBuilder) {

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -203,7 +203,6 @@ VF.Test.Stave = (function() {
       // Helper function to justify and draw a 4/4 voice
       VF.Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
 
-
       // bar 2 - juxtaposing second bar next to first bar
       var staveBar2 = new VF.Stave(staveBar1.width + staveBar1.x,
         staveBar1.y, 250);

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -209,7 +209,6 @@ VF.Test.StaveNote = (function() {
         });
     },
 
-
     setStemDirectionDisplacement: function() {
       function getDisplacements(note) {
         return note.note_heads.map(function(notehead) {
@@ -871,7 +870,6 @@ VF.Test.StaveNote = (function() {
 
       ok(true, 'Full Dot');
     },
-
 
     dotsAndFlagsStemDown: function(options, contextBuilder) {
       var ctx = new contextBuilder(options.elementId, 800, 160);

--- a/tests/tabslide_tests.js
+++ b/tests/tabslide_tests.js
@@ -45,7 +45,6 @@ VF.Test.TabSlide = (function() {
       return { context: ctx, stave: stave };
     },
 
-
     simple: function(options, contextBuilder) {
       options.contextBuilder = contextBuilder;
       var c = VF.Test.TabSlide.setupContext(options);


### PR DESCRIPTION
The call to drawLedgerLines method when put out of vf-stavenote group makes the drawn ledger lines to be not easy to remove from the stave. By keeping them together within the vf-stavenote group, one can remove a note and the corresponding ledgerline by doing just this:

`note.attrs.el.remove();`