### PR TITLE
Correctly check for empty array

### DIFF
--- a/src/beam.ts
+++ b/src/beam.ts
@@ -436,7 +436,7 @@ export class Beam extends Element {
     super();
     this.setAttribute('type', 'Beam');
 
-    if (!notes || notes === []) {
+    if (!notes || notes.length === 0) {
       throw new RuntimeError('BadArguments', 'No notes provided for beam.');
     }
 


### PR DESCRIPTION
I found a very tiny bug where it's checking for empty array using `notes === []`, which is always false because `[] !== []` in JavaScript. Changed to `notes.length === 0`.

Searching the code base, the file `src/beams.ts` is the only place where this comparison was used.