### PR TITLE
use formatter.preCalculateMinWidth in system/factory

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -68,6 +68,11 @@ export class Stave extends Element {
     const musicFont = Flow.DEFAULT_FONT_STACK[0];
     return musicFont.lookupMetric('stave.padding') + musicFont.lookupMetric('stave.endPaddingMax');
   }
+  // Right padding, used by system if startX is already determined.
+  static get rightPadding(): number {
+    const musicFont = Flow.DEFAULT_FONT_STACK[0];
+    return musicFont.lookupMetric('stave.endPaddingMax');
+  }
 
   constructor(x: number, y: number, width: number, options: Partial<StaveOptions>) {
     super();

--- a/tests/factory_tests.js
+++ b/tests/factory_tests.js
@@ -49,7 +49,7 @@ const FactoryTests = (function () {
     drawTab: function (options) {
       var vf = VF.Test.makeFactory(options, 500, 400);
 
-      var system = vf.System();
+      var system = vf.System({ width: 500 });
 
       var stave = vf.Stave().setClef('treble').setKeySignature('C#').setBegBarType(Vex.Flow.Barline.type.REPEAT_BEGIN);
 

--- a/tests/formatter_tests.js
+++ b/tests/formatter_tests.js
@@ -446,7 +446,7 @@ const FormatterTests = (function () {
       var vf = VF.Test.makeFactory(options, 650, 750);
       var system = vf.System({
         x: 50,
-        width: 500,
+        autoWidth: true,
         debugFormatter: debug,
         noJustification: !(options.params.justify === undefined && true),
         formatIterations: options.params.iterations,
@@ -498,8 +498,8 @@ const FormatterTests = (function () {
         var system = vf.System({
           x: 100,
           y,
-          width: 500,
           details: { softmaxFactor: factor },
+          autoWidth: true,
         });
 
         system
@@ -534,7 +534,7 @@ const FormatterTests = (function () {
       var score = vf.EasyScore();
       var system = vf.System({
         details: { softmaxFactor: 100 },
-        width: 500,
+        autoWidth: true,
         debugFormatter: true,
       });
 
@@ -563,7 +563,7 @@ const FormatterTests = (function () {
       vf.getContext().scale(0.8, 0.8);
       var score = vf.EasyScore();
       var system = vf.System({
-        width: 450,
+        autoWidth: true,
         debugFormatter: true,
         details: { maxIterations: 10 },
       });
@@ -595,7 +595,7 @@ const FormatterTests = (function () {
       vf.getContext().scale(0.8, 0.8);
       var score = vf.EasyScore();
       var system = vf.System({
-        width: 440,
+        autoWidth: true,
         debugFormatter: true,
       });
 


### PR DESCRIPTION
Possibly final issue with bug 846. 
If system is created with autoWidth set to true, it will calculate use formatter.preCalculateMinWidth and justify all voices.
autoWIdth flag is set by default if no width is provided, and justification is not specifically disabled with a flag.  I'll paste before/after.