### PR TITLE
Add missing setters to maintain compatibility with CanvasRenderingContext2D API

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -98,7 +98,7 @@ export class CanvasContext implements RenderContext {
     this.vexFlowCanvasContext.fillRect(0, 0, this.canvas.width, this.canvas.height);
     this.vexFlowCanvasContext.fillStyle = oldFillStyle;
     */
-    this.background_fillStyle = style; // TODO: Is this a BUG? The field is never referenced anywhere else.
+    this.background_fillStyle = style;
     return this;
   }
 

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -1,13 +1,11 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
-// Mohit Muthanna <mohit@muthanna.com>
-//
-// A rendering context for the Canvas backend (CanvasRenderingContext2D).
-//
-// Copyright Mohit Cheppudira 2010
-
+// MIT License
 import { RenderContext } from './types/common';
 import { warn } from './util';
 
+/**
+ * A rendering context for the Canvas backend (CanvasRenderingContext2D).
+ */
 export class CanvasContext implements RenderContext {
   vexFlowCanvasContext: CanvasRenderingContext2D;
   canvas: HTMLCanvasElement | { width: number; height: number };
@@ -94,14 +92,13 @@ export class CanvasContext implements RenderContext {
   // It only fills the area behind some tab number annotations.
   setBackgroundFillStyle(style: string): this {
     /*
-    // The CanvasContext version only sets a field which is never referenced anywhere else.
     // Should it fill the entire canvas rect? For example:
     const oldFillStyle = this.vexFlowCanvasContext.fillStyle;
     this.vexFlowCanvasContext.fillStyle = style;
     this.vexFlowCanvasContext.fillRect(0, 0, this.canvas.width, this.canvas.height);
     this.vexFlowCanvasContext.fillStyle = oldFillStyle;
     */
-    this.background_fillStyle = style; // BUG? It is never referenced anywhere else.
+    this.background_fillStyle = style; // TODO: Is this a BUG? The field is never referenced anywhere else.
     return this;
   }
 
@@ -244,22 +241,16 @@ export class CanvasContext implements RenderContext {
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set font(value: string) {
-    debugger;
-    console.log('CanvasContext .font! [' + value + ']');
     this.vexFlowCanvasContext.font = value;
   }
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set fillStyle(style: string) {
-    debugger;
-    console.log('CanvasContext .fillStyle! [' + style + ']');
     this.vexFlowCanvasContext.fillStyle = style;
   }
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set strokeStyle(style: string) {
-    debugger;
-    console.log('CanvasContext .strokeStyle! [' + style + ']');
     this.vexFlowCanvasContext.strokeStyle = style;
   }
 }

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -39,7 +39,7 @@ export class CanvasContext implements RenderContext {
 
   /**
    * This constructor is only called if Renderer.USE_CANVAS_PROXY is true.
-   * In most instances, we do not need to
+   * In most instances, we do not need to create a CanvasContext object.
    * See Renderer.bolsterCanvasContext().
    * @param context
    */
@@ -240,5 +240,26 @@ export class CanvasContext implements RenderContext {
   restore(): this {
     this.vexFlowCanvasContext.restore();
     return this;
+  }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set font(value: string) {
+    debugger;
+    console.log('CanvasContext .font! [' + value + ']');
+    this.vexFlowCanvasContext.font = value;
+  }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set fillStyle(style: string) {
+    debugger;
+    console.log('CanvasContext .fillStyle! [' + style + ']');
+    this.vexFlowCanvasContext.fillStyle = style;
+  }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set strokeStyle(style: string) {
+    debugger;
+    console.log('CanvasContext .strokeStyle! [' + style + ']');
+    this.vexFlowCanvasContext.strokeStyle = style;
   }
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -71,6 +71,8 @@ export class Renderer {
 
     // Modify the CanvasRenderingContext2D to include the following methods, if they do not already exist.
     // setLineDash exists natively: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash
+    // TODO: Is a Proxy object appropriate here?
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
     const methodNames = [
       'clear',
       'setFont',
@@ -90,9 +92,14 @@ export class Renderer {
 
     ctx.vexFlowCanvasContext = ctx;
 
+    // TODO: Do we get called with the same context over and over again?
+    // TODO: Keep references to the context to see if it's the same one.
+    // ANSWER: PROBABLY YES!!!
     methodNames.forEach((methodName) => {
-      // eslint-disable-next-line
-      ctx[methodName] = ctx[methodName] || (CanvasContext.prototype as any)[methodName];
+      if (!(methodName in ctx)) {
+        // eslint-disable-next-line
+        ctx[methodName] = (CanvasContext.prototype as any)[methodName];
+      }
     });
 
     return ctx;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -30,9 +30,11 @@ export class Renderer {
     DOWN: 3, // Downward leg
   };
 
-  // Set this to true if you're using VexFlow inside a runtime
-  // that does not allow modifiying canvas objects. There is a small
-  // performance degradation due to the extra indirection.
+  /**
+   * Set this to true if you're using VexFlow inside a runtime
+   * that does not allow modifying canvas objects. There is a small
+   * performance degradation due to the extra indirection.
+   */
   static readonly USE_CANVAS_PROXY = false;
 
   static lastContext: RenderContext | undefined = undefined;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,13 +1,14 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
-//
-// ## Description
-// Support for different rendering contexts: Canvas & SVG
+// MIT License
 
 import { CanvasContext } from './canvascontext';
 import { SVGContext } from './svgcontext';
 import { RenderContext } from './types/common';
 import { RuntimeError } from './util';
 
+/**
+ * Support Canvas & SVG rendering contexts.
+ */
 export class Renderer {
   protected elementId?: string | HTMLElement;
   protected element: HTMLCanvasElement;
@@ -70,7 +71,6 @@ export class Renderer {
     }
 
     // Modify the CanvasRenderingContext2D to include the following methods, if they do not already exist.
-    // setLineDash exists natively: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash
     // TODO: Is a Proxy object appropriate here?
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
     const methodNames = [
@@ -84,7 +84,6 @@ export class Renderer {
       'setShadowBlur',
       'setLineWidth',
       'setLineCap',
-      'setLineDash',
       'openGroup',
       'closeGroup',
       'getGroup',
@@ -92,9 +91,6 @@ export class Renderer {
 
     ctx.vexFlowCanvasContext = ctx;
 
-    // TODO: Do we get called with the same context over and over again?
-    // TODO: Keep references to the context to see if it's the same one.
-    // ANSWER: PROBABLY YES!!!
     methodNames.forEach((methodName) => {
       if (!(methodName in ctx)) {
         // eslint-disable-next-line

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -1,4 +1,5 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
+// MIT License
 // @author Gregory Ristow (2015)
 
 import { RuntimeError, prefix } from './util';
@@ -30,7 +31,7 @@ const attrNamesToIgnoreMap: { [nodeName: string]: Attributes } = {
   },
 };
 
-// Create the SVG in the SVG namespace:
+/** Create the SVG in the SVG namespace. */
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 interface State {
@@ -40,6 +41,9 @@ interface State {
   lineWidth: number;
 }
 
+/**
+ * SVG rendering context with an API similar to CanvasRenderingContext2D.
+ */
 export class SVGContext implements RenderContext {
   element: HTMLElement; // the parent DOM object
   svg: SVGSVGElement;
@@ -253,6 +257,10 @@ export class SVGContext implements RenderContext {
     return this;
   }
 
+  /**
+   * @param width
+   * @returns this
+   */
   setLineWidth(width: number): this {
     this.attributes['stroke-width'] = width;
     this.lineWidth = width;
@@ -274,6 +282,10 @@ export class SVGContext implements RenderContext {
     }
   }
 
+  /**
+   * @param capType
+   * @returns this
+   */
   setLineCap(capType: CanvasLineCap): this {
     this.attributes['stroke-linecap'] = capType;
     return this;
@@ -712,19 +724,16 @@ export class SVGContext implements RenderContext {
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set font(value: string) {
-    console.log('SVG Context .font! [' + value + ']');
     this.setRawFont(value);
   }
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set fillStyle(style: string) {
-    console.log('SVG Context .fillStyle! [' + style + ']');
     this.setFillStyle(style);
   }
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   set strokeStyle(style: string) {
-    console.log('SVG Context .strokeStyle! [' + style + ']');
     this.setStrokeStyle(style);
   }
 }

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -709,4 +709,22 @@ export class SVGContext implements RenderContext {
     }
     return this;
   }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set font(value: string) {
+    console.log('SVG Context .font! [' + value + ']');
+    this.setRawFont(value);
+  }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set fillStyle(style: string) {
+    console.log('SVG Context .fillStyle! [' + style + ']');
+    this.setFillStyle(style);
+  }
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set strokeStyle(style: string) {
+    console.log('SVG Context .strokeStyle! [' + style + ']');
+    this.setStrokeStyle(style);
+  }
 }

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -82,10 +82,17 @@ export interface RenderContext {
   closeGroup(): void;
   add(child: any): void;
 
-  /**
-   * canvas returns TextMetrics and SVG returns SVGRect.
-   */
+  /** canvas returns TextMetrics and SVG returns SVGRect. */
   measureText(text: string): { width: number; height?: number };
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set font(value: string);
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set fillStyle(style: string);
+
+  /** Maintain compatibility with the CanvasRenderingContext2D API. */
+  set strokeStyle(style: string);
 }
 
 export interface TieNotes {

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -61,10 +61,8 @@ const AnnotationTests = (function () {
     simple: function (options, contextBuilder) {
       var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5);
-      // ctx.fillStyle = '#221';
-      // ctx.strokeStyle = '#221';
-      ctx.fillStyle = '#F21';
-      ctx.strokeStyle = '#F21';
+      ctx.fillStyle = '#221';
+      ctx.strokeStyle = '#221';
       ctx.font = ' 10pt Arial';
       var stave = new VF.TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 

--- a/tests/annotation_tests.js
+++ b/tests/annotation_tests.js
@@ -61,8 +61,10 @@ const AnnotationTests = (function () {
     simple: function (options, contextBuilder) {
       var ctx = contextBuilder(options.elementId, 500, 240);
       ctx.scale(1.5, 1.5);
-      ctx.fillStyle = '#221';
-      ctx.strokeStyle = '#221';
+      // ctx.fillStyle = '#221';
+      // ctx.strokeStyle = '#221';
+      ctx.fillStyle = '#F21';
+      ctx.strokeStyle = '#F21';
       ctx.font = ' 10pt Arial';
       var stave = new VF.TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 


### PR DESCRIPTION
Many test cases set the `fillStyle`, `strokeStyle`, and `font` directly via setters. However, `SVGContext` and `CanvasContext` did not actually implement those setters.

For example, if we write code like this:

```
      ctx.fillStyle = '#F21';
      ctx.strokeStyle = '#F21';
      ctx.font = '10pt Arial';
```

It will only affect the CanvasContext, since the web browser's native `CanvasRenderingContext2D` implements those setters.

I added the setters so that now it also works with `SVGContext`. See below for before/after:

![CanvasAPI](https://user-images.githubusercontent.com/239113/124418511-7b226900-dd10-11eb-80af-a095355aaf92.gif)


One question: We never actually create any CanvasContext objects. There are no test cases that set `Renderer.USE_CANVAS_PROXY` to true. What types of environments require us to use the CanvasContext() object?

```
    if (Renderer.USE_CANVAS_PROXY) {
      return new CanvasContext(ctx);
    }
```

Anyways, this PR is ready for code review!

Surprisingly there were no visual diffs with the test cases (or perhaps the `#221` color was close enough to the previous color that it was not detectable). However, I did verify that if I set the colors to #F00, that there is the expected visual diff on the test cases that use SVGContext (e.g., the black/red GIF above).