### PR TITLE
Fix/OpenSheetMusicDisplay

### DIFF
--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -5,7 +5,7 @@
 
 /* eslint max-classes-per-file: "off" */
 
-import { RuntimeError, MakeException, log } from './util';
+import { RuntimeError, log } from './util';
 import { StaveNote } from './stavenote';
 import { Match, Parser, Result, Rule, RuleFunction } from './parser';
 import { Articulation } from './articulation';
@@ -21,8 +21,6 @@ import { Voice } from './voice';
 function L(...args: any[]): void {
   if (EasyScore.DEBUG) log('Vex.Flow.EasyScore', args);
 }
-
-const X = MakeException('EasyScoreError');
 
 type IDUpdate = { id: string };
 type ClassUpdate = { class: string };
@@ -466,7 +464,8 @@ export class EasyScore {
     this.builder.reset(options);
     const result = this.parser.parse(line);
     if (!result.success && this.options.throwOnError) {
-      throw new X('Error parsing line: ' + line, result);
+      L(result);
+      throw new RuntimeError('Error parsing line: ' + line);
     }
     return result;
   }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -8,7 +8,7 @@
 //
 // *This API is currently DRAFT*
 
-import { RuntimeError, MakeException, log } from './util';
+import { RuntimeError, log } from './util';
 import { Accidental } from './accidental';
 import { Articulation } from './articulation';
 import { Annotation } from './annotation';
@@ -80,8 +80,6 @@ function L(...args: any[]) {
   if (Factory.DEBUG) log('Vex.Flow.Factory', args);
 }
 
-const X = MakeException('FactoryError');
-
 export class Factory {
   static DEBUG: boolean;
 
@@ -148,7 +146,8 @@ export class Factory {
     if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     const { elementId, backend, width, height, background } = this.options.renderer;
     if (elementId === '') {
-      throw new X('HTML DOM element not set in Factory', this);
+      L(this);
+      throw new RuntimeError('HTML DOM element not set in Factory');
     }
 
     this.context = Renderer.buildContext(

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,7 +2,7 @@
 //
 // A generic text parsing class for VexFlow.
 
-import { MakeException, log } from './util';
+import { RuntimeError, log } from './util';
 import { Grammar } from './easyscore';
 
 // To enable logging for this class. Set `Vex.Flow.Parser.DEBUG` to `true`.
@@ -10,8 +10,6 @@ import { Grammar } from './easyscore';
 function L(...args: any[]): void {
   if (Parser.DEBUG) log('Vex.Flow.Parser', args);
 }
-
-const X = MakeException('ParserError');
 
 const NO_ERROR_POS = -1;
 
@@ -214,7 +212,7 @@ export class Parser {
   expect(ruleFunc: RuleFunction): Result {
     L('Evaluating rule function:', ruleFunc);
     if (!ruleFunc) {
-      throw new X('Invalid rule function: ' + ruleFunc, ruleFunc);
+      throw new RuntimeError('Invalid rule function');
     }
     let result: Result;
 
@@ -245,7 +243,8 @@ export class Parser {
         result = this.expectOne(rule);
       }
     } else {
-      throw new X('Bad grammar! No `token` or `expect` property', rule);
+      L(rule);
+      throw new RuntimeError('Bad grammar! No `token` or `expect` property ' + rule);
     }
 
     // If there's a trigger attached to this rule, then run it.

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -17,10 +17,8 @@
 // the registry. This allows fast look up of elements by attributes like id, type,
 // and class.
 
-import { MakeException } from './util';
+import { RuntimeError } from './util';
 import { Element } from './element';
-
-const X = MakeException('RegistryError');
 
 // Indexes are represented as maps of maps of maps. This allows
 // for both multi-labeling (e.g., an element can have multiple classes)
@@ -95,7 +93,7 @@ export class Registry {
   register(elem: Element, id?: string): this {
     id = id || elem.getAttribute('id');
     if (!id) {
-      throw new X("Can't add element without `id` attribute to registry", elem);
+      throw new RuntimeError("Can't add element without `id` attribute to registry");
     }
 
     // Manually add id to index, then update other indexes.

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -82,8 +82,6 @@ export class StringNumber extends Modifier {
     // Sort string numbers by line number.
     nums_list.sort((a, b) => b.line - a.line);
 
-    // TODO: This variable never gets assigned to anything. Is that a bug or can this be removed?
-    let num_shiftL = 0; // eslint-disable-line
     let num_shiftR = 0;
     let x_widthL = 0;
     let x_widthR = 0;
@@ -95,12 +93,10 @@ export class StringNumber extends Modifier {
       const pos = nums_list[i].pos;
       const num = nums_list[i].num;
       const line = nums_list[i].line;
-      const shiftL = nums_list[i].shiftL;
       const shiftR = nums_list[i].shiftR;
 
       // Reset the position of the string number every line.
       if (line !== last_line || note !== last_note) {
-        num_shiftL = left_shift + shiftL; // eslint-disable-line
         num_shiftR = right_shift + shiftR;
       }
 

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -84,15 +84,6 @@ export interface RenderContext {
 
   /** canvas returns TextMetrics and SVG returns SVGRect. */
   measureText(text: string): { width: number; height?: number };
-
-  /** Maintain compatibility with the CanvasRenderingContext2D API. */
-  set font(value: string);
-
-  /** Maintain compatibility with the CanvasRenderingContext2D API. */
-  set fillStyle(style: string);
-
-  /** Maintain compatibility with the CanvasRenderingContext2D API. */
-  set strokeStyle(style: string);
 }
 
 export interface TieNotes {

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,23 +20,6 @@ export function check<T>(x?: T): T {
   return x;
 }
 
-/** Create exception class with a given name. */
-export function MakeException(name: string): typeof exception {
-  const exception = class extends Error {
-    // eslint-disable-next-line
-    data: any;
-    // eslint-disable-next-line
-    constructor(message: string, data: any) {
-      super(message);
-      this.name = name;
-      this.message = message;
-      this.data = data;
-    }
-  };
-
-  return exception;
-}
-
 /** Default log function sends all arguments to console. */
 export function log(
   block: string,


### PR DESCRIPTION
@0xfe I have built the version 1.0.0 of OpenSheetMusicDisplay using `npm link ../vexflow/` and as I said @types/vexflow is no longer necessary. However OSMD was complaining about two topics:
- MakeException returning a private type. Here I decided to simply use `RuntimeError` and `log` if extra data is required.
- One unused variable (`num_shitL` already identified in comments). Here I decided simply to delete it.
- The set accessors in an interface in common are also not accepted.

No changes on visual regressions, all tests passed. :)
