### PR TITLE
Opt-out of reporting width for chord symbols

### DIFF
--- a/src/chordsymbol.js
+++ b/src/chordsymbol.js
@@ -11,9 +11,8 @@
 import { Vex } from './vex';
 import { Flow } from './tables';
 import { Glyph } from './glyph';
+import { TextFont } from './textfont';
 import { Modifier } from './modifier';
-import { PetalumaScriptTextMetrics } from './fonts/petalumascript_textmetrics';
-import { RobotoSlabTextMetrics } from './fonts/robotoslab_textmetrics';
 
 // To enable logging for this class. Set `Vex.Flow.ChordSymbol.DEBUG` to `true`.
 function L(...args) { if (ChordSymbol.DEBUG) Vex.L('Vex.Flow.ChordSymbol', args); }
@@ -39,7 +38,6 @@ export class ChordSymbol extends Modifier {
       centerStem: ChordSymbol.horizontalJustify.CENTER_STEM,
     };
   }
-
 
   static get verticalJustify() {
     return {
@@ -86,30 +84,12 @@ export class ChordSymbol extends Modifier {
     return null;
   }
 
-  static get textMetricsForEngravingFont() {
-    if (Vex.Flow.DEFAULT_FONT_STACK[0].name === 'Petaluma') {
-      return PetalumaScriptTextMetrics;
-    } else {
-      return RobotoSlabTextMetrics;
-    }
-  }
-
-  static getMetricForCharacter(c) {
-    if (ChordSymbol.NOTEXTFORMAT) {
-      return null;
-    }
-    if (ChordSymbol.textMetricsForEngravingFont.glyphs[c]) {
-      return ChordSymbol.textMetricsForEngravingFont.glyphs[c];
-    }
-    return null;
-  }
-
-  static getYOffsetForText(text) {
+  getYOffsetForText(text) {
     let acc = 0;
     let ix = 0;
-    const resolution = ChordSymbol.textMetricsForEngravingFont.resolution;
+    const resolution = this.textFont.resolution;
     for (ix = 0; ix < text.length; ++ix) {
-      const metric = ChordSymbol.getMetricForCharacter(text[ix]);
+      const metric = this.textFont.getMetricForCharacter(text[ix]);
 
       if (metric) {
         acc = metric.y < acc ? metric.y : acc;
@@ -127,13 +107,8 @@ export class ChordSymbol extends Modifier {
     return ChordSymbol.chordSymbolMetrics.global.spacing / ChordSymbol.engravingFontResolution;
   }
 
-  static getWidthForCharacter(c) {
-    const resolution = ChordSymbol.textMetricsForEngravingFont.resolution;
-    const metric = ChordSymbol.getMetricForCharacter(c);
-    if (!metric) {
-      return 0.65;
-    }
-    return metric.advanceWidth / resolution;
+  getWidthForCharacter(c) {
+    return this.textFont.getMetricForCharacter(c).advanceWidth / this.textFont.resolution;
   }
 
   static getWidthForGlyph(glyph) {
@@ -275,6 +250,7 @@ export class ChordSymbol extends Modifier {
 
     let width = 0;
     let nonSuperWidth = 0;
+    const reportedWidths = [];
 
     for (let i = 0; i < instances.length; ++i) {
       const instance = instances[i];
@@ -304,8 +280,8 @@ export class ChordSymbol extends Modifier {
           symbol.glyph.scale = symbol.glyph.scale * adj;
           symbol.width = ChordSymbol.getWidthForGlyph(symbol.glyph) * instance.pointsToPixels * subAdj;
         } else if (symbol.symbolType === ChordSymbol.symbolTypes.TEXT) {
-          symbol.width = symbol.width * instance.pointsToPixels * subAdj;
-          symbol.yShift += ChordSymbol.getYOffsetForText(symbol.text) * adj;
+          symbol.width = symbol.width * instance.textFont.pointsToPixels * subAdj;
+          symbol.yShift += instance.getYOffsetForText(symbol.text) * adj;
         }
 
         if (symbol.symbolType === ChordSymbol.symbolTypes.GLYPH &&
@@ -349,7 +325,14 @@ export class ChordSymbol extends Modifier {
         instance.setTextLine(state.text_line + 1);
         state.text_line += lineSpaces + 1;
       }
+      if (instance.getReportWidth()) {
+        reportedWidths.push(width);
+      } else {
+        reportedWidths.push(0);
+      }
     }
+
+    width = reportedWidths.reduce((a, b) => a + b);
 
     state.left_shift += width / 2;
     state.right_shift += width / 2;
@@ -369,6 +352,7 @@ export class ChordSymbol extends Modifier {
     this.horizontal = ChordSymbol.horizontalJustify.LEFT;
     this.vertical = ChordSymbol.verticalJustify.TOP;
     this.useKerning = true;
+    this.reportWidth = true;
 
     let fontFamily = 'Arial';
     if (this.musicFont.name === 'Petaluma') {
@@ -381,12 +365,13 @@ export class ChordSymbol extends Modifier {
       size: 12,
       weight: '',
     };
+    this.textFont = TextFont.getTextFontFromVexFontData(this.font);
   }
 
   // ### pointsToPixels
   // The font size is specified in points, convert to 'pixels' in the svg space
   get pointsToPixels() {
-    return (this.font.size / 72) / (1 / 96);
+    return this.textFont.pointsToPixels;
   }
 
   get superscriptOffset() {
@@ -395,6 +380,15 @@ export class ChordSymbol extends Modifier {
 
   get subscriptOffset() {
     return ChordSymbol.subscriptOffset * this.pointsToPixels;
+  }
+
+  setReportWidth(value) {
+    this.reportWidth = value;
+    return this;
+  }
+
+  getReportWidth() {
+    return this.reportWidth;
   }
 
   updateOverBarAdjustments() {
@@ -512,7 +506,7 @@ export class ChordSymbol extends Modifier {
     } else if (symbolType === ChordSymbol.symbolTypes.TEXT) {
       let twidth = 0;
       for (let i = 0; i < rv.text.length; ++i) {
-        twidth += ChordSymbol.getWidthForCharacter(rv.text[i]);
+        twidth += this.getWidthForCharacter(rv.text[i]);
       }
       rv.width = twidth;
     } else if (symbolType === ChordSymbol.symbolTypes.LINE) {
@@ -610,11 +604,13 @@ export class ChordSymbol extends Modifier {
   // Set font family, size, and weight. E.g., `Arial`, `10pt`, `Bold`.
   setFont(family, size, weight) {
     this.font = { family, size, weight };
+    this.textFont = TextFont.getTextFontFromVexFontData(this.font);
     return this;
   }
 
   setFontSize(size) {
     this.font.size = size;
+    this.textFont.setFontSize(size);
     return this;
   }
 

--- a/tests/chordsymbol_tests.js
+++ b/tests/chordsymbol_tests.js
@@ -42,20 +42,24 @@ VF.Test.ChordSymbol = (function() {
       var chords = [];
       chords.push(new VF.ChordSymbol()
         .addText('A')
-        .addGlyphSuperscript('dim'));
+        .addGlyphSuperscript('dim')
+        .setReportWidth(false));
 
       chords.push(new VF.ChordSymbol()
         .addText('A')
         .addGlyphSuperscript('dim')
-        .setEnableKerning(false));
+        .setEnableKerning(false)
+        .setReportWidth(false));
 
       chords.push(new VF.ChordSymbol()
         .setHorizontal('left').addText('C')
-        .addGlyph('halfDiminished', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT }));
+        .addGlyph('halfDiminished', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
+        .setReportWidth(false));
 
       chords.push(new VF.ChordSymbol()
         .setHorizontal('left').addText('D')
-        .addGlyph('halfDiminished', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT }));
+        .addGlyph('halfDiminished', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
+        .setReportWidth(false));
 
       draw(chords, 10);
 
@@ -142,10 +146,13 @@ VF.Test.ChordSymbol = (function() {
       }
 
       var chord1 = new VF.ChordSymbol().addText('F7').setHorizontal('left')
-        .addGlyphOrText('(#11b9)', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT });
+        .addGlyphOrText('(#11b9)', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
+        .setReportWidth(false);
       var chord2 = new VF.ChordSymbol()
         .addText('C').setHorizontal('left')
-        .addGlyphSuperscript('majorSeventh');
+        .addGlyphSuperscript('majorSeventh')
+        .setReportWidth(false);
+
       draw(chord1, chord2, 40);
 
       chord1 = new VF.ChordSymbol().addText('F7')
@@ -196,22 +203,26 @@ VF.Test.ChordSymbol = (function() {
         .addGlyphOrText('b9', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
         .addGlyphOrText('#11', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUBSCRIPT })
         .addGlyph('rightParenTall')
+        .setReportWidth(false)
       );
       chords.push(new VF.ChordSymbol().setFontSize(12).addText('F7')
         .addGlyphOrText('b9', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
         .addGlyphOrText('#11', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUBSCRIPT })
+        .setReportWidth(false)
       );
       chords.push(new VF.ChordSymbol().setFontSize(14).addText('F7')
         .addGlyph('leftParenTall')
         .addGlyphOrText('add 3', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
         .addGlyphOrText('omit 9', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUBSCRIPT })
         .addGlyph('rightParenTall')
+        .setReportWidth(false)
       );
       chords.push(new VF.ChordSymbol().setFontSize(16).addText('F7')
         .addGlyph('leftParenTall')
         .addGlyphOrText('b9', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
         .addGlyphOrText('#11', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUBSCRIPT })
         .addGlyph('rightParenTall')
+        .setReportWidth(false)
       );
       draw(chords, 40);
 


### PR DESCRIPTION
When there are a few chord symbols and many notes, it is often desirable to ignore the width of the chord symbol and let the music flow normally.
With `reportWidth = true:` (default)
![image](https://user-images.githubusercontent.com/5438280/105273515-0cd25b80-5b61-11eb-99de-f6c565ffb521.png)

With `reportWidth = false:`
![image](https://user-images.githubusercontent.com/5438280/105273601-43a87180-5b61-11eb-8a50-34630f0bacce.png)

This change also uses the new TextFont class for text font metrics, vs reading it from the text fonts directly like I originally did.
