### PR TITLE
migration/no-non-null-assertion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,6 @@
       ],
       "rules": {
         "@typescript-eslint/no-inferrable-types": "off",
-        "@typescript-eslint/no-non-null-assertion": "off"
       }
     },
     {

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -20,8 +20,7 @@ export interface ClefAnnotation {
 }
 
 export interface ClefType {
-  // eslint-disable-next-line
-  point?: any;
+  point?: number;
   code: string;
   line?: number;
 }
@@ -127,7 +126,7 @@ export class Clef extends StaveModifier {
       this.size = size;
     }
     this.clef.point = this.musicFont.lookupMetric(`clef.${this.size}.point`, 0);
-    this.glyph = new Glyph(this.clef.code, this.clef.point, {
+    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0, {
       category: `clef.${this.clef.code}.${this.size}`,
     });
 
@@ -141,7 +140,7 @@ export class Clef extends StaveModifier {
       this.annotation = { code, point, line, x_shift };
 
       this.attachment = new Glyph(this.annotation.code, this.annotation.point);
-      this.attachment.metrics!.x_max = 0;
+      this.attachment.metrics.x_max = 0;
       this.attachment.setXShift(this.annotation.x_shift);
     } else {
       this.annotation = undefined;

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -20,7 +20,7 @@ export interface ClefAnnotation {
 }
 
 export interface ClefType {
-  point?: number;
+  point: number;
   code: string;
   line?: number;
 }
@@ -54,49 +54,61 @@ export class Clef extends StaveModifier {
       treble: {
         code: 'gClef',
         line: 3,
+        point: 0,
       },
       bass: {
         code: 'fClef',
         line: 1,
+        point: 0,
       },
       alto: {
         code: 'cClef',
         line: 2,
+        point: 0,
       },
       tenor: {
         code: 'cClef',
         line: 1,
+        point: 0,
       },
       percussion: {
         code: 'restMaxima',
         line: 2,
+        point: 0,
       },
       soprano: {
         code: 'cClef',
         line: 4,
+        point: 0,
       },
       'mezzo-soprano': {
         code: 'cClef',
         line: 3,
+        point: 0,
       },
       'baritone-c': {
         code: 'cClef',
         line: 0,
+        point: 0,
       },
       'baritone-f': {
         code: 'fClef',
         line: 2,
+        point: 0,
       },
       subbass: {
         code: 'fClef',
         line: 0,
+        point: 0,
       },
       french: {
         code: 'gClef',
         line: 4,
+        point: 0,
       },
       tab: {
         code: '6stringTabClef',
+        point: 0,
       },
     };
   }
@@ -126,7 +138,7 @@ export class Clef extends StaveModifier {
       this.size = size;
     }
     this.clef.point = this.musicFont.lookupMetric(`clef.${this.size}.point`, 0);
-    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0, {
+    this.glyph = new Glyph(this.clef.code, this.clef.point, {
       category: `clef.${this.clef.code}.${this.size}`,
     });
 

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -28,7 +28,7 @@ export class ClefNote extends Note {
     this.type = type;
     this.clef_obj = new Clef(type, size, annotation);
     this.clef = this.clef_obj.clef;
-    this.glyph = new Glyph(this.clef.code, this.clef.point);
+    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0);
     this.setWidth(this.glyph.getMetrics().width);
 
     // Note properties
@@ -39,7 +39,7 @@ export class ClefNote extends Note {
     this.type = type;
     this.clef_obj = new Clef(type, size, annotation);
     this.clef = this.clef_obj.clef;
-    this.glyph = new Glyph(this.clef.code, this.clef.point);
+    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0);
     this.setWidth(this.glyph.getMetrics().width);
     return this;
   }

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -28,7 +28,7 @@ export class ClefNote extends Note {
     this.type = type;
     this.clef_obj = new Clef(type, size, annotation);
     this.clef = this.clef_obj.clef;
-    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0);
+    this.glyph = new Glyph(this.clef.code, this.clef.point);
     this.setWidth(this.glyph.getMetrics().width);
 
     // Note properties
@@ -39,7 +39,7 @@ export class ClefNote extends Note {
     this.type = type;
     this.clef_obj = new Clef(type, size, annotation);
     this.clef = this.clef_obj.clef;
-    this.glyph = new Glyph(this.clef.code, this.clef.point ?? 0);
+    this.glyph = new Glyph(this.clef.code, this.clef.point);
     this.setWidth(this.glyph.getMetrics().width);
     return this;
   }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,3 +1,12 @@
+import { Vex } from './vex';
+
+export function check<T>(x?: T): T {
+  if (x === undefined) {
+    throw new Vex.RERR('undefined');
+  }
+  return x;
+}
+
 //** TODO: Resolve duplication with Flow */
 export const GLYPH_PROPS_VALID_TYPES: Record<string, Record<string, string>> = {
   n: { name: 'note' },

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -54,9 +54,9 @@ export interface GlyphMetrics {
   x_shift: number;
   y_shift: number;
   scale: number;
-  ha?: number;
+  ha: number;
   outline: string[];
-  font?: Font;
+  font: Font;
 }
 
 function processOutline(
@@ -112,7 +112,9 @@ function processOutline(
 export class Glyph extends Element {
   bbox: BoundingBox = new BoundingBox(0, 0, 0, 0);
   code: string;
-  metrics?: GlyphMetrics;
+  // metrics is initialised in the constructor by either setOptions or reset
+  // eslint-disable-next-line
+  metrics!: GlyphMetrics; 
   topGlyphs: Glyph[] = [];
   botGlyphs: Glyph[] = [];
 
@@ -248,7 +250,7 @@ export class Glyph extends Element {
       });
     }
 
-    const scale = metrics.font ? (point * 72.0) / (metrics.font.getResolution() * 100.0) : 1;
+    const scale = (point * 72.0) / (metrics.font.getResolution() * 100.0);
 
     Glyph.renderOutline(ctx, metrics.outline, scale * metrics.scale, x_pos + metrics.x_shift, y_pos + metrics.y_shift);
     return metrics;
@@ -342,7 +344,7 @@ export class Glyph extends Element {
   reset(): void {
     this.metrics = Glyph.loadMetrics(this.options.fontStack, this.code, this.options.category);
     // Override point from metrics file
-    if (this.options.category && this.metrics?.font) {
+    if (this.options.category) {
       this.point = Glyph.lookupFontMetric({
         category: this.options.category,
         font: this.metrics.font,
@@ -352,7 +354,7 @@ export class Glyph extends Element {
       });
     }
 
-    this.scale = this.metrics?.font ? (this.point * 72) / (this.metrics.font.getResolution() * 100) : 1;
+    this.scale = (this.point * 72) / (this.metrics.font.getResolution() * 100);
     this.bbox = Glyph.getOutlineBoundingBox(
       this.metrics.outline,
       this.scale * this.metrics.scale,
@@ -375,6 +377,8 @@ export class Glyph extends Element {
       x_shift: this.metrics.x_shift,
       y_shift: this.metrics.y_shift,
       outline: this.metrics.outline,
+      font: this.metrics.font,
+      ha: this.metrics.ha,
     };
   }
 

--- a/src/multimeasurerest.js
+++ b/src/multimeasurerest.js
@@ -215,7 +215,7 @@ export class MultiMeasureRest extends Element {
 
     if (this.render_options.show_number) {
       const timeSpec = '/' + this.number_of_measures;
-      const timeSig = new TimeSignature(null, undefined, false);
+      const timeSig = new TimeSignature(timeSpec, 0, false);
       timeSig.point = this.render_options.number_glyph_point;
       timeSig.setTimeSig(timeSpec);
       timeSig.setStave(stave);

--- a/src/note.ts
+++ b/src/note.ts
@@ -39,7 +39,7 @@ export interface Metrics {
   modRightPx: number;
   /** Extra space on left of note. */
   leftDisplacedHeadPx: number;
-  glyphPx?: number;
+  glyphPx: number;
   /** Extra space on right of note. */
   rightDisplacedHeadPx: number;
 }
@@ -54,14 +54,14 @@ export interface NoteRenderOptions {
   draw_stem_through_stave?: boolean;
   draw_dots?: boolean;
   draw_stem?: boolean;
-  y_shift?: number;
+  y_shift: number;
   extend_left?: number;
   extend_right?: number;
   glyph_font_scale: number;
   annotation_spacing: number;
   glyph_font_size?: number;
-  scale?: number;
-  font?: string;
+  scale: number;
+  font: string;
   stroke_px: number;
 }
 
@@ -310,6 +310,9 @@ export abstract class Note extends Tickable {
       annotation_spacing: 5,
       glyph_font_scale: 1,
       stroke_px: 1,
+      scale: 1,
+      font: '',
+      y_shift: 0,
     };
   }
 
@@ -341,6 +344,12 @@ export abstract class Note extends Tickable {
 
   // Get and set the target stave.
   getStave(): Stave | undefined {
+    return this.stave;
+  }
+  checkStave(): Stave {
+    if (!this.stave) {
+      throw new Vex.RERR('NoStave', 'No stave attached to instance');
+    }
     return this.stave;
   }
   setStave(stave: Stave): this {
@@ -569,6 +578,7 @@ export abstract class Note extends Tickable {
       // Displaced note head on left or right.
       leftDisplacedHeadPx: this.leftDisplacedHeadPx,
       rightDisplacedHeadPx: this.rightDisplacedHeadPx,
+      glyphPx: 0,
     };
   }
 

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -83,8 +83,8 @@ export class StaveModifier extends Element {
     return '';
   }
 
-  placeGlyphOnLine(glyph: Glyph, stave: Stave, line: number, customShift = 0): void {
-    glyph.setYShift(stave.getYForLine(line) - stave.getYForGlyphs() + customShift);
+  placeGlyphOnLine(glyph: Glyph, stave: Stave, line?: number, customShift = 0): void {
+    glyph.setYShift(stave.getYForLine(line ?? 0) - stave.getYForGlyphs() + customShift);
   }
 
   getPadding(index: number): number {

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -147,10 +147,11 @@ export class StaveTie extends Element {
     let center_x = (first_x_px + last_x_px) / 2;
     center_x -= ctx.measureText(this.text).width / 2;
     const stave = this.notes.first_note?.getStave() ?? this.notes.last_note?.getStave();
+    if (!stave) throw new Vex.RERR('NoStave', "Can't render text without a stave.");
 
     ctx.save();
     ctx.setFont(this.font.family, this.font.size, this.font.weight);
-    ctx.fillText(this.text, center_x + this.render_options.text_shift_x, stave!.getYForTopText() - 1);
+    ctx.fillText(this.text, center_x + this.render_options.text_shift_x, stave.getYForTopText() - 1);
     ctx.restore();
   }
 

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -28,6 +28,13 @@ export abstract class StemmableNote extends Note {
     return this.stem;
   }
 
+  checkStem(): Stem {
+    if (!this.stem) {
+      throw new Vex.RERR('NoStem', 'No stem attached to instance');
+    }
+    return this.stem;
+  }
+
   setStem(stem: Stem): this {
     this.stem = stem;
     return this;

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -339,8 +339,7 @@ export class TabNote extends StemmableNote {
 
   // Get the y position for the stem
   getStemY(): number {
-    // eslint-disable-next-line
-    const num_lines = this.stave!.getNumLines();
+    const num_lines = this.checkStave().getNumLines();
 
     // The decimal staff line amounts provide optimal spacing between the
     // fret number and the stem
@@ -348,14 +347,12 @@ export class TabNote extends StemmableNote {
     const stemDownLine = num_lines - 0.5;
     const stemStartLine = Stem.UP === this.stem_direction ? stemUpLine : stemDownLine;
 
-    // eslint-disable-next-line
-    return this.stave!.getYForLine(stemStartLine);
+    return this.checkStave().getYForLine(stemStartLine);
   }
 
   // Get the stem extents for the tabnote
   getStemExtents(): Record<string, number> {
-    // eslint-disable-next-line
-    return this.stem!.getExtents();
+    return this.checkStem().getExtents();
   }
 
   // Draw the fal onto the context
@@ -363,7 +360,6 @@ export class TabNote extends StemmableNote {
     const {
       beam,
       glyph,
-      stem,
       stem_direction,
       render_options: { draw_stem, glyph_font_scale },
     } = this;
@@ -374,8 +370,7 @@ export class TabNote extends StemmableNote {
     // Now it's the flag's turn.
     if (glyph.flag && shouldDrawFlag) {
       const flag_x = this.getStemX() + 1;
-      // eslint-disable-next-line
-      const flag_y = this.getStemY() - stem!.getHeight();
+      const flag_y = this.getStemY() - this.checkStem().getHeight();
 
       const flag_code =
         stem_direction === Stem.DOWN
@@ -408,13 +403,11 @@ export class TabNote extends StemmableNote {
     const stem_through = this.render_options.draw_stem_through_stave;
     const draw_stem = this.render_options.draw_stem;
     if (draw_stem && stem_through) {
-      // eslint-disable-next-line
-      const total_lines = this.stave!.getNumLines();
+      const total_lines = this.checkStave().getNumLines();
       const strings_used = this.positions.map((position) => Number(position.str));
 
       const unused_strings = getUnusedStringGroups(total_lines, strings_used);
-      // eslint-disable-next-line
-      const stem_lines = getPartialStemLines(stem_y, unused_strings, this.stave!, this.getStemDirection());
+      const stem_lines = getPartialStemLines(stem_y, unused_strings, this.checkStave(), this.getStemDirection());
 
       ctx.save();
       ctx.setLineWidth(Stem.WIDTH);
@@ -437,8 +430,7 @@ export class TabNote extends StemmableNote {
     const x = this.getAbsoluteX();
     const ys = this.ys;
     for (let i = 0; i < this.positions.length; ++i) {
-      // eslint-disable-next-line
-      const y = ys[i] + this.render_options.y_shift!;
+      const y = ys[i] + this.render_options.y_shift;
       const glyph = this.glyphs[i];
 
       // Center the fret text beneath the notation note head
@@ -449,15 +441,12 @@ export class TabNote extends StemmableNote {
       ctx.clearRect(tab_x - 2, y - 3, glyph.getWidth() + 4, 6);
 
       if (glyph.code) {
-        // eslint-disable-next-line
-        Glyph.renderGlyph(ctx, tab_x, y, this.render_options.glyph_font_scale * this.render_options.scale!, glyph.code);
+        Glyph.renderGlyph(ctx, tab_x, y, this.render_options.glyph_font_scale * this.render_options.scale, glyph.code);
       } else {
         ctx.save();
-        // eslint-disable-next-line
-        ctx.setRawFont(this.render_options.font!);
+        ctx.setRawFont(this.render_options.font);
         const text = glyph.text.toString();
-        // eslint-disable-next-line
-        ctx.fillText(text, tab_x, y + 5 * this.render_options.scale!);
+        ctx.fillText(text, tab_x, y + 5 * this.render_options.scale);
         ctx.restore();
       }
     }

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -42,8 +42,8 @@ export class TabSlide extends TabTie {
     this.setAttribute('type', 'TabSlide');
 
     if (!direction) {
-      const first_fret = (notes.first_note as unknown as TabNote).getPositions()[0].fret;
-      const last_fret = (notes.last_note as unknown as TabNote).getPositions()[0].fret;
+      const first_fret = ((notes.first_note as unknown) as TabNote).getPositions()[0].fret;
+      const last_fret = ((notes.last_note as unknown) as TabNote).getPositions()[0].fret;
 
       direction = parseInt(first_fret, 10) > parseInt(last_fret, 10) ? TabSlide.SLIDE_DOWN : TabSlide.SLIDE_UP;
     }

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -151,6 +151,7 @@ export class TextNote extends Note {
   // Pre-render formatting
   preFormat(): void {
     const ctx = this.checkContext();
+    if (!this.tickContext) throw new Vex.RERR('NoTickContext', "Can't preformat without a TickContext.");
 
     if (this.preFormatted) return;
 
@@ -172,13 +173,14 @@ export class TextNote extends Note {
     }
 
     // We reposition to the center of the note head
-    this.rightDisplacedHeadPx = this.tickContext!.getMetrics().glyphPx! / 2;
+    this.rightDisplacedHeadPx = this.tickContext.getMetrics().glyphPx / 2;
     this.setPreFormatted(true);
   }
 
   // Renders the TextNote
   draw(): void {
     const ctx = this.checkContext();
+    if (!this.tickContext) throw new Vex.RERR('NoTickContext', "Can't draw without a TickContext.");
 
     if (!this.stave) {
       throw new Vex.RERR('NoStave', "Can't draw without a stave.");
@@ -187,7 +189,7 @@ export class TextNote extends Note {
     this.setRendered();
 
     // Reposition to center of note head
-    let x = this.getAbsoluteX() + this.tickContext!.getMetrics().glyphPx! / 2;
+    let x = this.getAbsoluteX() + this.tickContext.getMetrics().glyphPx / 2;
 
     // Align based on tick-context width.
     const width = this.getWidth();

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -1,3 +1,4 @@
+import { Vex } from './vex';
 import { Glyph, GlyphMetrics } from './glyph';
 import { TimeSignature } from './timesignature';
 
@@ -24,19 +25,19 @@ export class TimeSignatureGlyph extends Glyph {
     let topWidth = 0;
     for (let i = 0; i < topDigits.length; ++i) {
       const num = topDigits[i];
-      const topGlyph = new Glyph('timeSig' + num, this.timeSignature.point!);
+      const topGlyph = new Glyph('timeSig' + num, this.timeSignature.point);
 
       this.topGlyphs.push(topGlyph);
-      topWidth += topGlyph.getMetrics().width!;
+      topWidth += topGlyph.getMetrics().width ?? 0;
     }
 
     let botWidth = 0;
     for (let i = 0; i < botDigits.length; ++i) {
       const num = botDigits[i];
-      const botGlyph = new Glyph('timeSig' + num, this.timeSignature.point!);
+      const botGlyph = new Glyph('timeSig' + num, this.timeSignature.point);
 
       this.botGlyphs.push(botGlyph);
-      botWidth += botGlyph.getMetrics().width!;
+      botWidth += botGlyph.getMetrics().width ?? 0;
     }
 
     this.width = Math.max(topWidth, botWidth);
@@ -55,6 +56,8 @@ export class TimeSignatureGlyph extends Glyph {
   }
 
   renderToStave(x: number): void {
+    if (!this.stave) throw new Vex.RERR('NoStave', "Can't render without a stave.");
+
     let start_x = x + this.topStartX;
     for (let i = 0; i < this.topGlyphs.length; ++i) {
       const glyph = this.topGlyphs[i];
@@ -63,23 +66,23 @@ export class TimeSignatureGlyph extends Glyph {
         glyph.getMetrics().outline,
         this.scale,
         start_x + this.x_shift,
-        this.stave!.getYForLine(this.timeSignature.topLine!)
+        this.stave.getYForLine(this.timeSignature.topLine)
       );
-      start_x += glyph.getMetrics().width!;
+      start_x += glyph.getMetrics().width ?? 0;
     }
 
     start_x = x + this.botStartX;
     for (let i = 0; i < this.botGlyphs.length; ++i) {
       const glyph = this.botGlyphs[i];
-      this.timeSignature.placeGlyphOnLine(glyph, this.stave!, 0);
+      this.timeSignature.placeGlyphOnLine(glyph, this.stave, 0);
       Glyph.renderOutline(
         this.checkContext(),
         glyph.getMetrics().outline,
         this.scale,
         start_x + glyph.getMetrics().x_shift,
-        this.stave!.getYForLine(this.timeSignature.bottomLine!)
+        this.stave.getYForLine(this.timeSignature.bottomLine)
       );
-      start_x += glyph.getMetrics().width!;
+      start_x += glyph.getMetrics().width ?? 0;
     }
   }
 }

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -1,6 +1,7 @@
 import { Vex } from './vex';
 import { Glyph, GlyphMetrics } from './glyph';
 import { TimeSignature } from './timesignature';
+import { check } from './common';
 
 export class TimeSignatureGlyph extends Glyph {
   timeSignature: TimeSignature;
@@ -37,7 +38,7 @@ export class TimeSignatureGlyph extends Glyph {
       const botGlyph = new Glyph('timeSig' + num, this.timeSignature.point);
 
       this.botGlyphs.push(botGlyph);
-      botWidth += botGlyph.getMetrics().width ?? 0;
+      botWidth += check<number>(botGlyph.getMetrics().width);
     }
 
     this.width = Math.max(topWidth, botWidth);
@@ -68,7 +69,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + this.x_shift,
         this.stave.getYForLine(this.timeSignature.topLine)
       );
-      start_x += glyph.getMetrics().width ?? 0;
+      start_x += check<number>(glyph.getMetrics().width);
     }
 
     start_x = x + this.botStartX;
@@ -82,7 +83,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + glyph.getMetrics().x_shift,
         this.stave.getYForLine(this.timeSignature.bottomLine)
       );
-      start_x += glyph.getMetrics().width ?? 0;
+      start_x += check<number>(glyph.getMetrics().width);
     }
   }
 }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -9,6 +9,7 @@ import { Vex } from './vex';
 import { Glyph } from './glyph';
 import { StaveModifier } from './stavemodifier';
 import { TimeSignatureGlyph } from './timesigglyph';
+import { check } from './common';
 
 export interface TimeSignatureInfo {
   glyph: Glyph;
@@ -73,7 +74,7 @@ export class TimeSignature extends StaveModifier {
     this.bottomLine = 4 + fontLineShift;
     this.setPosition(StaveModifier.Position.BEGIN);
     this.timeSig = this.parseTimeSpec(timeSpec);
-    this.setWidth(this.timeSig.glyph.getMetrics().width ?? 0);
+    this.setWidth(check<number>(this.timeSig.glyph.getMetrics().width));
     this.setPadding(padding);
   }
 

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -34,13 +34,12 @@ const assertIsValidFraction = (timeSpec: string) => {
 };
 
 export class TimeSignature extends StaveModifier {
-  point?: number;
-  bottomLine?: number;
-  protected timeSig?: TimeSignatureInfo;
+  point: number;
+  bottomLine: number;
+  topLine: number;
 
+  protected timeSig: TimeSignatureInfo;
   protected validate_args: boolean;
-
-  topLine?: number;
 
   static get CATEGORY(): string {
     return 'timesignatures';
@@ -61,12 +60,11 @@ export class TimeSignature extends StaveModifier {
     };
   }
 
-  constructor(timeSpec?: string, customPadding = 15, validate_args = true) {
+  constructor(timeSpec: string = '4/4', customPadding = 15, validate_args = true) {
     super();
     this.setAttribute('type', 'TimeSignature');
     this.validate_args = validate_args;
 
-    if (!timeSpec) return;
     const padding = customPadding;
 
     this.point = this.musicFont.lookupMetric('digits.point');
@@ -75,7 +73,7 @@ export class TimeSignature extends StaveModifier {
     this.bottomLine = 4 + fontLineShift;
     this.setPosition(StaveModifier.Position.BEGIN);
     this.timeSig = this.parseTimeSpec(timeSpec);
-    this.setWidth(this.timeSig.glyph.getMetrics().width!);
+    this.setWidth(this.timeSig.glyph.getMetrics().width ?? 0);
     this.setPadding(padding);
   }
 
@@ -106,7 +104,7 @@ export class TimeSignature extends StaveModifier {
   }
 
   makeTimeSignatureGlyph(topDigits: string[], botDigits: string[]): Glyph {
-    const glyph = new TimeSignatureGlyph(this, topDigits, botDigits, 'timeSig0', this.point!);
+    const glyph = new TimeSignatureGlyph(this, topDigits, botDigits, 'timeSig0', this.point);
     return glyph;
   }
 
@@ -129,9 +127,9 @@ export class TimeSignature extends StaveModifier {
     }
 
     this.setRendered();
-    this.timeSig!.glyph.setStave(this.stave);
-    this.timeSig!.glyph.setContext(this.stave.getContext());
-    this.placeGlyphOnLine(this.timeSig!.glyph, this.stave, 2);
-    this.timeSig!.glyph.renderToStave(this.x);
+    this.timeSig.glyph.setStave(this.stave);
+    this.timeSig.glyph.setContext(this.stave.getContext());
+    this.placeGlyphOnLine(this.timeSig.glyph, this.stave, this.timeSig.line);
+    this.timeSig.glyph.renderToStave(this.x);
   }
 }

--- a/src/vibratobracket.ts
+++ b/src/vibratobracket.ts
@@ -72,26 +72,20 @@ export class VibratoBracket extends Element {
   draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
-    let y = 0;
-    let start_x = 0;
-    let stop_x = 0;
-    if (this.start) {
-      y = this.start.checkStave().getYForTopText(this.line);
-      start_x = this.start.getAbsoluteX();
-    } else if (this.stop) {
-      y = this.stop.checkStave().getYForTopText(this.line);
-      // If start note is not set then vibrato will be drawn
-      // from the beginning of the stave
-      start_x = this.stop.checkStave().getTieStartX();
-    }
-
-    if (this.stop) {
-      stop_x = this.stop.getAbsoluteX() - this.stop.getWidth() - 5;
-    } else if (this.start) {
-      // If stop note is not set then vibrato will be drawn
-      // until the end of the stave
-      stop_x = this.start.checkStave().getTieEndX() - 10;
-    }
+    const y: number =
+      (this.start && this.start.checkStave().getYForTopText(this.line)) ||
+      (this.stop && this.stop.checkStave().getYForTopText(this.line)) ||
+      0;
+    // If start note is not set then vibrato will be drawn
+    // from the beginning of the stave
+    const start_x: number =
+      (this.start && this.start.getAbsoluteX()) || (this.stop && this.stop.checkStave().getTieStartX()) || 0;
+    // If stop note is not set then vibrato will be drawn
+    // until the end of the stave
+    const stop_x: number =
+      (this.stop && this.stop.getAbsoluteX() - this.stop.getWidth() - 5) ||
+      (this.start && this.start.checkStave().getTieEndX() - 10) ||
+      0;
 
     this.render_options.vibrato_width = stop_x - start_x;
 

--- a/src/vibratobracket.ts
+++ b/src/vibratobracket.ts
@@ -72,18 +72,26 @@ export class VibratoBracket extends Element {
   draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
-    const y = this.start
-      ? this.start!.getStave()!.getYForTopText(this.line)
-      : this.stop!.getStave()!.getYForTopText(this.line);
-    // If start note is not set then vibrato will be drawn
-    // from the beginning of the stave
-    const start_x = this.start ? this.start.getAbsoluteX() : this.stop!.getStave()!.getTieStartX();
+    let y = 0;
+    let start_x = 0;
+    let stop_x = 0;
+    if (this.start) {
+      y = this.start.checkStave().getYForTopText(this.line);
+      start_x = this.start.getAbsoluteX();
+    } else if (this.stop) {
+      y = this.stop.checkStave().getYForTopText(this.line);
+      // If start note is not set then vibrato will be drawn
+      // from the beginning of the stave
+      start_x = this.stop.checkStave().getTieStartX();
+    }
 
-    // If stop note is not set then vibrato will be drawn
-    // until the end of the stave
-    const stop_x = this.stop
-      ? this.stop.getAbsoluteX() - this.stop.getWidth() - 5
-      : this.start!.getStave()!.getTieEndX() - 10;
+    if (this.stop) {
+      stop_x = this.stop.getAbsoluteX() - this.stop.getWidth() - 5;
+    } else if (this.start) {
+      // If stop note is not set then vibrato will be drawn
+      // until the end of the stave
+      stop_x = this.start.checkStave().getTieEndX() - 10;
+    }
 
     this.render_options.vibrato_width = stop_x - start_x;
 

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -31,6 +31,7 @@ const MT = (function () {
         modRightPx: 0,
         leftDisplacedHeadPx: 0,
         rightDisplacedHeadPx: 0,
+        glyphPx: 0,
       };
     },
     getWidth: function () {


### PR DESCRIPTION
no-non-null-assertion warning enabled

I had enough about checking that `this.stave` is not `undefined` and I created:
`checkStave` & `checkStem`

this is the same approach as `checkContext`

If you agree that this is a good idea I will refactor to get rid of all the `NoStave` errors all over the code. :)