### PR TITLE
Remove instanceof from Fraction.

### DIFF
--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -11,14 +11,12 @@ export class Fraction {
   numerator: number = 1;
   denominator: number = 1;
 
-  // Cached objects for comparisons
+  // Cached objects for comparisons.
   private static __staticFractionA = new Fraction();
   private static __staticFractionB = new Fraction();
   private static __staticFractionTmp = new Fraction();
 
-  /**
-   * GCD: Greatest common divisor using Euclidean algorithm.
-   */
+  /** GCD: Greatest common divisor using Euclidean algorithm. */
   static GCD(a: number, b: number): number {
     if (typeof a !== 'number' || Number.isNaN(a) || a === 0 || typeof b !== 'number' || Number.isNaN(b) || b === 0) {
       throw new RuntimeError('BadArgument', `Invalid numbers: ${a}, ${b}`);
@@ -228,9 +226,7 @@ export class Fraction {
   }
 }
 
-/**
- * Helper Function to extract the numerator and denominator from another fraction.
- */
+/** Helper function to extract the numerator and denominator from another fraction. */
 function getNumeratorAndDenominator(n: Fraction | number, d: number = 1): [number, number] {
   if (typeof n === 'number') {
     // Both params are numbers, so we return them as [numerator, denominator].

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -1,21 +1,19 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
-// @author zz85
-// @author incompleteopus (modifications)
 // MIT License
+//
+// Author: Joshua Koo / @zz85
+// Author: @incompleteopus
 
 import { RuntimeError } from './util';
 
 /** Fraction represents a rational number. */
 export class Fraction {
   numerator: number = 1;
-
   denominator: number = 1;
 
   // Cached objects for comparisons
   private static __staticFractionA = new Fraction();
-
   private static __staticFractionB = new Fraction();
-
   private static __staticFractionTmp = new Fraction();
 
   /**
@@ -37,31 +35,24 @@ export class Fraction {
     return a;
   }
 
-  /**
-   * LCM: Lowest common multiple.
-   */
+  /** LCM: Lowest common multiple. */
   static LCM(a: number, b: number): number {
     return (a * b) / Fraction.GCD(a, b);
   }
 
-  /**
-   * LCMM: Lowest common multiple for more than two numbers.
-   */
-  static LCMM(
-    // eslint-disable-next-line
-    args: any): number {
+  /** Lowest common multiple for more than two numbers. */
+  static LCMM(args: number[]): number {
     if (args.length === 0) {
       return 0;
-    }
-    if (args.length === 1) {
+    } else if (args.length === 1) {
       return args[0];
-    }
-    if (args.length === 2) {
+    } else if (args.length === 2) {
       return Fraction.LCM(args[0], args[1]);
+    } else {
+      // args.shift() removes the first number.
+      // LCM the first number with the rest of the numbers.
+      return Fraction.LCM(args.shift() as number, Fraction.LCMM(args));
     }
-    const arg0 = args[0];
-    args.shift();
-    return Fraction.LCM(arg0, Fraction.LCMM(args));
   }
 
   /** Construct providing numerator and denominator. */
@@ -99,75 +90,33 @@ export class Fraction {
 
   /** Add value of another fraction. */
   add(param1: Fraction | number = 0, param2: number = 1): this {
-    let otherNumerator: number;
-    let otherDenominator: number;
-
-    if (param1 instanceof Fraction) {
-      otherNumerator = param1.numerator;
-      otherDenominator = param1.denominator;
-    } else {
-      otherNumerator = param1;
-      otherDenominator = param2;
-    }
-
+    const [otherNumerator, otherDenominator] = getNumeratorAndDenominator(param1, param2);
     const lcm = Fraction.LCM(this.denominator, otherDenominator);
     const a = lcm / this.denominator;
     const b = lcm / otherDenominator;
-
     const u = this.numerator * a + otherNumerator * b;
     return this.set(u, lcm);
   }
 
   /** Substract value of another fraction. */
   subtract(param1: Fraction | number = 0, param2: number = 1): this {
-    let otherNumerator: number;
-    let otherDenominator: number;
-
-    if (param1 instanceof Fraction) {
-      otherNumerator = param1.numerator;
-      otherDenominator = param1.denominator;
-    } else {
-      otherNumerator = param1;
-      otherDenominator = param2;
-    }
-
+    const [otherNumerator, otherDenominator] = getNumeratorAndDenominator(param1, param2);
     const lcm = Fraction.LCM(this.denominator, otherDenominator);
     const a = lcm / this.denominator;
     const b = lcm / otherDenominator;
-
     const u = this.numerator * a - otherNumerator * b;
     return this.set(u, lcm);
   }
 
   /** Multiply by value of another fraction. */
   multiply(param1: Fraction | number = 1, param2: number = 1): this {
-    let otherNumerator: number;
-    let otherDenominator: number;
-
-    if (param1 instanceof Fraction) {
-      otherNumerator = param1.numerator;
-      otherDenominator = param1.denominator;
-    } else {
-      otherNumerator = param1;
-      otherDenominator = param2;
-    }
-
+    const [otherNumerator, otherDenominator] = getNumeratorAndDenominator(param1, param2);
     return this.set(this.numerator * otherNumerator, this.denominator * otherDenominator);
   }
 
   /** Divide by value of another Fraction. */
   divide(param1: Fraction | number = 1, param2: number = 1): this {
-    let otherNumerator: number;
-    let otherDenominator: number;
-
-    if (param1 instanceof Fraction) {
-      otherNumerator = param1.numerator;
-      otherDenominator = param1.denominator;
-    } else {
-      otherNumerator = param1;
-      otherDenominator = param2;
-    }
-
+    const [otherNumerator, otherDenominator] = getNumeratorAndDenominator(param1, param2);
     return this.set(this.numerator * otherDenominator, this.denominator * otherNumerator);
   }
 
@@ -209,11 +158,12 @@ export class Fraction {
   }
 
   /** Copy value of another fraction. */
-  copy(copy: Fraction | number): this {
-    if (typeof copy === 'number') {
-      return this.set(copy || 0, 1);
+  copy(other: Fraction | number): this {
+    if (typeof other === 'number') {
+      return this.set(other, 1);
+    } else {
+      return this.set(other.numerator, other.denominator);
     }
-    return this.set(copy.numerator, copy.denominator);
   }
 
   /** Return the integer component (eg. 5/2 => 2). */
@@ -275,5 +225,18 @@ export class Fraction {
     const d = i[1] ? parseInt(i[1], 10) : 1;
 
     return this.set(n, d);
+  }
+}
+
+/**
+ * Helper Function to extract the numerator and denominator from another fraction.
+ */
+function getNumeratorAndDenominator(n: Fraction | number, d: number = 1): [number, number] {
+  if (typeof n === 'number') {
+    // Both params are numbers, so we return them as [numerator, denominator].
+    return [n, d];
+  } else {
+    // First param is a Fraction object. We ignore the second param.
+    return [n.numerator, n.denominator];
   }
 }

--- a/tests/fraction_tests.ts
+++ b/tests/fraction_tests.ts
@@ -3,13 +3,25 @@
 //
 // Fraction Tests
 
-import { QUnit, ok, test, notOk, notEqual, strictEqual, deepEqual, notDeepEqual, notStrictEqual } from './declarations';
+import {
+  QUnit,
+  deepEqual,
+  notDeepEqual,
+  notEqual,
+  notOk,
+  notStrictEqual,
+  ok,
+  strictEqual,
+  test,
+  equal,
+} from './declarations';
 import { Fraction } from 'fraction';
 
 const FractionTests = {
   Start(): void {
     QUnit.module('Fraction');
-    test('Basic', FractionTests.basic);
+    test('Basic', this.basic);
+    test('With Other Fractions', this.withOtherFractions);
   },
 
   basic(): void {
@@ -52,7 +64,37 @@ const FractionTests = {
     tF_n.divide(2);
     ok(tF_n.equals(2), 'Fraction: 4 / 2 equals 2');
 
-    // TODO: Add more detailed tests.
+    equal(Fraction.LCMM([]), 0);
+    equal(Fraction.LCMM([17]), 17);
+    equal(Fraction.LCMM([2, 5]), 10);
+    equal(Fraction.LCMM([15, 3, 5]), 15);
+    equal(Fraction.LCMM([2, 4, 6]), 12);
+    equal(Fraction.LCMM([2, 3, 4, 5]), 60);
+    equal(Fraction.LCMM([12, 15, 10, 75]), 300);
+  },
+
+  withOtherFractions(): void {
+    const f_1_2 = new Fraction(1, 2);
+    const f_1_4 = new Fraction(1, 4);
+    const f_1_8 = new Fraction(1, 8);
+    const f_2 = new Fraction(2, 1);
+
+    // IMPORTANT NOTE: Fraction methods modify the existing Fraction object.
+    // They do not return new objects.
+    // Use clone() if you don't want to modify the original object.
+    const a = f_1_2.clone().multiply(f_1_2);
+    ok(a.equals(f_1_4), '1/2 x 1/2 == 1/4');
+
+    const b = f_1_2.clone().divide(f_1_4);
+    ok(b.equals(f_2), '1/2 / 1/4 == 2');
+
+    const c = f_2.clone().subtract(f_1_2).subtract(f_1_2).subtract(f_1_4); // 3/4
+    const d = f_1_8.clone().add(f_1_8).add(f_1_8).multiply(f_2);
+    ok(c.equals(d), '2-1/2-1/2-1/4 == (1/8+1/8+1/8)*(2/1)');
+    equal(c.value(), 0.75, '3/4 == 0.75');
+
+    const e = f_1_8.clone().add(f_1_4).add(f_1_8);
+    ok(e.equals(f_1_2), '1/8 + 1/4 + 1/8 == 1/2');
   },
 };
 


### PR DESCRIPTION
Use `if (typeof n === 'number') {` instead of `instanceof Fraction` to differentiate between Fraction objects and numbers.

Added more tests to exercise the Fraction API, including tests for `Fraction.LCMM()`, which was previously untested. 

This PR partially addresses: https://github.com/0xfe/vexflow/issues/1096

No visual diffs.