### PR TITLE
Replace instances of Barline.type with BarlineType.

### DIFF
--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -13,10 +13,8 @@ import { Note } from './note';
 import { Barline, BarlineType } from './stavebarline';
 
 // To enable logging for this class. Set `Vex.Flow.BarNote.DEBUG` to `true`.
-function L(
-  // eslint-disable-next-line
-  ...args: any[]
-) {
+// eslint-disable-next-line
+function L(...args: any[]) {
   if (BarNote.DEBUG) Vex.L('Vex.Flow.BarNote', args);
 }
 

--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -15,7 +15,8 @@ import { Barline, BarlineType } from './stavebarline';
 // To enable logging for this class. Set `Vex.Flow.BarNote.DEBUG` to `true`.
 function L(
   // eslint-disable-next-line
-  ...args: any[]) {
+  ...args: any[]
+) {
   if (BarNote.DEBUG) Vex.L('Vex.Flow.BarNote', args);
 }
 
@@ -24,7 +25,7 @@ export class BarNote extends Note {
   static DEBUG: boolean;
   protected type!: BarlineType;
 
-  constructor(type = Barline.type.SINGLE) {
+  constructor(type = BarlineType.SINGLE) {
     super({ duration: 'b' });
     this.setAttribute('type', 'BarNote');
 
@@ -32,7 +33,7 @@ export class BarNote extends Note {
       widths: {},
     };
 
-    const TYPE = Barline.type;
+    const TYPE = BarlineType;
     this.metrics.widths = {
       [TYPE.SINGLE]: 8,
       [TYPE.DOUBLE]: 12,
@@ -48,7 +49,7 @@ export class BarNote extends Note {
     this.setType(type);
   }
 
-  // Get and set the type of Bar note. `type` must be one of `Vex.Flow.Barline.type`.
+  // Get and set the type of bar note. `type` must be one of `BarlineType`.
   getType(): BarlineType {
     return this.type;
   }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -4,7 +4,7 @@ import { Vex } from './vex';
 import { RuntimeError } from './util';
 import { Element, ElementStyle } from './element';
 import { Flow } from './tables';
-import { Barline } from './stavebarline';
+import { Barline, BarlineType } from './stavebarline';
 import { StaveModifier } from './stavemodifier';
 import { Repetition } from './staverepetition';
 import { StaveSection } from './stavesection';
@@ -105,11 +105,10 @@ export class Stave extends Element {
 
     this.resetLines();
 
-    const BARTYPE = Barline.type;
     // beg bar
-    this.addModifier(new Barline(this.options.left_bar ? BARTYPE.SINGLE : BARTYPE.NONE));
+    this.addModifier(new Barline(this.options.left_bar ? BarlineType.SINGLE : BarlineType.NONE));
     // end bar
-    this.addEndModifier(new Barline(this.options.right_bar ? BARTYPE.SINGLE : BARTYPE.NONE));
+    this.addEndModifier(new Barline(this.options.right_bar ? BarlineType.SINGLE : BarlineType.NONE));
   }
 
   space(spacing: number): number {
@@ -254,7 +253,7 @@ export class Stave extends Element {
 
     let start_x = this.start_x - this.x;
     const begBarline = this.modifiers[0] as Barline;
-    if (begBarline.getType() === Barline.type.REPEAT_BEGIN && start_x > begBarline.getWidth()) {
+    if (begBarline.getType() === BarlineType.REPEAT_BEGIN && start_x > begBarline.getWidth()) {
       start_x -= begBarline.getWidth();
     }
 
@@ -391,7 +390,7 @@ export class Stave extends Element {
   // Bar Line functions
   setBegBarType(type: number): this {
     // Only valid bar types at beginning of stave is none, single or begin repeat
-    const { SINGLE, REPEAT_BEGIN, NONE } = Barline.type;
+    const { SINGLE, REPEAT_BEGIN, NONE } = BarlineType;
     if (type === SINGLE || type === REPEAT_BEGIN || type === NONE) {
       (this.modifiers[0] as Barline).setType(type);
       this.formatted = false;
@@ -401,7 +400,7 @@ export class Stave extends Element {
 
   setEndBarType(type: number): this {
     // Repeat end not valid at end of stave
-    if (type !== Barline.type.REPEAT_BEGIN) {
+    if (type !== BarlineType.REPEAT_BEGIN) {
       (this.modifiers[1] as Barline).setType(type);
       this.formatted = false;
     }
@@ -557,13 +556,13 @@ export class Stave extends Element {
       clefs: 3,
     });
 
-    if (begModifiers.length > 1 && begBarline.getType() === Barline.type.REPEAT_BEGIN) {
+    if (begModifiers.length > 1 && begBarline.getType() === BarlineType.REPEAT_BEGIN) {
       begModifiers.push(begModifiers.splice(0, 1)[0]);
-      begModifiers.splice(0, 0, new Barline(Barline.type.SINGLE));
+      begModifiers.splice(0, 0, new Barline(BarlineType.SINGLE));
     }
 
     if (endModifiers.indexOf(endBarline) > 0) {
-      endModifiers.splice(0, 0, new Barline(Barline.type.NONE));
+      endModifiers.splice(0, 0, new Barline(BarlineType.NONE));
     }
 
     let width;

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -34,13 +34,13 @@ export class Barline extends StaveModifier {
 
   static get typeString(): Record<string, BarlineType> {
     return {
-      single: Barline.type.SINGLE,
-      double: Barline.type.DOUBLE,
-      end: Barline.type.END,
-      repeatBegin: Barline.type.REPEAT_BEGIN,
-      repeatEnd: Barline.type.REPEAT_END,
-      repeatBoth: Barline.type.REPEAT_BOTH,
-      none: Barline.type.NONE,
+      single: BarlineType.SINGLE,
+      double: BarlineType.DOUBLE,
+      end: BarlineType.END,
+      repeatBegin: BarlineType.REPEAT_BEGIN,
+      repeatEnd: BarlineType.REPEAT_END,
+      repeatBoth: BarlineType.REPEAT_BOTH,
+      none: BarlineType.NONE,
     };
   }
 
@@ -52,7 +52,7 @@ export class Barline extends StaveModifier {
     this.setAttribute('type', 'Barline');
     this.thickness = Flow.STAVE_LINE_THICKNESS;
 
-    const TYPE = Barline.type;
+    const TYPE = BarlineType;
     this.widths = {};
     this.widths[TYPE.SINGLE] = 5;
     this.widths[TYPE.DOUBLE] = 5;
@@ -141,16 +141,16 @@ export class Barline extends StaveModifier {
     this.setRendered();
 
     switch (this.type) {
-      case Barline.type.SINGLE:
+      case BarlineType.SINGLE:
         this.drawVerticalBar(stave, this.x, false);
         break;
-      case Barline.type.DOUBLE:
+      case BarlineType.DOUBLE:
         this.drawVerticalBar(stave, this.x, true);
         break;
-      case Barline.type.END:
+      case BarlineType.END:
         this.drawVerticalEndBar(stave, this.x);
         break;
-      case Barline.type.REPEAT_BEGIN:
+      case BarlineType.REPEAT_BEGIN:
         // If the barline is shifted over (in front of clef/time/key)
         // Draw vertical bar at the beginning.
         this.drawRepeatBar(stave, this.x, true);
@@ -159,10 +159,10 @@ export class Barline extends StaveModifier {
         }
 
         break;
-      case Barline.type.REPEAT_END:
+      case BarlineType.REPEAT_END:
         this.drawRepeatBar(stave, this.x, false);
         break;
-      case Barline.type.REPEAT_BOTH:
+      case BarlineType.REPEAT_BOTH:
         this.drawRepeatBar(stave, this.x, false);
         this.drawRepeatBar(stave, this.x, true);
         break;


### PR DESCRIPTION
The `Barline.type` getter just returns `BarlineType`. I did not remove the getter, in case it is important for backwards compatibility.

However, I replaced instances of Barline.type in the VexFlow library with `BarlineType`, to skip the getter.

Tests remain unchanged for now. We can fix them as we migrate tests to TS.