### PR TITLE
Fix small issue where parts of the stem are visible around the note head. This patch affects the Bravura font.

### DIFF
--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -145,7 +145,12 @@ export const BravuraMetrics = {
         offsetYBaseStemUp: -4,
         offsetYBaseStemDown: 4,
       },
+      noteheadHalf: {
+        offsetYBaseStemUp: -2.5,
+        offsetYBaseStemDown: 2.6,
+      },
       noteheadBlack: {
+        offsetYBaseStemUp: -2,
         offsetYBaseStemDown: 2,
       },
       noteheadSquareWhite: {


### PR DESCRIPTION
The visual diffs are very minimal, and only noticeable at context scale 2 or higher.

However, I did notice one visual diff that is noticeable at 1x scale. Since the `Annotation.TabNote_Annotations` test does not include round note heads, it is more obvious that the height of the note stems has changed. Please see images below. Perhaps this is something that would require a special case, to make sure **stems without note heads** have identical heights whether they are going up or down.

![Annotation TabNote_Annotations_Current](https://user-images.githubusercontent.com/239113/115804902-c4614e80-a398-11eb-8618-2b62c48fb12f.png)

![Annotation TabNote_Annotations_Reference](https://user-images.githubusercontent.com/239113/115804907-c4f9e500-a398-11eb-80f9-6880638315eb.png)

![Annotation TabNote_Annotations](https://user-images.githubusercontent.com/239113/115804908-c4f9e500-a398-11eb-87da-bd9fa7cdb3c4.png)
