### PR TITLE
fix new keyword mess

### DIFF
--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -300,7 +300,7 @@ VF.Test.Annotation = (function () {
     },
 
     tabNotes: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/articulation_tests.js
+++ b/tests/articulation_tests.js
@@ -273,7 +273,7 @@ VF.Test.Articulation = (function () {
     },
 
     tabNotes: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/bend_tests.js
+++ b/tests/bend_tests.js
@@ -15,7 +15,7 @@ VF.Test.Bend = (function () {
     },
 
     doubleBends: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -65,7 +65,7 @@ VF.Test.Bend = (function () {
     },
 
     doubleBendsWithRelease: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 550, 240);
+      var ctx = contextBuilder(options.elementId, 550, 240);
       ctx.scale(1.0, 1.0);
       ctx.setBackgroundFillStyle('#FFF');
       ctx.setFont('Arial', VF.Test.Font.size);
@@ -119,7 +119,7 @@ VF.Test.Bend = (function () {
     },
 
     reverseBends: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
 
       ctx.scale(1.5, 1.5);
       ctx.fillStyle = '#221';
@@ -179,7 +179,7 @@ VF.Test.Bend = (function () {
     },
 
     bendPhrase: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -226,7 +226,7 @@ VF.Test.Bend = (function () {
     },
 
     whackoBends: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 240);
+      var ctx = contextBuilder(options.elementId, 400, 240);
       ctx.scale(1.0, 1.0);
       ctx.setBackgroundFillStyle('#FFF');
       ctx.setFont('Arial', VF.Test.Font.size);

--- a/tests/dot_tests.js
+++ b/tests/dot_tests.js
@@ -38,7 +38,7 @@ VF.Test.Dot = (function () {
     },
 
     basic: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 1000, 240);
+      var ctx = contextBuilder(options.elementId, 1000, 240);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
 
@@ -106,7 +106,7 @@ VF.Test.Dot = (function () {
     },
 
     multiVoice: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 750, 300);
+      var ctx = contextBuilder(options.elementId, 750, 300);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
 

--- a/tests/gracenote_tests.js
+++ b/tests/gracenote_tests.js
@@ -175,7 +175,7 @@ VF.Test.GraceNote = (function () {
       voice.addTickables(createNoteBlock(['g/4'], 1));
       voice.addTickables(createNoteBlock(['d/5'], -1));
 
-      new vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+      vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
       vf.draw();
 
@@ -220,7 +220,7 @@ VF.Test.GraceNote = (function () {
       voice.addTickables(createBeamdNoteBlock(['g/4'], 1, beams));
       voice.addTickables(createBeamdNoteBlock(['d/5'], -1, beams));
 
-      new vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+      vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
       vf.draw();
 
@@ -275,7 +275,7 @@ VF.Test.GraceNote = (function () {
       voice.addTickables(createNoteBlock(['d/4', 'a/4'], 1));
       voice.addTickables(createNoteBlock(['d/4', 'a/4'], -1));
 
-      new vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+      vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
       vf.draw();
 
@@ -323,7 +323,7 @@ VF.Test.GraceNote = (function () {
       voice.addTickables(createNoteBlock(['d/4', 'a/4'], 1));
       voice.addTickables(createNoteBlock(['d/4', 'a/4'], -1));
 
-      new vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+      vf.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
       vf.draw();
 
@@ -388,7 +388,7 @@ VF.Test.GraceNote = (function () {
       vf.Beam({ notes: notes2.slice(0, 4) });
       vf.Beam({ notes: notes2.slice(4, 8) });
 
-      new VF.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
+      vf.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
 
       vf.draw();
 
@@ -453,7 +453,7 @@ VF.Test.GraceNote = (function () {
       vf.Beam({ notes: notes2.slice(0, 4) });
       vf.Beam({ notes: notes2.slice(4, 8) });
 
-      new VF.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
+      vf.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
 
       vf.draw();
       vf.draw();

--- a/tests/key_clef_tests.js
+++ b/tests/key_clef_tests.js
@@ -65,7 +65,7 @@ VF.Test.ClefKeySignature = (function () {
         'percussion',
       ];
 
-      var ctx = new contextBuilder(options.elementId, 400, 20 + 80 * 2 * clefs.length);
+      var ctx = contextBuilder(options.elementId, 400, 20 + 80 * 2 * clefs.length);
       var staves = [];
       var keys = options.params.majorKeys ? VF.Test.ClefKeySignature.MAJOR_KEYS : VF.Test.ClefKeySignature.MINOR_KEYS;
 
@@ -102,7 +102,7 @@ VF.Test.ClefKeySignature = (function () {
     },
 
     staveHelper: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 400);
+      var ctx = contextBuilder(options.elementId, 400, 400);
       var stave = new VF.Stave(10, 10, 370);
       var stave2 = new VF.Stave(10, 90, 370);
       var stave3 = new VF.Stave(10, 170, 370);

--- a/tests/keysignature_tests.js
+++ b/tests/keysignature_tests.js
@@ -56,7 +56,7 @@ VF.Test.KeySignature = (function () {
     },
 
     majorKeys: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 240);
+      var ctx = contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MAJOR_KEYS;
@@ -81,7 +81,7 @@ VF.Test.KeySignature = (function () {
     },
 
     majorKeysCanceled: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 780, 500);
+      var ctx = contextBuilder(options.elementId, 780, 500);
       ctx.scale(0.9, 0.9);
       var stave = new VF.Stave(10, 10, 750).addTrebleGlyph();
       var stave2 = new VF.Stave(10, 90, 750).addTrebleGlyph();
@@ -135,7 +135,7 @@ VF.Test.KeySignature = (function () {
     },
 
     keysCanceledForEachClef: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 380);
+      var ctx = contextBuilder(options.elementId, 600, 380);
       ctx.scale(0.8, 0.8);
       var keys = ['C#', 'Cb'];
 
@@ -161,7 +161,7 @@ VF.Test.KeySignature = (function () {
     },
 
     majorKeysAltered: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 780, 500);
+      var ctx = contextBuilder(options.elementId, 780, 500);
       ctx.scale(0.9, 0.9);
       var stave = new VF.Stave(10, 10, 750).addTrebleGlyph();
       var stave2 = new VF.Stave(10, 90, 750).addTrebleGlyph();
@@ -213,7 +213,7 @@ VF.Test.KeySignature = (function () {
     },
 
     minorKeys: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 240);
+      var ctx = contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MINOR_KEYS;
@@ -237,7 +237,7 @@ VF.Test.KeySignature = (function () {
       ok(true, 'all pass');
     },
     endKeyWithClef: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 200);
+      var ctx = contextBuilder(options.elementId, 400, 200);
       ctx.scale(0.9, 0.9);
       var stave1 = new VF.Stave(10, 10, 350);
       stave1
@@ -257,7 +257,7 @@ VF.Test.KeySignature = (function () {
     },
 
     staveHelper: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 240);
+      var ctx = contextBuilder(options.elementId, 400, 240);
       var stave = new VF.Stave(10, 10, 350);
       var stave2 = new VF.Stave(10, 90, 350);
       var keys = VF.Test.KeySignature.MAJOR_KEYS;

--- a/tests/notehead_tests.js
+++ b/tests/notehead_tests.js
@@ -14,7 +14,7 @@ VF.Test.NoteHead = (function () {
     },
 
     setupContext: function (options, x, y) {
-      var ctx = new options.contextBuilder(options.elementId, x || 450, y || 140);
+      var ctx = options.contextBuilder(options.elementId, x || 450, y || 140);
       ctx.scale(0.9, 0.9);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -97,7 +97,7 @@ VF.Test.NoteHead = (function () {
         { keys: ['g/5/r2'], duration: '4' },
       ];
 
-      var ctx = new contextBuilder(options.elementId, notes.length * 25 + 100, 240);
+      var ctx = contextBuilder(options.elementId, notes.length * 25 + 100, 240);
 
       // Draw two staves, one with up-stems and one with down-stems.
       for (var h = 0; h < 2; ++h) {
@@ -138,7 +138,7 @@ VF.Test.NoteHead = (function () {
         { keys: ['a/4/r2', 'g/5/t3'], duration: '4' },
       ];
 
-      var ctx = new contextBuilder(options.elementId, notes.length * 25 + 100, 240);
+      var ctx = contextBuilder(options.elementId, notes.length * 25 + 100, 240);
 
       // Draw two staves, one with up-stems and one with down-stems.
       for (var h = 0; h < 2; ++h) {

--- a/tests/percussion_tests.js
+++ b/tests/percussion_tests.js
@@ -188,7 +188,7 @@ VF.Test.Percussion = (function () {
     },
 
     draw: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
 
       new VF.Stave(10, 10, 300).addClef('percussion').setContext(ctx).draw();
 
@@ -215,7 +215,7 @@ VF.Test.Percussion = (function () {
         { keys: ['g/5/x3'], duration: '4' },
       ];
 
-      var ctx = new contextBuilder(options.elementId, notes.length * 25 + 100, 240);
+      var ctx = contextBuilder(options.elementId, notes.length * 25 + 100, 240);
 
       // Draw two staves, one with up-stems and one with down-stems.
       for (var h = 0; h < 2; ++h) {

--- a/tests/rests_tests.js
+++ b/tests/rests_tests.js
@@ -22,7 +22,7 @@ VF.Test.Rests = (function () {
     },
 
     setupContext: function (options, contextBuilder, x, y) {
-      var ctx = new contextBuilder(options.elementId, x || 350, y || 150);
+      var ctx = contextBuilder(options.elementId, x || 350, y || 150);
       ctx.scale(0.9, 0.9);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -294,7 +294,7 @@ VF.Test.Rests = (function () {
     },
 
     multi: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
 
       var stave = new VF.Stave(50, 10, 500).addClef('treble').setContext(ctx).addTimeSignature('4/4').draw();
 

--- a/tests/rhythm_tests.js
+++ b/tests/rhythm_tests.js
@@ -16,7 +16,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawSlash: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 350, 180);
+      var ctx = contextBuilder(options.elementId, 350, 180);
       var stave = new VF.Stave(10, 10, 350);
       stave.setContext(ctx);
       stave.draw();
@@ -43,7 +43,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawBasic: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 150);
@@ -159,7 +159,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawBeamedSlashNotes: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -233,7 +233,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawSlashAndBeamAndRests: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -318,7 +318,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawSixtenthWithScratches: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);
@@ -393,7 +393,7 @@ VF.Test.Rhythm = (function () {
     },
 
     drawThirtySecondWithScratches: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
 
       // bar 1
       var staveBar1 = new VF.Stave(10, 30, 300);

--- a/tests/stave_tests.js
+++ b/tests/stave_tests.js
@@ -86,7 +86,7 @@ VF.Test.Stave = (function () {
     },
 
     draw: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 150);
+      var ctx = contextBuilder(options.elementId, 400, 150);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();
@@ -100,7 +100,7 @@ VF.Test.Stave = (function () {
     },
 
     drawOpenStave: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 350);
+      var ctx = contextBuilder(options.elementId, 400, 350);
       var stave = new VF.Stave(10, 10, 300, { left_bar: false });
       stave.setContext(ctx);
       stave.draw();
@@ -670,7 +670,7 @@ VF.Test.Stave = (function () {
     },
 
     configureSingleLine: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave
         .setConfigForLine(0, { visible: true })
@@ -691,7 +691,7 @@ VF.Test.Stave = (function () {
     },
 
     configureAllLines: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave
         .setConfigForLines([{ visible: false }, null, { visible: false }, { visible: true }, { visible: false }])
@@ -709,7 +709,7 @@ VF.Test.Stave = (function () {
     },
 
     drawStaveText: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 900, 140);
+      var ctx = contextBuilder(options.elementId, 900, 140);
       var stave = new VF.Stave(300, 10, 300);
       stave.setText('Violin', VF.Modifier.Position.LEFT);
       stave.setText('Right Text', VF.Modifier.Position.RIGHT);
@@ -721,7 +721,7 @@ VF.Test.Stave = (function () {
     },
 
     drawStaveTextMultiLine: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 900, 200);
+      var ctx = contextBuilder(options.elementId, 900, 200);
       var stave = new VF.Stave(300, 40, 300);
       stave.setText('Violin', VF.Modifier.Position.LEFT, { shift_y: -10 });
       stave.setText('2nd line', VF.Modifier.Position.LEFT, { shift_y: 10 });

--- a/tests/staveconnector_tests.js
+++ b/tests/staveconnector_tests.js
@@ -25,7 +25,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawSingle: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -42,7 +42,7 @@ VF.Test.StaveConnector = (function () {
 
     drawSingle1pxBarlines: function (options, contextBuilder) {
       VF.STAVE_LINE_THICKNESS = 1;
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -59,7 +59,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawSingleBoth: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -79,7 +79,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawDouble: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -100,7 +100,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawBrace: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 450, 300);
+      var ctx = contextBuilder(options.elementId, 450, 300);
       var stave = new VF.Stave(100, 10, 300);
       var stave2 = new VF.Stave(100, 120, 300);
       stave.setContext(ctx);
@@ -122,7 +122,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawBraceWide: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, -20, 300);
       var stave2 = new VF.Stave(25, 200, 300);
       stave.setContext(ctx);
@@ -143,7 +143,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawBracket: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -164,7 +164,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawRepeatBegin: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -183,7 +183,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawRepeatEnd: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -202,7 +202,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawThinDouble: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 300);
       var stave2 = new VF.Stave(25, 120, 300);
       stave.setContext(ctx);
@@ -221,7 +221,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawRepeatAdjacent: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(175, 10, 150);
@@ -265,7 +265,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawRepeatOffset2: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(175, 10, 150);
@@ -330,7 +330,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawRepeatOffset: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 300);
+      var ctx = contextBuilder(options.elementId, 400, 300);
       var stave = new VF.Stave(25, 10, 150);
       var stave2 = new VF.Stave(25, 120, 150);
       var stave3 = new VF.Stave(185, 10, 150);
@@ -398,7 +398,7 @@ VF.Test.StaveConnector = (function () {
     },
 
     drawCombined: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 550, 700);
+      var ctx = contextBuilder(options.elementId, 550, 700);
       var stave = new VF.Stave(150, 10, 300);
       var stave2 = new VF.Stave(150, 100, 300);
       var stave3 = new VF.Stave(150, 190, 300);

--- a/tests/stavemodifier_tests.js
+++ b/tests/stavemodifier_tests.js
@@ -13,7 +13,7 @@ VF.Test.StaveModifier = (function () {
     },
 
     draw: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 120);
+      var ctx = contextBuilder(options.elementId, 400, 120);
       var stave = new VF.Stave(10, 10, 300);
       stave.setContext(ctx);
       stave.draw();

--- a/tests/stavenote_tests.js
+++ b/tests/stavenote_tests.js
@@ -317,7 +317,7 @@ VF.Test.StaveNote = (function () {
       var octaveShift = options.params.octaveShift;
       var restKey = options.params.restKey;
 
-      var ctx = new contextBuilder(options.elementId, 700, 180);
+      var ctx = contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 30, 750);
       stave.setContext(ctx);
       stave.addClef(clef);
@@ -396,7 +396,7 @@ VF.Test.StaveNote = (function () {
       var octaveShift = options.params.octaveShift;
       var restKey = options.params.restKey;
 
-      var ctx = new contextBuilder(options.elementId, 700, 180);
+      var ctx = contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 30, 750);
       stave.setContext(ctx);
       stave.addClef(clef);
@@ -456,7 +456,7 @@ VF.Test.StaveNote = (function () {
 
     drawBass: function (options, contextBuilder) {
       expect(40);
-      var ctx = new contextBuilder(options.elementId, 600, 280);
+      var ctx = contextBuilder(options.elementId, 600, 280);
       var stave = new VF.Stave(10, 10, 650);
       stave.setContext(ctx);
       stave.addClef('bass');
@@ -497,7 +497,7 @@ VF.Test.StaveNote = (function () {
     },
 
     displacements: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 700, 140);
+      var ctx = contextBuilder(options.elementId, 700, 140);
       ctx.scale(0.9, 0.9);
       ctx.fillStyle = '#221';
       ctx.strokeStyle = '#221';
@@ -539,7 +539,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawHarmonicAndMuted: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 1000, 180);
+      var ctx = contextBuilder(options.elementId, 1000, 180);
       var stave = new VF.Stave(10, 10, 950);
       stave.setContext(ctx);
       stave.draw();
@@ -596,7 +596,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawSlash: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 700, 180);
+      var ctx = contextBuilder(options.elementId, 700, 180);
       var stave = new VF.Stave(10, 10, 650);
       stave.setContext(ctx);
       stave.draw();
@@ -644,7 +644,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawKeyStyles: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var ctx = contextBuilder(options.elementId, 300, 280);
       ctx.scale(3, 3);
 
       var stave = new VF.Stave(10, 0, 100);
@@ -664,7 +664,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawNoteStyles: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var ctx = contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
       ctx.scale(3, 3);
 
@@ -684,7 +684,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawNoteStemStyles: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var ctx = contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
       ctx.scale(3, 3);
 
@@ -703,7 +703,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawNoteStemLengths: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 975, 150);
+      var ctx = contextBuilder(options.elementId, 975, 150);
       var stave = new VF.Stave(10, 10, 975);
       stave.setContext(ctx).draw();
 
@@ -761,7 +761,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawNoteStylesWithFlag: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 300, 280);
+      var ctx = contextBuilder(options.elementId, 300, 280);
       var stave = new VF.Stave(10, 0, 100);
       ctx.scale(3, 3);
 
@@ -781,7 +781,7 @@ VF.Test.StaveNote = (function () {
     },
 
     drawBeamStyles: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 160);
+      var ctx = contextBuilder(options.elementId, 400, 160);
       var stave = new VF.Stave(10, 10, 380);
       stave.setStyle({
         strokeStyle: '#EEAAEE',
@@ -872,7 +872,7 @@ VF.Test.StaveNote = (function () {
     },
 
     dotsAndFlagsStemUp: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -912,7 +912,7 @@ VF.Test.StaveNote = (function () {
     },
 
     dotsAndFlagsStemDown: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 160);
+      var ctx = contextBuilder(options.elementId, 800, 160);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -948,7 +948,7 @@ VF.Test.StaveNote = (function () {
     },
 
     dotsAndBeamsUp: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 150);
+      var ctx = contextBuilder(options.elementId, 800, 150);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');
@@ -990,7 +990,7 @@ VF.Test.StaveNote = (function () {
     },
 
     dotsAndBeamsDown: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 800, 160);
+      var ctx = contextBuilder(options.elementId, 800, 160);
       ctx.scale(1.0, 1.0);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');

--- a/tests/tabnote_tests.js
+++ b/tests/tabnote_tests.js
@@ -97,7 +97,7 @@ VF.Test.TabNote = (function () {
     },
 
     draw: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 140);
+      var ctx = contextBuilder(options.elementId, 600, 140);
 
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
@@ -165,7 +165,7 @@ VF.Test.TabNote = (function () {
     },
 
     drawStemsUp: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 30, 550);
       stave.setContext(ctx);
@@ -237,7 +237,7 @@ VF.Test.TabNote = (function () {
     },
 
     drawStemsDown: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
 
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
@@ -311,7 +311,7 @@ VF.Test.TabNote = (function () {
     },
 
     drawStemsUpThrough: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 30, 550);
       stave.setContext(ctx);
@@ -385,7 +385,7 @@ VF.Test.TabNote = (function () {
     },
 
     drawStemsDownThrough: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 250);
+      var ctx = contextBuilder(options.elementId, 600, 250);
 
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550, { num_lines: 8 });
@@ -465,7 +465,7 @@ VF.Test.TabNote = (function () {
     },
 
     drawStemsDotted: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 600, 200);
+      var ctx = contextBuilder(options.elementId, 600, 200);
       ctx.font = '10pt Arial';
       var stave = new VF.TabStave(10, 10, 550);
       stave.setContext(ctx);

--- a/tests/tabstave_tests.js
+++ b/tests/tabstave_tests.js
@@ -12,7 +12,7 @@ VF.Test.TabStave = (function () {
     },
 
     draw: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 160);
+      var ctx = contextBuilder(options.elementId, 400, 160);
       var stave = new VF.TabStave(10, 10, 300);
       stave.setNumLines(6);
       stave.setContext(ctx);
@@ -27,7 +27,7 @@ VF.Test.TabStave = (function () {
     },
 
     drawVerticalBar: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 400, 160);
+      var ctx = contextBuilder(options.elementId, 400, 160);
       var stave = new VF.TabStave(10, 10, 300);
       stave.setNumLines(6);
       stave.setContext(ctx);

--- a/tests/timesignature_tests.js
+++ b/tests/timesignature_tests.js
@@ -30,7 +30,7 @@ VF.Test.TimeSignature = (function () {
       var run = VF.Test.runTests;
 
       run('Basic Time Signatures', function (options, contextBuilder) {
-        var ctx = new contextBuilder(options.elementId, 600, 120);
+        var ctx = contextBuilder(options.elementId, 600, 120);
 
         new VF.Stave(10, 10, 500)
           .addTimeSignature('2/2')
@@ -53,7 +53,7 @@ VF.Test.TimeSignature = (function () {
       });
 
       run('Big Signature Test', function (options, contextBuilder) {
-        var ctx = new contextBuilder(options.elementId, 400, 120);
+        var ctx = contextBuilder(options.elementId, 400, 120);
 
         new VF.Stave(10, 10, 300)
           .addTimeSignature('12/8')
@@ -67,7 +67,7 @@ VF.Test.TimeSignature = (function () {
       });
 
       run('Time Signature multiple staves alignment test', function (options, contextBuilder) {
-        var ctx = new contextBuilder(options.elementId, 400, 350);
+        var ctx = contextBuilder(options.elementId, 400, 350);
 
         var stave = new VF.Stave(15, 0, 300)
           .setConfigForLines(

--- a/tests/vibrato_tests.js
+++ b/tests/vibrato_tests.js
@@ -14,7 +14,7 @@ VF.Test.Vibrato = (function () {
     },
 
     simple: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 140);
+      var ctx = contextBuilder(options.elementId, 500, 140);
 
       ctx.scale(1.5, 1.5);
       ctx.fillStyle = '#221';
@@ -48,7 +48,7 @@ VF.Test.Vibrato = (function () {
     },
 
     harsh: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
 
       ctx.scale(1.5, 1.5);
       ctx.fillStyle = '#221';
@@ -82,7 +82,7 @@ VF.Test.Vibrato = (function () {
     },
 
     withBend: function (options, contextBuilder) {
-      var ctx = new contextBuilder(options.elementId, 500, 240);
+      var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.3, 1.3);
       ctx.setFillStyle('#221');
       ctx.setStrokeStyle('#221');


### PR DESCRIPTION
This PR fixes new keyword mess:
```typescript
// new keyword is not needed. contextBuilder is just a function, not a constructor
var ctx = contextBuilder(options.elementId, 600, 200); 

// new keyword is not needed. Formatter() is just a factory method in Factory class, not a constructor
var vf = VF.Test.makeFactory(options, 300);
vf.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave); 
```
@0xfe I ask for a quick review. It is a really straightforward and small PR, but it will help me to continue my work on ts migration