### PR TITLE
Allow modifiers like ChordSymbol to be attached to GlyphNotes.

### DIFF
--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -14,9 +14,7 @@ export interface GlyphNoteOptions {
 
 export class GlyphNote extends Note {
   protected options: GlyphNoteOptions;
-  static format(notes: GlyphNote[], state: ModifierContextState): boolean {
-    return false;
-  }
+
   constructor(glyph: Glyph | undefined, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
     super(noteStruct);
     this.options = {
@@ -50,7 +48,6 @@ export class GlyphNote extends Note {
     for (let i = 0; i < this.modifiers.length; ++i) {
       this.modifierContext.addMember(this.modifiers[i]);
     }
-    this.modifierContext.addMember(this);
     this.setPreFormatted(false);
     return this;
   }
@@ -62,7 +59,6 @@ export class GlyphNote extends Note {
     this.setPreFormatted(true);
     return this;
   }
-  // Draw all key modifiers
   drawModifiers(): void {
     const ctx = this.checkContext();
     ctx.openGroup('modifiers');

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -1,6 +1,5 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 
-import { Vex } from './vex';
 import { BoundingBox } from './boundingbox';
 import { Glyph } from './glyph';
 import { Note, NoteStruct } from './note';
@@ -58,6 +57,7 @@ export class GlyphNote extends Note {
     this.setPreFormatted(true);
     return this;
   }
+
   drawModifiers(): void {
     const ctx = this.checkContext();
     ctx.openGroup('modifiers');

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -1,8 +1,12 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 
+import { Vex } from './vex';
 import { BoundingBox } from './boundingbox';
 import { Glyph } from './glyph';
 import { Note, NoteStruct } from './note';
+import { ModifierContext } from './modifiercontext';
+import { ModifierContextState } from './modifiercontext';
+
 export interface GlyphNoteOptions {
   ignoreTicks?: boolean;
   line?: number;
@@ -10,6 +14,9 @@ export interface GlyphNoteOptions {
 
 export class GlyphNote extends Note {
   protected options: GlyphNoteOptions;
+  static format(notes: GlyphNote[], state: ModifierContextState): boolean {
+    return false;
+  }
   constructor(glyph: Glyph | undefined, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
     super(noteStruct);
     this.options = {
@@ -36,31 +43,56 @@ export class GlyphNote extends Note {
     return this.glyph.getBoundingBox();
   }
 
-  /*
-  addToModifierContext() {
+  // Add self to modifier context. `mContext` is the `ModifierContext`
+  // to be added to.
+  addToModifierContext(mContext: ModifierContext): this {
+    this.modifierContext = mContext;
+    for (let i = 0; i < this.modifiers.length; ++i) {
+      this.modifierContext.addMember(this.modifiers[i]);
+    }
+    this.modifierContext.addMember(this);
+    this.setPreFormatted(false);
     return this;
   }
-  */
 
   preFormat(): this {
+    if (!this.preFormatted && this.modifierContext) {
+      this.modifierContext.preFormat();
+    }
     this.setPreFormatted(true);
     return this;
   }
-
+  // Draw all key modifiers
+  drawModifiers(): void {
+    const ctx = this.checkContext();
+    ctx.openGroup('modifiers');
+    for (let i = 0; i < this.modifiers.length; i++) {
+      const modifier = this.modifiers[i];
+      modifier.setContext(ctx);
+      modifier.drawWithStyle();
+    }
+    ctx.closeGroup();
+  }
   draw(): void {
-    const stave = this.checkStave();
-    const ctx = stave.checkContext();
+    if (!this.stave) {
+      throw new Vex.RERR('NoStave', 'No stave attached to this note.');
+    }
+
+    const ctx = this.stave.checkContext();
     this.setRendered();
+    ctx.openGroup('glypheNote', this.getAttribute('id'));
 
     // Context is set when setStave is called on Note
     if (!this.glyph.getContext()) {
       this.glyph.setContext(ctx);
     }
 
-    this.glyph.setStave(stave);
-    this.glyph.setYShift(stave.getYForLine(this.options.line as number) - stave.getYForGlyphs());
+    this.glyph.setStave(this.stave);
+    this.glyph.setYShift(this.stave.getYForLine(this.options.line as number) - this.stave.getYForGlyphs());
 
     const x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
     this.glyph.renderToStave(x);
+    this.drawModifiers();
+    ctx.closeGroup();
   }
 }

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -5,7 +5,6 @@ import { BoundingBox } from './boundingbox';
 import { Glyph } from './glyph';
 import { Note, NoteStruct } from './note';
 import { ModifierContext } from './modifiercontext';
-import { ModifierContextState } from './modifiercontext';
 
 export interface GlyphNoteOptions {
   ignoreTicks?: boolean;
@@ -70,11 +69,8 @@ export class GlyphNote extends Note {
     ctx.closeGroup();
   }
   draw(): void {
-    if (!this.stave) {
-      throw new Vex.RERR('NoStave', 'No stave attached to this note.');
-    }
-
-    const ctx = this.stave.checkContext();
+    const stave = this.checkStave();
+    const ctx = stave.checkContext();
     this.setRendered();
     ctx.openGroup('glypheNote', this.getAttribute('id'));
 
@@ -83,8 +79,8 @@ export class GlyphNote extends Note {
       this.glyph.setContext(ctx);
     }
 
-    this.glyph.setStave(this.stave);
-    this.glyph.setYShift(this.stave.getYForLine(this.options.line as number) - this.stave.getYForGlyphs());
+    this.glyph.setStave(stave);
+    this.glyph.setYShift(stave.getYForLine(this.options.line as number) - stave.getYForGlyphs());
 
     const x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
     this.glyph.renderToStave(x);

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -7,6 +7,7 @@
 
 import { Vex } from './vex';
 import { StaveNote } from './stavenote';
+import { GlyphNote } from './glyphnote';
 import { Dot } from './dot';
 import { FretHandFinger } from './frethandfinger';
 import { Accidental } from './accidental';
@@ -36,7 +37,7 @@ export interface ModifierContextMetrics {
   spacing: number;
 }
 
-export type ModifierContextMember = Modifier | StaveNote | TabNote;
+export type ModifierContextMember = Modifier | StaveNote | TabNote | GlyphNote;
 
 // To enable logging for this class. Set `Vex.Flow.ModifierContext.DEBUG` to `true`.
 function L(
@@ -82,6 +83,7 @@ export class ModifierContext {
     // members are formatted and rendered before higher ones.
     this.PREFORMAT = [
       StaveNote,
+      GlyphNote,
       Dot,
       FretHandFinger,
       Accidental,

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -37,7 +37,7 @@ export interface ModifierContextMetrics {
   spacing: number;
 }
 
-export type ModifierContextMember = Modifier | StaveNote | TabNote | GlyphNote;
+export type ModifierContextMember = Modifier | StaveNote | TabNote;
 
 // To enable logging for this class. Set `Vex.Flow.ModifierContext.DEBUG` to `true`.
 function L(
@@ -83,7 +83,6 @@ export class ModifierContext {
     // members are formatted and rendered before higher ones.
     this.PREFORMAT = [
       StaveNote,
-      GlyphNote,
       Dot,
       FretHandFinger,
       Accidental,

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -7,7 +7,6 @@
 
 import { Vex } from './vex';
 import { StaveNote } from './stavenote';
-import { GlyphNote } from './glyphnote';
 import { Dot } from './dot';
 import { FretHandFinger } from './frethandfinger';
 import { Accidental } from './accidental';

--- a/tests/glyphnote_tests.js
+++ b/tests/glyphnote_tests.js
@@ -16,7 +16,7 @@ const GlyphNoteTests = (function () {
     chordChanges: function (options) {
       VF.Registry.enableDefaultRegistry(new VF.Registry());
 
-      var vf = VF.Test.makeFactory(options, 300, 400);
+      var vf = VF.Test.makeFactory(options, 300, 200);
       var system = vf.System({
         x: 50,
         width: 250,

--- a/tests/glyphnote_tests.js
+++ b/tests/glyphnote_tests.js
@@ -8,11 +8,52 @@ const GlyphNoteTests = (function () {
   var GlyphNote = {
     Start: function () {
       QUnit.module('GlyphNote');
+      run('GlyphNote with ChordSymbols', GlyphNote.chordChanges, { debug: false, noPadding: false });
       run('GlyphNote Positioning', GlyphNote.basic, { debug: false, noPadding: false });
       run('GlyphNote No Stave Padding', GlyphNote.basic, { debug: true, noPadding: true });
       run('GlyphNote RepeatNote', GlyphNote.repeatNote, { debug: false, noPadding: true });
     },
+    chordChanges: function (options) {
+      VF.Registry.enableDefaultRegistry(new VF.Registry());
 
+      var vf = VF.Test.makeFactory(options, 300, 400);
+      var system = vf.System({
+        x: 50,
+        width: 250,
+        debugFormatter: options.params.debug,
+        noPadding: options.params.noPadding,
+        options: { alpha: options.params.alpha },
+      });
+
+      var score = vf.EasyScore();
+
+      var notes = [
+        vf.GlyphNote(new VF.Glyph('repeatBarSlash', 40), { duration: 'q' }),
+        vf.GlyphNote(new VF.Glyph('repeatBarSlash', 40), { duration: 'q' }),
+        vf.GlyphNote(new VF.Glyph('repeatBarSlash', 40), { duration: 'q' }),
+        vf.GlyphNote(new VF.Glyph('repeatBarSlash', 40), { duration: 'q' }),
+      ];
+      const chord1 = vf
+        .ChordSymbol({ reportWidth: false })
+        .addText('F7')
+        .setHorizontal('left')
+        .addGlyphOrText('(#11b9)', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT });
+      const chord2 = vf
+        .ChordSymbol()
+        .addText('F7')
+        .setHorizontal('left')
+        .addGlyphOrText('#11', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUPERSCRIPT })
+        .addGlyphOrText('b9', { symbolModifier: VF.ChordSymbol.symbolModifiers.SUBSCRIPT });
+
+      notes[0].addModifier(chord1, 0);
+      notes[2].addModifier(chord2, 0);
+      const voice = score.voice(notes);
+      system.addStave({ voices: [voice], debugNoteMetrics: options.params.debug });
+      system.addConnector().setType(VF.StaveConnector.type.BRACKET);
+      vf.draw();
+      VF.Registry.disableDefaultRegistry();
+      ok(true);
+    },
     basic: function (options) {
       VF.Registry.enableDefaultRegistry(new VF.Registry());
 


### PR DESCRIPTION
This change allows modifiers to be attached to GlyphNotes.  This is used to notate chord changes in an improvised solo.

![image](https://user-images.githubusercontent.com/5438280/119274208-682a5e00-bbd4-11eb-8b88-4dbca59c9808.png)
