### PR TITLE
Add additional padding to left of accidentals

### DIFF
--- a/src/accidental.js
+++ b/src/accidental.js
@@ -34,9 +34,11 @@ export class Accidental extends Modifier {
 
   // Arrange accidentals inside a ModifierContext.
   static format(accidentals, state) {
-    const noteheadAccidentalPadding = 1;
+    const musicFont = Flow.DEFAULT_FONT_STACK[0];
+    const noteheadAccidentalPadding = musicFont.lookupMetric('accidental.noteheadAccidentalPadding');
     const leftShift = state.left_shift + noteheadAccidentalPadding;
-    const accidentalSpacing = 3;
+    const accidentalSpacing = musicFont.lookupMetric('accidental.accidentalSpacing');
+    const additionalPadding = musicFont.lookupMetric('accidental.leftPadding'); // padding to the left of all accidentals
 
     // If there are no accidentals, we needn't format their positions
     if (!accidentals || accidentals.length === 0) return;
@@ -298,7 +300,7 @@ export class Accidental extends Modifier {
     });
 
     // update the overall layout with the full width of the accidental shapes:
-    state.left_shift += totalShift;
+    state.left_shift += totalShift + additionalPadding;
   }
 
   // Helper function to determine whether two lines of accidentals collide vertically

--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -7,7 +7,11 @@ export const BravuraMetrics = {
     endPaddingMax: 10,
     endPaddingMin: 5
   },
-
+  accidental: {
+    noteheadAccidentalPadding: 1,
+    leftPadding: 2,
+    accidentalSpacing: 3
+  },
   clef: {
     default: {
       point: 32,

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -6,7 +6,11 @@ export const GonvilleMetrics = {
     endPaddingMax: 10,
     endPaddingMin: 5
   },
-
+  accidental: {
+    noteheadAccidentalPadding: 1,
+    leftPadding: 2,
+    accidentalSpacing: 3
+  },
   clef: {
     default: {
       point: 40,

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -7,7 +7,11 @@ export const PetalumaMetrics = {
     endPaddingMax: 15,
     endPaddingMin: 7
   },
-
+  accidental: {
+    noteheadAccidentalPadding: 1,
+    leftPadding: 2,
+    accidentalSpacing: 3
+  },
   clef: {
     default: {
       point: 32,


### PR DESCRIPTION
I thought it made sense to do the actual formatting changes first, b/c it's hard to evaluate the success of an estimate if there are formatting issues.

This just adds 2 pixels of padding to an accidental block, so they don't get squished against the notes to the left.  Also moved a couple of formatting magic numbers to metrics.  

Before:
![pr-accidental-padding](https://user-images.githubusercontent.com/5438280/121907338-94c42800-ccf1-11eb-9450-8d1cd1bc598c.PNG)

After, 1px padding:
![image](https://user-images.githubusercontent.com/5438280/122102612-396e6480-cddb-11eb-91b4-83116e8bbeb2.png)

After, 2px padding (this PR):
![image](https://user-images.githubusercontent.com/5438280/121907489-b6251400-ccf1-11eb-9336-93244ad9aee5.png)

