### PR TITLE
Fix inconsistencies with the way we check against null vs. undefined.

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -190,10 +190,7 @@ export class Music {
   }
 
   isValidNoteValue(note: number): boolean {
-    if (note == null || note < 0 || note >= Music.NUM_TONES) {
-      return false;
-    }
-    return true;
+    return note >= 0 && note < Music.NUM_TONES;
   }
 
   isValidIntervalValue(interval: number): boolean {
@@ -214,7 +211,7 @@ export class Music {
     const regex = /^([cdefgab])(b|bb|n|#|##)?$/;
     const match = regex.exec(note);
 
-    if (match != null) {
+    if (match !== null) {
       const root = match[1];
       const accidental = match[2];
 
@@ -238,7 +235,7 @@ export class Music {
     const regex = /^([cdefgab])(b|#)?(mel|harm|m|M)?$/;
     const match = regex.exec(key);
 
-    if (match != null) {
+    if (match !== null) {
       const root = match[1];
       const accidental = match[2];
       let type = match[3];
@@ -258,19 +255,17 @@ export class Music {
 
   getNoteValue(noteString: string): number {
     const value = Music.noteValues[noteString];
-    if (value == null) {
+    if (value === undefined) {
       throw new Vex.RERR('BadArguments', `Invalid note name: ${noteString}`);
     }
-
     return value.int_val;
   }
 
   getIntervalValue(intervalString: string): number {
     const value = Music.intervals[intervalString];
-    if (value == null) {
+    if (value === undefined) {
       throw new Vex.RERR('BadArguments', `Invalid interval name: ${intervalString}`);
     }
-
     return value;
   }
 
@@ -278,7 +273,6 @@ export class Music {
     if (!this.isValidNoteValue(noteValue)) {
       throw new Vex.RERR('BadArguments', `Invalid note value: ${noteValue}`);
     }
-
     return Music.canonical_notes[noteValue];
   }
 
@@ -286,16 +280,13 @@ export class Music {
     if (!this.isValidIntervalValue(intervalValue)) {
       throw new Vex.RERR('BadArguments', `Invalid interval value: ${intervalValue}`);
     }
-
     return Music.diatonic_intervals[intervalValue];
   }
 
-  /* Given a note, interval, and interval direction, product the
-   * relative note.
+  /**
+   * Given a note, interval, and interval direction, produce the relative note.
    */
-  getRelativeNoteValue(noteValue: number, intervalValue: number, direction?: number): number {
-    if (direction == null) direction = 1;
-
+  getRelativeNoteValue(noteValue: number, intervalValue: number, direction: number = 1): number {
     if (direction !== 1 && direction !== -1) {
       throw new Vex.RERR('BadArguments', `Invalid direction: ${direction}`);
     }
@@ -343,7 +334,8 @@ export class Music {
     return relativeNoteName;
   }
 
-  /* Return scale tones, given intervals. Each successive interval is
+  /**
+   * Return scale tones, given intervals. Each successive interval is
    * relative to the previous one, e.g., Major Scale:
    *
    *   TTSTTTS = [2,2,1,2,2,2,1]
@@ -363,13 +355,11 @@ export class Music {
     return tones;
   }
 
-  /* Returns the interval of a note, given a diatonic scale.
-   *
-   * E.g., Given the scale C, and the note E, returns M3
+  /**
+   * Return the interval of a note, given a diatonic scale.
+   * e.g., given the scale C, and the note E, returns M3.
    */
-  getIntervalBetween(note1: number, note2: number, direction?: number): number {
-    if (direction == null) direction = 1;
-
+  getIntervalBetween(note1: number, note2: number, direction: number = 1): number {
     if (direction !== 1 && direction !== -1) {
       throw new Vex.RERR('BadArguments', `Invalid direction: ${direction}`);
     }
@@ -385,10 +375,12 @@ export class Music {
     return difference;
   }
 
-  // Create a scale map that represents the pitch state for a
-  // `keySignature`. For example, passing a `G` to `keySignature` would
-  // return a scale map with every note naturalized except for `F` which
-  // has an `F#` state.
+  /**
+   * Create a scale map that represents the pitch state for a
+   * `keySignature`. For example, passing a `G` to `keySignature` would
+   * return a scale map with every note naturalized except for `F` which
+   * has an `F#` state.
+   */
   createScaleMap(keySignature: string): Record<string, string> {
     const keySigParts = this.getKeyParts(keySignature);
     if (!keySigParts.type) throw new Vex.RERR('BadArguments', 'Unsupported key type: undefined');


### PR DESCRIPTION
In reviewing music.ts, I noticed that sometimes we were incorrectly comparing against `null`. For example: https://github.com/0xfe/vexflow/blob/3e13b92cc7437d5c6ac2b23fa2d056bb1f0f1564/src/music.ts#L192-L197

When we expect a number (as in the example above) or an undefined parameter (see below), comparing against `null` is incorrect.
https://github.com/0xfe/vexflow/blob/3e13b92cc7437d5c6ac2b23fa2d056bb1f0f1564/src/music.ts#L296-L297

Well, this latter line is actually fine... since undefined is falsy and null is falsy so it will do the right thing. :-D

This PR improves consistency so that we:

- check against undefined / null with strict equality operators ===
- utilize optional parameter syntax when appropriate.