### PR TITLE
Small fixes to TabNoteStruct and Unicode

### DIFF
--- a/src/tables.ts
+++ b/src/tables.ts
@@ -2,12 +2,11 @@
 
 /* eslint-disable key-spacing */
 
-import { RuntimeError } from './util';
+import { ArticulationStruct } from './articulation';
+import { Fonts } from './font';
 import { Fraction } from './fraction';
 import { Glyph } from './glyph';
-import { ArticulationStruct } from './articulation';
-
-import { Fonts } from './font';
+import { RuntimeError } from './util';
 
 // Custom note heads
 const customNoteHeads: Record<string, { code: string }> = {
@@ -539,7 +538,7 @@ export const Tables = {
     let width = 0;
     let shift_y = 0;
 
-    if (fret.toString().toUpperCase() === 'X') {
+    if (fret.toUpperCase() === 'X') {
       const glyphMetrics = new Glyph('accidentalDoubleSharp', Tables.DEFAULT_TABLATURE_FONT_SCALE).getMetrics();
       glyph = 'accidentalDoubleSharp';
       if (glyphMetrics.width == undefined || glyphMetrics.height == undefined)
@@ -547,7 +546,7 @@ export const Tables = {
       width = glyphMetrics.width;
       shift_y = -glyphMetrics.height / 2;
     } else {
-      width = Tables.textWidth(fret.toString());
+      width = Tables.textWidth(fret);
     }
 
     return {
@@ -730,17 +729,20 @@ export const Tables = {
   },
 
   unicode: {
-    // Unicode accidentals
-    sharp: String.fromCharCode(parseInt('266F', 16)),
-    flat: String.fromCharCode(parseInt('266D', 16)),
-    natural: String.fromCharCode(parseInt('266E', 16)),
-    // Major Chord
-    triangle: String.fromCharCode(parseInt('25B3', 16)),
-    // half-diminished
-    'o-with-slash': String.fromCharCode(parseInt('00F8', 16)),
-    // Diminished
-    degrees: String.fromCharCode(parseInt('00B0', 16)),
-    circle: String.fromCharCode(parseInt('25CB', 16)),
+    // ♯ accidental sharp
+    sharp: String.fromCharCode(0x266f),
+    // ♭ accidental flat
+    flat: String.fromCharCode(0x266d),
+    // ♮ accidental natural
+    natural: String.fromCharCode(0x266e),
+    // △ major seventh
+    triangle: String.fromCharCode(0x25b3),
+    // ø half-diminished
+    'o-with-slash': String.fromCharCode(0x00f8),
+    // ° diminished
+    degrees: String.fromCharCode(0x00b0),
+    // ○ diminished
+    circle: String.fromCharCode(0x25cb),
   },
 
   // Used to convert duration aliases to the number based duration.

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -7,19 +7,28 @@
 //
 // See `tests/tabnote_tests.js` for usage examples
 
-import { RuntimeError } from './util';
-import { Flow } from './flow';
-import { Modifier } from './modifier';
-import { Stem } from './stem';
-import { StemmableNote } from './stemmablenote';
 import { Dot } from './dot';
+import { Flow } from './flow';
 import { Glyph, GlyphProps } from './glyph';
+import { Modifier } from './modifier';
+import { ModifierContext } from './modifiercontext';
 import { Stave } from './stave';
 import { StaveNoteStruct } from './stavenote';
-import { ModifierContext } from './modifiercontext';
+import { Stem } from './stem';
+import { StemmableNote } from './stemmablenote';
+import { RuntimeError } from './util';
+
+export interface TabNotePosition {
+  // For example, on a six stringed instrument, `str` ranges from 1 to 6.
+  str: number;
+
+  // fret: 'X' indicates an unused/muted string.
+  // fret: 3 indicates the third fret.
+  fret: number | string;
+}
 
 export interface TabNoteStruct extends StaveNoteStruct {
-  positions: { str: string; fret: string }[];
+  positions: TabNotePosition[];
 }
 // Gets the unused strings grouped together if consecutive.
 //
@@ -116,7 +125,7 @@ function getPartialStemLines(stem_y: number, unused_strings: number[][], stave: 
 export class TabNote extends StemmableNote {
   protected ghost: boolean;
   protected glyphs: GlyphProps[] = [];
-  protected positions: { str: string; fret: string }[];
+  protected positions: TabNotePosition[];
 
   static get CATEGORY(): string {
     return 'tabnotes';
@@ -129,8 +138,8 @@ export class TabNote extends StemmableNote {
     this.setAttribute('type', 'TabNote');
 
     this.ghost = false; // Renders parenthesis around notes
+
     // Note properties
-    //
     // The fret positions in the note. An array of `{ str: X, fret: X }`
     this.positions = tab_struct.positions;
 
@@ -230,7 +239,7 @@ export class TabNote extends StemmableNote {
     for (let i = 0; i < this.positions.length; ++i) {
       let fret = this.positions[i].fret;
       if (this.ghost) fret = '(' + fret + ')';
-      const glyph = Flow.tabToGlyph(fret, this.render_options.scale);
+      const glyph = Flow.tabToGlyph(fret.toString(), this.render_options.scale);
       this.glyphs.push(glyph as GlyphProps);
       this.width = Math.max(glyph.getWidth(), this.width);
     }
@@ -280,7 +289,7 @@ export class TabNote extends StemmableNote {
   }
 
   // Get the fret positions for the note
-  getPositions(): { str: string; fret: string }[] {
+  getPositions(): TabNotePosition[] {
     return this.positions;
   }
 

--- a/tests/textnote_tests.ts
+++ b/tests/textnote_tests.ts
@@ -6,12 +6,13 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
-import { QUnit, equal, ok, test } from './declarations';
-import { Flow } from 'flow';
 import { Crescendo } from 'crescendo';
-import { TextNote } from 'textnote';
+import { Flow } from 'flow';
 import { Note } from 'note';
+import { TextNote } from 'textnote';
+
+import { equal, ok, QUnit, test } from './declarations';
+import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 const TextNoteTests = {
   Start(): void {


### PR DESCRIPTION
TabNoteStruct: Use `number | string` for fret positions. Handle edge cases. Fixes: https://github.com/0xfe/vexflow/issues/1093
Unicode: Remove `parseInt()` because I think JS engines should be able to deal with numbers starting with `0x`. Add comments showing the unicode output. Fixes: https://github.com/0xfe/vexflow/issues/1087

**No visual diffs from master.**

I have been using a VS Code extension called "TypeScript Import Sorter" so the imports are getting alphabetized by module name when I save the file. At some point we can add a [eslint rule](https://eslint.org/docs/rules/sort-imports) so we can have consistent imports. :-)