### PR TITLE
Flow.ts: Use shorthand property names. Sort imports and keys.

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -1,162 +1,158 @@
-import { Element } from './element';
-import { Fraction } from './fraction';
-import { Renderer } from './renderer';
-import { Formatter } from './formatter';
-import { Music } from './music';
-import { Glyph } from './glyph';
-import { Stave } from './stave';
-import { StaveNote } from './stavenote';
-import { StaveModifier } from './stavemodifier';
-import { StaveTempo } from './stavetempo';
-import { Voice } from './voice';
+import { Tables } from './tables';
+
 import { Accidental } from './accidental';
-import { Beam } from './beam';
-import { StaveTie } from './stavetie';
-import { TabStave } from './tabstave';
-import { TabNote } from './tabnote';
-import { Bend } from './bend';
-import { Vibrato } from './vibrato';
-import { VibratoBracket } from './vibratobracket';
-import { Note } from './note';
-import { ModifierContext } from './modifiercontext';
-import { MultiMeasureRest } from './multimeasurerest';
-import { TickContext } from './tickcontext';
-import { Articulation } from './articulation';
 import { Annotation } from './annotation';
-import { ChordSymbol } from './chordsymbol';
+import { Articulation } from './articulation';
 import { Barline } from './stavebarline';
-import { NoteHead } from './notehead';
-import { StaveConnector } from './staveconnector';
+import { BarNote } from './barnote';
+import { Beam } from './beam';
+import { Bend } from './bend';
+import { BoundingBox } from './boundingbox';
+import { ChordSymbol } from './chordsymbol';
+import { Clef } from './clef';
 import { ClefNote } from './clefnote';
+import { Crescendo } from './crescendo';
+import { Curve } from './curve';
+import { Dot } from './dot';
+import { EasyScore } from './easyscore';
+import { Element } from './element';
+import { Factory } from './factory';
+import { Font, Fonts } from './font';
+import { Formatter } from './formatter';
+import { Fraction } from './fraction';
+import { FretHandFinger } from './frethandfinger';
+import { GhostNote } from './ghostnote';
+import { Glyph } from './glyph';
+import { GlyphNote } from './glyphnote';
+import { GraceNote } from './gracenote';
+import { GraceNoteGroup } from './gracenotegroup';
+import { GraceTabNote } from './gracetabnote';
+import { KeyManager } from './keymanager';
 import { KeySignature } from './keysignature';
 import { KeySigNote } from './keysignote';
+import { Modifier } from './modifier';
+import { ModifierContext } from './modifiercontext';
+import { MultiMeasureRest } from './multimeasurerest';
+import { Music } from './music';
+import { Note } from './note';
+import { NoteHead } from './notehead';
+import { NoteSubGroup } from './notesubgroup';
+import { Ornament } from './ornament';
+import { Parser } from './parser';
+import { PedalMarking } from './pedalmarking';
+import { Registry } from './registry';
+import { Renderer } from './renderer';
+import { RepeatNote } from './repeatnote';
+import { Repetition } from './staverepetition';
+import { Stave } from './stave';
+import { StaveConnector } from './staveconnector';
+import { StaveHairpin } from './stavehairpin';
+import { StaveLine } from './staveline';
+import { StaveModifier } from './stavemodifier';
+import { StaveNote } from './stavenote';
+import { StaveTempo } from './stavetempo';
+import { StaveText } from './stavetext';
+import { StaveTie } from './stavetie';
+import { Stem } from './stem';
+import { StringNumber } from './stringnumber';
+import { Stroke } from './strokes';
+import { System } from './system';
+import { TabNote } from './tabnote';
+import { TabSlide } from './tabslide';
+import { TabStave } from './tabstave';
+import { TabTie } from './tabtie';
+import { TextBracket } from './textbracket';
+import { TextDynamics } from './textdynamics';
+import { TextFont } from './textfont';
+import { TextNote } from './textnote';
+import { TickContext } from './tickcontext';
 import { TimeSignature } from './timesignature';
 import { TimeSigNote } from './timesignote';
-import { Stem } from './stem';
-import { TabTie } from './tabtie';
-import { Clef } from './clef';
-import { Dot } from './dot';
-import { Modifier } from './modifier';
-import { TabSlide } from './tabslide';
-import { Tuplet } from './tuplet';
-import { GraceNote } from './gracenote';
-import { GraceTabNote } from './gracetabnote';
-import { Tuning } from './tuning';
-import { KeyManager } from './keymanager';
-import { StaveHairpin } from './stavehairpin';
-import { BoundingBox } from './boundingbox';
-import { Stroke } from './strokes';
-import { TextNote } from './textnote';
-import { Curve } from './curve';
-import { TextDynamics } from './textdynamics';
-import { StaveLine } from './staveline';
-import { Ornament } from './ornament';
-import { PedalMarking } from './pedalmarking';
-import { TextBracket } from './textbracket';
-import { FretHandFinger } from './frethandfinger';
-import { Repetition } from './staverepetition';
-import { BarNote } from './barnote';
-import { GhostNote } from './ghostnote';
-import { NoteSubGroup } from './notesubgroup';
-import { GraceNoteGroup } from './gracenotegroup';
 import { Tremolo } from './tremolo';
-import { StringNumber } from './stringnumber';
-import { Crescendo } from './crescendo';
+import { Tuning } from './tuning';
+import { Tuplet } from './tuplet';
+import { Vibrato } from './vibrato';
+import { VibratoBracket } from './vibratobracket';
+import { Voice } from './voice';
 import { Volta } from './stavevolta';
