### PR TITLE
Test All Fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lint": "grunt eslint",
     "qunit": "grunt test",
     "generate:current": "node ./tools/generate_png_images.js ../build ./build/images/current",
+    "generate:current:all-fonts": "node ./tools/generate_png_images.js ../build ./build/images/current --fonts=all",
     "generate:reference": "node ./tools/generate_png_images.js ../reference ./build/images/reference",
     "generate:blessed": "node ./tools/generate_png_images.js ../releases ./build/images/blessed",
     "generate": "npm run generate:current && npm run generate:blessed",

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -52,8 +52,6 @@ if (!global.QUnit) {
 
 global['VF'] = Vex.Flow;
 VF.Test = (function () {
-  var DEFAULT_FONTS_TO_TEST = [VF.Fonts.Bravura, VF.Fonts.Gonville, VF.Fonts.Petaluma];
-
   var Test = {
     // Test Options.
     RUN_CANVAS_TESTS: true,
@@ -67,8 +65,8 @@ VF.Test = (function () {
     // Default font properties for tests.
     Font: { size: 10 },
 
-    // Test all three fonts by default. Customize the FONTS_TO_TEST array to test fewer fonts.
-    FONTS_TO_TEST: DEFAULT_FONTS_TO_TEST,
+    // Customize this array to test more fonts (e.g., ['Bravura', 'Gonville', 'Petaluma']).
+    FONT_STACKS_TO_TEST: ['Bravura'],
 
     FONT_STACKS: {
       Bravura: [VF.Fonts.Bravura, VF.Fonts.Gonville, VF.Fonts.Custom],
@@ -242,7 +240,16 @@ VF.Test = (function () {
         if (VF.Renderer.lastContext !== null) {
           var moduleName = sanitizeName(QUnit.current_module);
           var testName = sanitizeName(QUnit.current_test);
-          var fileName = `${VF.Test.NODE_IMAGEDIR}/${moduleName}.${testName}.${fontName}.png`;
+          var fileName;
+          if (fontName === 'Bravura' && VF.Test.FONT_STACKS_TO_TEST.length === 1) {
+            // If we are only testing Bravura, we do not add the font name
+            // to the output image file's name, which allows visual diffs against
+            // the previous release: version 3.0.9. In the future, if we decide
+            // to test all fonts by default, we can remove this check.
+            fileName = `${VF.Test.NODE_IMAGEDIR}/${moduleName}.${testName}.png`;
+          } else {
+            fileName = `${VF.Test.NODE_IMAGEDIR}/${moduleName}.${testName}.${fontName}.png`;
+          }
 
           var imageData = canvas.toDataURL().split(';base64,').pop();
           var image = Buffer.from(imageData, 'base64');
@@ -254,14 +261,10 @@ VF.Test = (function () {
       VF.Test.runTestWithFonts(name, testFunc);
     },
 
-    // Run QUnit.test() for each font that is included in VF.Test.FONTS_TO_TEST.
+    // Run QUnit.test() for each font that is included in VF.Test.FONT_STACKS_TO_TEST.
     runTestWithFonts: function (name, func) {
-      if (!Array.isArray(VF.Test.FONTS_TO_TEST)) {
-        VF.Test.FONTS_TO_TEST = DEFAULT_FONTS_TO_TEST;
-      }
-
-      VF.Test.FONTS_TO_TEST.forEach((font) => {
-        QUnit.test(name, func(font.getName()));
+      VF.Test.FONT_STACKS_TO_TEST.forEach((fontName) => {
+        QUnit.test(name, func(fontName));
       });
     },
 

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -52,6 +52,8 @@ if (!global.QUnit) {
 
 global['VF'] = Vex.Flow;
 VF.Test = (function () {
+  var DEFAULT_FONTS_TO_TEST = [VF.Fonts.Bravura, VF.Fonts.Gonville, VF.Fonts.Petaluma];
+
   var Test = {
     // Test Options.
     RUN_CANVAS_TESTS: true,
@@ -64,6 +66,9 @@ VF.Test = (function () {
 
     // Default font properties for tests.
     Font: { size: 10 },
+
+    // Test all three fonts by default. Customize the FONTS_TO_TEST array to test fewer fonts.
+    FONTS_TO_TEST: DEFAULT_FONTS_TO_TEST,
 
     FONT_STACKS: {
       Bravura: [VF.Fonts.Bravura, VF.Fonts.Gonville, VF.Fonts.Custom],
@@ -203,9 +208,7 @@ VF.Test = (function () {
         VF.DEFAULT_FONT_STACK = defaultFontStack;
       };
 
-      QUnit.test(name, testFunc('Bravura'));
-      QUnit.test(name, testFunc('Gonville'));
-      QUnit.test(name, testFunc('Petaluma'));
+      VF.Test.runTestWithFonts(name, testFunc);
     },
 
     runNodeTest: function (name, func, params) {
@@ -248,9 +251,18 @@ VF.Test = (function () {
         }
       };
 
-      QUnit.test(name, testFunc('Bravura'));
-      QUnit.test(name, testFunc('Gonville'));
-      QUnit.test(name, testFunc('Petaluma'));
+      VF.Test.runTestWithFonts(name, testFunc);
+    },
+
+    // Run QUnit.test() for each font that is included in VF.Test.FONTS_TO_TEST.
+    runTestWithFonts: function (name, func) {
+      if (!Array.isArray(VF.Test.FONTS_TO_TEST)) {
+        VF.Test.FONTS_TO_TEST = DEFAULT_FONTS_TO_TEST;
+      }
+
+      VF.Test.FONTS_TO_TEST.forEach((font) => {
+        QUnit.test(name, func(font.getName()));
+      });
     },
 
     plotNoteWidth: VF.Note.plotMetrics,

--- a/tools/generate_png_images.js
+++ b/tools/generate_png_images.js
@@ -31,6 +31,13 @@ VF.Test.RUN_RAPHAEL_TESTS = false;
 VF.Test.RUN_NODE_TESTS = true;
 VF.Test.NODE_IMAGEDIR = imageDir;
 
+// By default we test all fonts.
+// Modify VF.Test.FONTS_TO_TEST to test fewer fonts at a time.
+// In the future, we can allow customization via process.argv.
+// VF.Test.FONTS_TO_TEST = [VF.Fonts.Petaluma];
+// VF.Test.FONTS_TO_TEST = [VF.Fonts.Gonville];
+// VF.Test.FONTS_TO_TEST = [VF.Fonts.Bravura];
+
 // Create the image directory if it doesn't exist.
 fs.mkdirSync(VF.Test.NODE_IMAGEDIR, { recursive: true });
 

--- a/tools/generate_png_images.js
+++ b/tools/generate_png_images.js
@@ -13,6 +13,24 @@ document = dom.window.document;
 const fs = require('fs');
 const [scriptDir, imageDir] = process.argv.slice(2, 4);
 
+// Optional: 3rd argument specifies which font stacks to test.
+// For example: 
+//   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=all
+//   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=petaluma
+//   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=bravura,gonville
+let fontStacksToTest = ['Bravura'];
+if (process.argv.length >= 5) {
+  const fontsOption = process.argv[4].toLowerCase();
+  if (fontsOption.startsWith('--fonts=')) {
+    const fontsList = fontsOption.split('=')[1].split(',');
+    if (fontsList.includes('all')) {
+      fontStacksToTest = ['Bravura', 'Petaluma', 'Gonville'];
+    } else {
+      fontStacksToTest = fontsList.map((fontName) => fontName.charAt(0).toUpperCase() + fontName.slice(1));
+    }
+  }
+}
+
 global['Vex'] = require(`${scriptDir}/vexflow-debug.js`);
 
 require(`${scriptDir}/vexflow-tests.js`);
@@ -30,13 +48,7 @@ VF.Test.RUN_SVG_TESTS = false;
 VF.Test.RUN_RAPHAEL_TESTS = false;
 VF.Test.RUN_NODE_TESTS = true;
 VF.Test.NODE_IMAGEDIR = imageDir;
-
-// By default we test all fonts.
-// Modify VF.Test.FONTS_TO_TEST to test fewer fonts at a time.
-// In the future, we can allow customization via process.argv.
-// VF.Test.FONTS_TO_TEST = [VF.Fonts.Petaluma];
-// VF.Test.FONTS_TO_TEST = [VF.Fonts.Gonville];
-// VF.Test.FONTS_TO_TEST = [VF.Fonts.Bravura];
+VF.Test.FONT_STACKS_TO_TEST = fontStacksToTest;
 
 // Create the image directory if it doesn't exist.
 fs.mkdirSync(VF.Test.NODE_IMAGEDIR, { recursive: true });

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -15,7 +15,7 @@
 #
 #  Run the regression tests against the reference or blessed images in tests/blessed.
 #
-#    $ ./tools/visual_regression.js (reference|blessed) [test_prefix]
+#    $ ./tools/visual_regression.sh (reference|blessed) [test_prefix]
 #
 #  Check build/images/diff/results.txt for results. This file is sorted
 #  by PHASH difference (most different files on top.) The composite diff
@@ -52,7 +52,7 @@ then
   BNAME=Current
   DIFF=$BASE/build/images/diff
 else
-  echo >&2 "Usage: visual_regresion.sh (reference|blessed) [test_prefix]"; exit 1;
+  echo >&2 "Usage: visual_regression.sh (reference|blessed) [test_prefix]"; exit 1;
 fi
 
 # All results are stored here.


### PR DESCRIPTION
This change allows us to render visual diff images for all three fonts.

runNodeTest() now tests all three fonts, and outputs images files with names like:
```
  Accidental.Basic.Bravura.png
  Accidental.Basic.Gonville.png
  Accidental.Basic.Petaluma.png
  ...
  Vibrato.Harsh_Vibrato.Bravura.png
  Vibrato.Harsh_Vibrato.Gonville.png
  Vibrato.Harsh_Vibrato.Petaluma.png
```
This allows us to tweak individual fonts and use `npm run test:reference` to see the changes via visual diff.