### PR TITLE
Add `ver` query param to flow.html to allow switching between different vexflow builds.

### DIFF
--- a/tests/flow.html
+++ b/tests/flow.html
@@ -3,13 +3,11 @@
   <head>
     <title>VexFlow - JavaScript Music Notation and Guitar Tab</title>
     <link rel="stylesheet" href="flow.css" type="text/css" media="screen" />
-
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@500&display=swap" rel="stylesheet" />
     <!-- Test Dependencies: jQuery, QUnit -->
     <link rel="stylesheet" href="support/qunit.css" type="text/css" media="screen" />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@500&display=swap" rel="stylesheet" />
     <script src="support/jquery.js"></script>
     <script src="support/qunit.js"></script>
-
     <script>
       function loadScript(url) {
         return new Promise(function (resolve, reject) {
@@ -17,21 +15,31 @@
           script.onload = resolve;
           script.onerror = reject;
           script.src = url;
-          // The utf-8 charset is required for the measureText cache, since the index contains weird unicode characters.
+          // The utf-8 charset is required for the measureText cache,
+          // since the index contains weird unicode characters.
           script.charset = 'utf-8';
           document.getElementsByTagName('head')[0].appendChild(script);
         });
       }
 
       $(function () {
-        var urlParams = new URLSearchParams(window.location.search);
-        var ver = urlParams.get('ver') || 'build';
-        var vexSrcURL = '../' + ver + '/vexflow-debug.js';
-        var vexTestsURL = '../' + ver + '/vexflow-tests.js';
+        // Support a query param ver=(build|reference|releases|etc...)
+        // If omitted, ver defaults to 'build'.
+        var params = new URLSearchParams(window.location.search);
+        var param_ver = params.get('ver');
+        var path = param_ver || 'build';
+        var vexURL = '../' + path + '/vexflow-debug.js';
+        var testsURL = '../' + path + '/vexflow-tests.js';
 
-        loadScript(vexSrcURL)
+        // Display which VexFlow version we loaded, if the `ver` param was specified.
+        var info = param_ver !== null ? ` [${param_ver}]` : '';
+        $('#vex-src')
+          .attr('href', vexURL)
+          .text('VexFlow Source' + info);
+
+        loadScript(vexURL)
           .then(function () {
-            return loadScript(vexTestsURL);
+            return loadScript(testsURL);
           })
           .then(function () {
             // Show only failed tests.
@@ -50,7 +58,7 @@
       <div>
         <h2>[ <a href="http://vexflow.com">Home</a> ] [ <a href="http://github.com/0xfe/vexflow">GitHub</a> ]</h2>
         <h3>
-          Don't forget to run the
+          See the: <a id="vex-src" target="_blank"></a>. Don't forget to run the
           <a href="https://github.com/0xfe/vexflow/wiki/Visual-Regression-Tests">Visual Regression Tests</a>!
         </h3>
       </div>

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -1,53 +1,66 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>VexFlow - JavaScript Music Notation and Guitar Tab</title>
+    <link rel="stylesheet" href="flow.css" type="text/css" media="screen" />
 
-<head>
-  <title>VexFlow - JavaScript Music Notation and Guitar Tab</title>
-  <link rel="stylesheet" href="flow.css" type="text/css" media="screen" />
-  <!-- VexFlow Sources -->
-  <script src="../build/vexflow-debug.js"></script>
+    <!-- Test Dependencies: jQuery, QUnit -->
+    <link rel="stylesheet" href="support/qunit.css" type="text/css" media="screen" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@500&display=swap" rel="stylesheet" />
+    <script src="support/jquery.js"></script>
+    <script src="support/qunit.js"></script>
 
-  <!-- Test Dependencies: jQuery, QUnit -->
-  <link rel="stylesheet" href="support/qunit.css" type="text/css" media="screen" />
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@500&display=swap" rel="stylesheet">
-  <script src="support/jquery.js"></script>
-  <script src="support/qunit.js"></script>
+    <script>
+      function loadScript(url) {
+        return new Promise(function (resolve, reject) {
+          var script = document.createElement('script');
+          script.onload = resolve;
+          script.onerror = reject;
+          script.src = url;
+          // The utf-8 charset is required for the measureText cache, since the index contains weird unicode characters.
+          script.charset = 'utf-8';
+          document.getElementsByTagName('head')[0].appendChild(script);
+        });
+      }
 
-  <!-- VexFlow Tests. Note the charset below: this is required for
-       the measureText cache, since the index contains weird unicode
-       characters. -->
-  <script src="../build/vexflow-tests.js" charset="utf-8"></script>
+      $(function () {
+        var urlParams = new URLSearchParams(window.location.search);
+        var ver = urlParams.get('ver') || 'build';
+        var vexSrcURL = '../' + ver + '/vexflow-debug.js';
+        var vexTestsURL = '../' + ver + '/vexflow-tests.js';
 
-  <script>
-    $(function() {
-      // Show only failed tests.
-      QUnit.config.hidepassed = true;
-      QUnit.config.noglobals = true;
-      VF.Test.run();
-    });
-  </script>
-</head>
+        loadScript(vexSrcURL)
+          .then(function () {
+            return loadScript(vexTestsURL);
+          })
+          .then(function () {
+            // Show only failed tests.
+            QUnit.config.hidepassed = true;
+            QUnit.config.noglobals = true;
+            VF.Test.run();
+          });
+      });
+    </script>
+  </head>
 
-<body>
-  <div style="text-align: center;">
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
-    <div>
-      <h2>
-        [ <a href="http://vexflow.com">Home</a> ]
-        [ <a href="http://github.com/0xfe/vexflow">GitHub</a> ]
-      </h2>
-      <h3>Don't forget to run the <a href="https://github.com/0xfe/vexflow/wiki/Visual-Regression-Tests">Visual Regression Tests</a>!</h3>
+  <body>
+    <div style="text-align: center">
+      <div id="qunit"></div>
+      <div id="qunit-fixture"></div>
+      <div>
+        <h2>[ <a href="http://vexflow.com">Home</a> ] [ <a href="http://github.com/0xfe/vexflow">GitHub</a> ]</h2>
+        <h3>
+          Don't forget to run the
+          <a href="https://github.com/0xfe/vexflow/wiki/Visual-Regression-Tests">Visual Regression Tests</a>!
+        </h3>
+      </div>
+      <p>&nbsp;</p>
+      <div id="vexflow_testoutput"></div>
+      <p>&nbsp;</p>
+      <p class="vf-footer">
+        [ <a href="http://vexflow.com">home</a> ] [ <a href="http://github.com/0xfe/vexflow">github</a> ] [
+        <a href="http://0xfe.muthanna.com">0xfe</a> ]
+      </p>
     </div>
-
-    <p/>
-    <div id="vexflow_testoutput"></div>
-    <p/>
-    <p class="vf-footer">
-      [ <a href="http://vexflow.com">home</a> ]
-      [ <a href="http://github.com/0xfe/vexflow">github</a> ]
-      [ <a href="http://0xfe.muthanna.com">0xfe</a> ]
-    </p>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
For example:
`flow.html?ver=(build|reference|releases)`

You can open different versions in different tabs and switch between them to see the visual differences.