### PR TITLE
Correct staff padding to include end padding

### DIFF
--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -4,6 +4,9 @@ export const BravuraMetrics = {
 
   stave: {
     padding: 12,
+    endPaddingMax: 10,
+    endPaddingMin: 5,
+    unalignedNotePadding: 10
   },
 
   clef: {

--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -5,8 +5,7 @@ export const BravuraMetrics = {
   stave: {
     padding: 12,
     endPaddingMax: 10,
-    endPaddingMin: 5,
-    unalignedNotePadding: 10
+    endPaddingMin: 5
   },
 
   clef: {

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -4,8 +4,7 @@ export const GonvilleMetrics = {
   stave: {
     padding: 12,
     endPaddingMax: 10,
-    endPaddingMin: 5,
-    unalignedNotePadding: 10
+    endPaddingMin: 5
   },
 
   clef: {

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -3,6 +3,9 @@ export const GonvilleMetrics = {
   smufl: false,
   stave: {
     padding: 12,
+    endPaddingMax: 10,
+    endPaddingMin: 5,
+    unalignedNotePadding: 10
   },
 
   clef: {

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -5,8 +5,7 @@ export const PetalumaMetrics = {
   stave: {
     padding: 15,
     endPaddingMax: 15,
-    endPaddingMin: 7,
-    unalignedNotePadding: 12
+    endPaddingMin: 7
   },
 
   clef: {

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -4,6 +4,9 @@ export const PetalumaMetrics = {
 
   stave: {
     padding: 15,
+    endPaddingMax: 15,
+    endPaddingMin: 7,
+    unalignedNotePadding: 12
   },
 
   clef: {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -17,7 +17,6 @@
 // See `tests/formatter_tests.js` for usage examples. The helper functions included
 // here (`FormatAndDraw`, `FormatAndDrawTab`) also serve as useful usage examples.
 
-import { Vex } from './vex';
 import { RuntimeError, midLine, log } from './util';
 import { Beam } from './beam';
 import { Flow } from './tables';

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -693,10 +693,13 @@ export class Formatter {
       firstContext.getMetrics().totalLeftPx;
     let targetWidth = adjustedJustifyWidth;
     let actualWidth = shiftToIdealDistances(calculateIdealDistances(targetWidth));
-    const maxX = adjustedJustifyWidth + lastContext.getMetrics().notePx;
+    const musicFont = Flow.DEFAULT_FONT_STACK[0];
+    const paddingMax = musicFont.lookupMetric('stave.endPaddingMax');
+    const paddingMin = musicFont.lookupMetric('stave.endPaddingMin');
+    const maxX = adjustedJustifyWidth + lastContext.getMetrics().notePx - paddingMin;
 
     let iterations = this.formatterOptions.maxIterations;
-    while (actualWidth > maxX && iterations > 0) {
+    while ((actualWidth > maxX && iterations > 0) || (actualWidth + paddingMax < maxX && iterations > 1)) {
       // If we couldn't fit all the notes into the jusification width, it's because the softmax-scaled
       // widths between different durations differ across stave (e.g., 1 quarter note is not the same pixel-width
       // as 4 16th-notes). Run another pass, now that we know how much to justify.
@@ -917,7 +920,7 @@ export class Formatter {
     const options: FormatOptions = { padding: 10, /*stave,*/ context: stave.getContext(), ...optionsParam };
 
     // eslint-disable-next-line
-    const justifyWidth = stave.getNoteEndX() - stave.getNoteStartX() - options.padding!;
+    const justifyWidth = stave.getNoteEndX() - stave.getNoteStartX() - Stave.defaultPadding;
     L('Formatting voices to width: ', justifyWidth);
     return this.format(voices, justifyWidth, options);
   }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -64,7 +64,7 @@ export class Stave extends Element {
 
   // This is the sum of the padding that normally goes on left + right of a stave during
   // drawing.  Used to size staves correctly with content width
-  static get defaultPadding() {
+  static get defaultPadding(): number {
     const musicFont = Flow.DEFAULT_FONT_STACK[0];
     return musicFont.lookupMetric('stave.padding') + musicFont.lookupMetric('stave.endPaddingMax');
   }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -62,6 +62,13 @@ export class Stave extends Element {
   protected bounds: Bounds;
   protected readonly modifiers: StaveModifier[];
 
+  // This is the sum of the padding that normally goes on left + right of a stave during
+  // drawing.  Used to size staves correctly with content width
+  static get defaultPadding() {
+    const musicFont = Flow.DEFAULT_FONT_STACK[0];
+    return musicFont.lookupMetric('stave.padding') + musicFont.lookupMetric('stave.endPaddingMax');
+  }
+
   constructor(x: number, y: number, width: number, options?: StaveOptions) {
     super();
     this.setAttribute('type', 'Stave');

--- a/src/system.js
+++ b/src/system.js
@@ -6,6 +6,7 @@
 
 import { Element } from './element';
 import { Factory } from './factory';
+import { Stave } from './stave';
 import { Formatter } from './formatter';
 import { Note } from './note';
 
@@ -117,7 +118,7 @@ export class System extends Element {
     // Update the start position of all staves.
     this.parts.forEach((part) => part.stave.setNoteStartX(startX));
     const justifyWidth = this.options.noPadding
-      ? this.options.width - this.options.x
+      ? this.options.width - Stave.defaultPadding
       : this.options.width - (startX - this.options.x) - this.musicFont.lookupMetric('stave.padding');
 
     formatter.format(allVoices, this.options.noJustification ? 0 : justifyWidth);

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -2,7 +2,6 @@
  * VexFlow - TickContext Tests
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
-import { Stave } from '../releases/vexflow-tests';
 import { MockTickable } from './mocks';
 
 const FormatterTests = (function () {
@@ -531,7 +530,7 @@ const FormatterTests = (function () {
     },
 
     mixTime: function (options) {
-      var vf = VF.Test.makeFactory(options, 400 + Stave.defaultPadding, 250);
+      var vf = VF.Test.makeFactory(options, 400 + VF.Stave.defaultPadding, 250);
       vf.getContext().scale(0.8, 0.8);
       var score = vf.EasyScore();
       var system = vf.System({

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -2,6 +2,7 @@
  * VexFlow - TickContext Tests
  * Copyright Mohit Muthanna 2010 <mohit@muthanna.com>
  */
+import { Stave } from '../releases/vexflow-tests';
 import { MockTickable } from './mocks';
 
 const FormatterTests = (function () {
@@ -530,7 +531,7 @@ const FormatterTests = (function () {
     },
 
     mixTime: function (options) {
-      var vf = VF.Test.makeFactory(options, 420, 250);
+      var vf = VF.Test.makeFactory(options, 400 + Stave.defaultPadding, 250);
       vf.getContext().scale(0.8, 0.8);
       var score = vf.EasyScore();
       var system = vf.System({


### PR DESCRIPTION
Currently Formatter.formatToStave uses the pre-first-note padding but does not consider padding at the end of the measure.  Also, the formatting doesn't really consider end padding at all, so the actual end point of the bar is pretty inconsistent.

2 new metrics are defined for stave:  endPaddingMin and endPaddingMax.  default padding for calculation purposes is `padding + endPaddingMax`.  The formatter decides the current format fits within the measure if the right-most point is > `staffWidth - endPaddingMin` and < `staffWidth - endPaddingMax`.

Note that many test cases don't actually use formatToStave (even some that think they do) due to some other bugs that will be addressed in other changesets.

Here is a test case that _does_ use formatToStave.  Three images, pre-changes, changing only the padding, and changing the formatting to consider the padding.
Prior to this cs:
![pr_formatter_before](https://user-images.githubusercontent.com/5438280/121823022-37d05f80-cc68-11eb-9b8f-9add5a265801.PNG)

Only considering additional end padding:
![pr-correctpadding](https://user-images.githubusercontent.com/5438280/121823034-49196c00-cc68-11eb-8876-10f2d5da04a4.PNG)

Using both end padding and formatting to the end padding:
![image](https://user-images.githubusercontent.com/5438280/121823049-59314b80-cc68-11eb-8118-486e0ec5ca43.png)

