### PR TITLE
Fix #1026 by using Flow.DEFAULT_FONT_STACK instead of a constant DefaultFontStack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "lint": "grunt eslint",
     "qunit": "grunt test",
     "generate:current": "node ./tools/generate_png_images.js ../build ./build/images/current",
-    "generate:current:all-fonts": "node ./tools/generate_png_images.js ../build ./build/images/current --fonts=all",
     "generate:reference": "node ./tools/generate_png_images.js ../reference ./build/images/reference",
     "generate:blessed": "node ./tools/generate_png_images.js ../releases ./build/images/blessed",
     "generate": "npm run generate:current && npm run generate:blessed",

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -7,7 +7,7 @@
 //
 // See `tests/annotation_tests.js` for usage examples.
 
-import { RuntimeError, log } from './util';
+import { log } from './util';
 import { Flow } from './tables';
 import { Modifier } from './modifier';
 import { TextFont } from './textfont';
@@ -16,9 +16,8 @@ import { StemmableNote } from './stemmablenote';
 import { ModifierContextState } from './modifiercontext';
 
 // To enable logging for this class. Set `Vex.Flow.Annotation.DEBUG` to `true`.
-function L(
-  // eslint-disable-next-line
-  ...args: any []) {
+// eslint-disable-next-line
+function L(...args: any[]) {
   if (Annotation.DEBUG) log('Vex.Flow.Annotation', args);
 }
 

--- a/src/chordsymbol.js
+++ b/src/chordsymbol.js
@@ -9,7 +9,6 @@
 // See `tests/chordsymbol_tests.js` for usage examples.
 
 import { log } from './util';
-import { DefaultFontStack } from './font';
 import { Flow } from './tables';
 import { Glyph } from './glyph';
 import { TextFont } from './textfont';
@@ -105,7 +104,7 @@ export class ChordSymbol extends Modifier {
   }
 
   static get engravingFontResolution() {
-    return DefaultFontStack[0].getResolution();
+    return Flow.DEFAULT_FONT_STACK[0].getResolution();
   }
 
   static get spacingBetweenBlocks() {
@@ -235,15 +234,15 @@ export class ChordSymbol extends Modifier {
   }
 
   static get chordSymbolMetrics() {
-    return DefaultFontStack[0].metrics.glyphs.chordSymbol;
+    return Flow.DEFAULT_FONT_STACK[0].metrics.glyphs.chordSymbol;
   }
 
   static get lowerKerningText() {
-    return DefaultFontStack[0].metrics.glyphs.chordSymbol.global.lowerKerningText;
+    return Flow.DEFAULT_FONT_STACK[0].metrics.glyphs.chordSymbol.global.lowerKerningText;
   }
 
   static get upperKerningText() {
-    return DefaultFontStack[0].metrics.glyphs.chordSymbol.global.upperKerningText;
+    return Flow.DEFAULT_FONT_STACK[0].metrics.glyphs.chordSymbol.global.upperKerningText;
   }
 
   // ### format

--- a/src/element.ts
+++ b/src/element.ts
@@ -8,10 +8,10 @@
 
 import { RuntimeError } from './util';
 import { Registry } from './registry';
-import { DefaultFontStack } from './font';
 import { BoundingBox } from './boundingbox';
 import { Font } from './font';
 import { RenderContext } from './types/common';
+import { Flow } from './tables';
 
 /** Element attributes. */
 export interface ElementAttributes {
@@ -62,8 +62,9 @@ export abstract class Element {
     };
 
     this.rendered = false;
-    this.fontStack = DefaultFontStack;
-    this.musicFont = DefaultFontStack[0];
+
+    this.fontStack = Flow.DEFAULT_FONT_STACK;
+    this.musicFont = Flow.DEFAULT_FONT_STACK[0];
 
     // If a default registry exist, then register with it right away.
     Registry.getDefaultRegistry()?.register(this);

--- a/src/font.ts
+++ b/src/font.ts
@@ -84,6 +84,4 @@ const Fonts = {
   Custom: new Font('Custom', CustomMetrics, CustomFont),
 };
 
-const DefaultFontStack = [Fonts.Bravura, Fonts.Gonville, Fonts.Custom];
-
-export { Fonts, DefaultFontStack, Font };
+export { Fonts, Font };

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -19,7 +19,6 @@
 
 import { Vex } from './vex';
 import { RuntimeError, log } from './util';
-import { DefaultFontStack } from './font';
 import { Beam } from './beam';
 import { Flow } from './tables';
 import { Fraction } from './fraction';
@@ -120,7 +119,8 @@ function createContexts<T>(
 // To enable logging for this class. Set `Vex.Flow.Formatter.DEBUG` to `true`.
 function L(
   // eslint-disable-next-line
-  ...args: any[]) {
+  ...args: any[]
+) {
   if (Formatter.DEBUG) log('Vex.Flow.Formatter', args);
 }
 
@@ -188,7 +188,7 @@ export class Formatter {
     options?: { stavePadding: number }
   ): void {
     options = {
-      stavePadding: DefaultFontStack[0].lookupMetric('stave.padding'),
+      stavePadding: Flow.DEFAULT_FONT_STACK[0].lookupMetric('stave.padding'),
       ...options,
     };
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -482,7 +482,7 @@ export class Formatter {
 
   // Create `ModifierContext`s for each tick in `voices`.
   createModifierContexts(voices: Voice[]): AlignmentContexts<ModifierContext> {
-    const fn: addToContextFn<ModifierContext> = (tickable: Note, context: ModifierContext, voiceIndex: number) =>
+    const fn: addToContextFn<ModifierContext> = (tickable: Note, context: ModifierContext) =>
       tickable.addToModifierContext(context);
     const contexts = createContexts(voices, () => new ModifierContext(), fn);
     this.modifierContexts = contexts;

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -1,7 +1,6 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 
 import { RuntimeError } from './util';
-import { DefaultFontStack } from './font';
 import { Element } from './element';
 import { BoundingBoxComputation } from './boundingboxcomputation';
 import { BoundingBox } from './boundingbox';
@@ -9,6 +8,7 @@ import { Font, FontGlyph } from './font';
 import { RenderContext, TypeProps } from './types/common';
 import { Stave } from './stave';
 import { Stem } from './stem';
+import { Flow } from './tables';
 
 export interface DurationCode {
   common: TypeProps;
@@ -66,7 +66,7 @@ function processOutline(
   scaleX: number,
   scaleY: number,
   // eslint-disable-next-line
-  outlineFns: Record<string, ((...args: any[]) => void) >
+  outlineFns: Record<string, (...args: any[]) => void>
 ): void {
   let command: string;
   let x: number;
@@ -114,7 +114,7 @@ export class Glyph extends Element {
   code: string;
   // metrics is initialised in the constructor by either setOptions or reset
   // eslint-disable-next-line
-  metrics!: GlyphMetrics; 
+  metrics!: GlyphMetrics;
   topGlyphs: Glyph[] = [];
   botGlyphs: Glyph[] = [];
 
@@ -127,7 +127,7 @@ export class Glyph extends Element {
   protected stave?: Stave;
 
   // eslint-disable-next-line
-  draw() {};
+  draw() {}
 
   /*
     Static methods used to implement loading and rendering glyphs.
@@ -236,7 +236,7 @@ export class Glyph extends Element {
     options?: { font?: Font; category: string }
   ): GlyphMetrics {
     const params = {
-      fontStack: DefaultFontStack,
+      fontStack: Flow.DEFAULT_FONT_STACK,
       ...options,
     };
     const metrics = Glyph.loadMetrics(params.fontStack, val, params.category);

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -5,7 +5,7 @@
 // This file implements `GraceNoteGroup` which is used to format and
 // render grace notes.
 
-import { RuntimeError, log } from './util';
+import { log } from './util';
 import { Flow } from './tables';
 import { Modifier } from './modifier';
 import { Formatter } from './formatter';
@@ -20,9 +20,8 @@ import { ModifierContextState } from './modifiercontext';
 import { RenderContext } from './types/common';
 
 // To enable logging for this class. Set `GraceNoteGroup.DEBUG` to `true`.
-function L(
-  // eslint-disable-next-line
-  ...args: any) {
+// eslint-disable-next-line
+function L(...args: any) {
   if (GraceNoteGroup.DEBUG) log('Vex.Flow.GraceNoteGroup', args);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,7 @@ import { RepeatNote } from './repeatnote';
 import { TextFont } from './textfont';
 import { PetalumaScriptTextMetrics } from './fonts/petalumascript_textmetrics';
 import { RobotoSlabTextMetrics } from './fonts/robotoslab_textmetrics';
-
-import { Font, Fonts, DefaultFontStack } from './font';
+import { Font, Fonts } from './font';
 
 Vex.Flow = Flow;
 Vex.Flow.Element = Element;
@@ -159,7 +158,6 @@ Vex.Flow.RepeatNote = RepeatNote;
 Vex.Flow.Font = Font;
 Vex.Flow.Fonts = Fonts;
 Vex.Flow.TextFont = TextFont;
-Vex.Flow.DefaultFontStack = DefaultFontStack;
 Vex.Flow.PetalumaScriptTextMetrics = PetalumaScriptTextMetrics;
 Vex.Flow.RobotoSlabTextMetrics = RobotoSlabTextMetrics;
 

--- a/src/tables.js
+++ b/src/tables.js
@@ -6,7 +6,7 @@ import { Vex } from './vex';
 import { RuntimeError } from './util';
 import { Fraction } from './fraction';
 import { Glyph } from './glyph';
-import { DefaultFontStack } from './font';
+import { Fonts } from './font';
 
 const Flow = {
   STEM_WIDTH: 1.5,
@@ -14,7 +14,11 @@ const Flow = {
   STAVE_LINE_THICKNESS: 1,
   RESOLUTION: 16384,
 
-  DEFAULT_FONT_STACK: DefaultFontStack,
+  /**
+   * Customize this to choose a different music font.
+   * For example: Vex.Flow.DEFAULT_FONT_STACK = [Fonts.Petaluma, Fonts.Custom];
+   */
+  DEFAULT_FONT_STACK: [Fonts.Bravura, Fonts.Gonville, Fonts.Custom],
   DEFAULT_NOTATION_FONT_SCALE: 39,
   DEFAULT_TABLATURE_FONT_SCALE: 39,
   SLASH_NOTEHEAD_WIDTH: 15,

--- a/tests/vexflow_test_helpers.js
+++ b/tests/vexflow_test_helpers.js
@@ -66,8 +66,8 @@ const VexFlowTests = (function () {
     // Default font properties for tests.
     Font: { size: 10 },
 
-    // Customize this array to test more fonts (e.g., ['Bravura', 'Gonville', 'Petaluma']).
-    FONT_STACKS_TO_TEST: ['Bravura'],
+    // Customize this array to test fewer fonts (e.g., ['Bravura', 'Petaluma']).
+    FONT_STACKS_TO_TEST: ['Bravura', 'Gonville', 'Petaluma'],
 
     FONT_STACKS: {
       Bravura: [VF.Fonts.Bravura, VF.Fonts.Gonville, VF.Fonts.Custom],

--- a/tools/generate_png_images.js
+++ b/tools/generate_png_images.js
@@ -13,21 +13,17 @@ document = dom.window.document;
 const fs = require('fs');
 const [scriptDir, imageDir] = process.argv.slice(2, 4);
 
-// Optional: 3rd argument specifies which font stacks to test.
-// For example: 
-//   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=all
+// Optional: 3rd argument specifies which font stacks to test. Defaults to all.
+// For example:
 //   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=petaluma
 //   node generate_png_images.js SCRIPT_DIR IMAGE_OUTPUT_DIR --fonts=bravura,gonville
-let fontStacksToTest = ['Bravura'];
+const ALL_FONTS = ['Bravura', 'Petaluma', 'Gonville'];
+let fontStacksToTest = ALL_FONTS;
 if (process.argv.length >= 5) {
   const fontsOption = process.argv[4].toLowerCase();
   if (fontsOption.startsWith('--fonts=')) {
     const fontsList = fontsOption.split('=')[1].split(',');
-    if (fontsList.includes('all')) {
-      fontStacksToTest = ['Bravura', 'Petaluma', 'Gonville'];
-    } else {
-      fontStacksToTest = fontsList.map((fontName) => fontName.charAt(0).toUpperCase() + fontName.slice(1));
-    }
+    fontStacksToTest = fontsList.map((fontName) => fontName.charAt(0).toUpperCase() + fontName.slice(1));
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/0xfe/vexflow/issues/1026

I also turned on visual diffs for **all three fonts by default**.

For faster development, each individual developer can temporarily diff fewer fonts by customizing `generate_png_images.js` line 20. Before sending in a PR, the developer should make sure to run the visual diff for all three fonts.

In the future, we can add a npm script to allow testing of fewer fonts.