### PR TITLE
Update 'grunt watch' to watch src/ and tests/ concurrently.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,12 +82,24 @@ module.exports = (grunt) => {
       build: webpackProd,
       buildDev: webpackDev,
       buildTest: webpackTest,
-      watch: {
+      watchDev: {
         ...webpackDev,
         watch: true,
         keepalive: true,
         failOnError: false,
       },
+      watchTest: {
+        ...webpackTest,
+        watch: true,
+        keepalive: true,
+        failOnError: false,
+      },
+    },
+    concurrent: {
+      options: {
+        logConcurrentOutput: true,
+      },
+      tasks: ['webpack:watchDev', 'webpack:watchTest'],
     },
     eslint: {
       target: SOURCES.concat('./tests'),
@@ -95,15 +107,6 @@ module.exports = (grunt) => {
     },
     qunit: {
       files: ['tests/flow.html'],
-    },
-    watch: {
-      tests: {
-        files: ['tests/*', 'src/*'],
-        tasks: ['concat:tests'],
-        options: {
-          interrupt: true,
-        },
-      },
     },
     copy: {
       release: {
@@ -140,8 +143,8 @@ module.exports = (grunt) => {
           out: 'build/typedocs',
           name: 'vexflow',
         },
-        src: ['./typedoc.ts']
-      }
+        src: ['./typedoc.ts'],
+      },
     },
     gitcommit: {
       releases: {
@@ -178,7 +181,6 @@ module.exports = (grunt) => {
 
   // Load the plugin that provides the "uglify" task.
   grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-qunit');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-clean');
@@ -189,9 +191,19 @@ module.exports = (grunt) => {
   grunt.loadNpmTasks('grunt-git');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-webpack');
+  grunt.loadNpmTasks('grunt-concurrent');
 
   // Default task(s).
-  grunt.registerTask('default', ['clean', 'eslint', 'webpack:build', 'webpack:buildDev', 'webpack:buildTest', 'docco', 'typedoc']);
+  grunt.registerTask('default', [
+    'clean',
+    'eslint',
+    'webpack:build',
+    'webpack:buildDev',
+    'webpack:buildTest',
+    'docco',
+    'typedoc',
+  ]);
+  grunt.registerTask('watch', 'Watch src/ and tests/ concurrently', ['clean', 'eslint', 'concurrent']);
   grunt.registerTask('test', 'Run qunit tests.', [
     'clean',
     'webpack:build',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt": "^1.0.4",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.4.1",
+    "grunt-concurrent": "^3.0.0",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",


### PR DESCRIPTION
It will trigger the correct webpack task when it notices a changed file.

This is an alternative to an earlier PR proposal: https://github.com/0xfe/vexflow/pull/961

I actually prefer this PR, because it updates 'grunt watch' to use the webpack tasks, so it handles TypeScript files gracefully.

I decided to not include the `package-lock.json` in the PR, so that the diff is easy to understand.

If Mohit decides to merge, he can do a npm install on his machine and then check in the new `package-lock.json`.

I've tested this version and am happy with it. I drag flow.html into my local browser, and edit either src/* files or tests/* files and it recompiles quickly. Then I just CMD+R my browser to run the tests again.