-import { System } from './system';
-import { Factory } from './factory';
-import { Parser } from './parser';
-import { EasyScore } from './easyscore';
-import { Registry } from './registry';
-import { StaveText } from './stavetext';
-import { GlyphNote } from './glyphnote';
-import { RepeatNote } from './repeatnote';
-import { TextFont } from './textfont';
-import { PetalumaScriptTextMetrics } from './fonts/petalumascript_textmetrics';
-import { RobotoSlabTextMetrics } from './fonts/robotoslab_textmetrics';
-
-import { Font, Fonts } from './font';
-import { Tables } from './tables';
 
 export const Flow = {
   ...Tables,
-  Element: Element,
-  Fraction: Fraction,
-  Renderer: Renderer,
-  Formatter: Formatter,
-  Music: Music,
-  Glyph: Glyph,
-  Stave: Stave,
-  StaveNote: StaveNote,
-  StaveModifier: StaveModifier,
-  StaveTempo: StaveTempo,
-  Voice: Voice,
-  Accidental: Accidental,
-  Beam: Beam,
-  StaveTie: StaveTie,
-  TabStave: TabStave,
-  TabNote: TabNote,
-  Bend: Bend,
-  Vibrato: Vibrato,
-  VibratoBracket: VibratoBracket,
-  Note: Note,
-  ModifierContext: ModifierContext,
-  MultiMeasureRest: MultiMeasureRest,
-  TickContext: TickContext,
-  Articulation: Articulation,
-  Annotation: Annotation,
-  ChordSymbol: ChordSymbol,
-  Barline: Barline,
-  NoteHead: NoteHead,
-  StaveConnector: StaveConnector,
-  ClefNote: ClefNote,
-  KeySignature: KeySignature,
-  KeySigNote: KeySigNote,
-  TimeSignature: TimeSignature,
-  TimeSigNote: TimeSigNote,
-  Stem: Stem,
-  TabTie: TabTie,
-  Clef: Clef,
-  Dot: Dot,
-  Modifier: Modifier,
-  TabSlide: TabSlide,
-  Tuplet: Tuplet,
-  GraceNote: GraceNote,
-  GraceTabNote: GraceTabNote,
-  Tuning: Tuning,
-  KeyManager: KeyManager,
-  StaveHairpin: StaveHairpin,
-  BoundingBox: BoundingBox,
-  Stroke: Stroke,
-  TextNote: TextNote,
-  Curve: Curve,
-  TextDynamics: TextDynamics,
-  StaveLine: StaveLine,
-  Ornament: Ornament,
-  PedalMarking: PedalMarking,
-  TextBracket: TextBracket,
-  FretHandFinger: FretHandFinger,
-  Repetition: Repetition,
-  BarNote: BarNote,
-  GhostNote: GhostNote,
-  NoteSubGroup: NoteSubGroup,
-  GraceNoteGroup: GraceNoteGroup,
-  Tremolo: Tremolo,
-  StringNumber: StringNumber,
-  Crescendo: Crescendo,
-  Volta: Volta,
-  System: System,
-  Factory: Factory,
-  Parser: Parser,
-  EasyScore: EasyScore,
-  Registry: Registry,
-  StaveText: StaveText,
-  GlyphNote: GlyphNote,
-  RepeatNote: RepeatNote,
 
-  Font: Font,
-  Fonts: Fonts,
-  TextFont: TextFont,
-  PetalumaScriptTextMetrics: PetalumaScriptTextMetrics,
-  RobotoSlabTextMetrics: RobotoSlabTextMetrics,
+  Accidental,
+  Annotation,
+  Articulation,
+  Barline,
+  BarNote,
+  Beam,
+  Bend,
+  BoundingBox,
+  ChordSymbol,
+  Clef,
+  ClefNote,
+  Crescendo,
+  Curve,
+  Dot,
+  EasyScore,
+  Element,
+  Factory,
+  Font,
+  Fonts,
+  Formatter,
+  Fraction,
+  FretHandFinger,
+  GhostNote,
+  Glyph,
+  GlyphNote,
+  GraceNote,
+  GraceNoteGroup,
+  GraceTabNote,
+  KeyManager,
+  KeySignature,
+  KeySigNote,
+  Modifier,
+  ModifierContext,
+  MultiMeasureRest,
+  Music,
+  Note,
+  NoteHead,
+  NoteSubGroup,
+  Ornament,
+  Parser,
+  PedalMarking,
+  Registry,
+  Renderer,
+  RepeatNote,
+  Repetition,
+  Stave,
+  StaveConnector,
+  StaveHairpin,
+  StaveLine,
+  StaveModifier,
+  StaveNote,
+  StaveTempo,
+  StaveText,
+  StaveTie,
+  Stem,
+  StringNumber,
+  Stroke,
+  System,
+  TabNote,
+  TabSlide,
+  TabStave,
+  TabTie,
+  TextBracket,
+  TextDynamics,
+  TextFont,
+  TextNote,
+  TickContext,
+  TimeSignature,
+  TimeSigNote,
+  Tremolo,
+  Tuning,
+  Tuplet,
+  Vibrato,
+  VibratoBracket,
+  Voice,
+  Volta,
 };


### PR DESCRIPTION
While working on migrating test pages, I cleaned up flow.ts a bit. I extracted that change into this PR so it's easier to review.

In addition to sorting the imports and keys, I removed two entries that don't seem to be used anywhere on the test pages (and they are also not in version 3.0.9).

`PetalumaScriptTextMetrics`
`RobotoSlabTextMetrics`

I believe those two are used exclusively by `textfont.ts`, so they should be local to that file.