### PR TITLE
Optimizations to the glyph code

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -26,7 +26,7 @@ export interface FontGlyph {
   o: string;
   leftSideBearing?: number;
   advanceWidth?: number;
-  cached_outline?: string[];
+  cached_outline?: number[];
 }
 
 class Font {

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -276,7 +276,6 @@ export class Glyph extends Element {
       point = data.point;
     }
 
-
     const scale = (point * 72.0) / (metrics.font.getResolution() * 100.0);
 
     Glyph.renderOutline(ctx, metrics.outline, scale * metrics.scale, x_pos + metrics.x_shift, y_pos + metrics.y_shift);

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -55,30 +55,115 @@ export interface GlyphMetrics {
   y_shift: number;
   scale: number;
   ha: number;
-  outline: string[];
+  outline: number[];
   font: Font;
+}
+
+export const enum OutlineCode {
+  MOVE = 0,
+  LINE = 1,
+  QUADRATIC = 2,
+  BEZIER = 3,
+}
+
+class GlyphCacheEntry {
+  metrics: GlyphMetrics;
+  bbox: BoundingBox;
+  point: number = -1;
+
+  constructor(fontStack: Font[], code: string, category?: string) {
+    this.metrics = Glyph.loadMetrics(fontStack, code, category);
+    this.bbox = Glyph.getOutlineBoundingBox(
+      this.metrics.outline,
+      this.metrics.scale,
+      this.metrics.x_shift,
+      this.metrics.y_shift
+    );
+
+    if (category) {
+      this.point = Glyph.lookupFontMetric(this.metrics.font, category, code, 'point', -1);
+    }
+  }
+}
+
+class GlyphCache {
+  protected cache: Map<Font[], Record<string, GlyphCacheEntry>> = new Map();
+
+  lookup(fontStack: Font[], code: string, category?: string): GlyphCacheEntry {
+    let entries = this.cache.get(fontStack);
+    if (entries === undefined) {
+      entries = {};
+      this.cache.set(fontStack, entries);
+    }
+    const key = category ? `${code}%${category}` : code;
+    let entry = entries[key];
+    if (entry === undefined) {
+      entry = new GlyphCacheEntry(fontStack, code, category);
+      entries[key] = entry;
+    }
+    return entry;
+  }
 }
 
 class GlyphOutline {
   private i: number = 0;
 
-  constructor(private outline: string[], private originX: number, private originY: number, private scale: number) {}
+  constructor(private outline: number[], private originX: number, private originY: number, private scale: number) {}
 
   done(): boolean {
     return this.i >= this.outline.length;
   }
-  next(): string {
+  next(): number {
     return this.outline[this.i++];
   }
   nextX(): number {
-    return this.originX + parseInt(this.outline[this.i++]) * this.scale;
+    return this.originX + this.outline[this.i++] * this.scale;
   }
   nextY(): number {
-    return this.originY - parseInt(this.outline[this.i++]) * this.scale;
+    return this.originY - this.outline[this.i++] * this.scale;
+  }
+
+  static parse(str: string): number[] {
+    const result: number[] = [];
+    const parts = str.split(' ');
+    let i = 0;
+    while (i < parts.length) {
+      switch (parts[i++]) {
+        case 'm':
+          result.push(OutlineCode.MOVE, parseInt(parts[i++]), parseInt(parts[i++]));
+          break;
+        case 'l':
+          result.push(OutlineCode.LINE, parseInt(parts[i++]), parseInt(parts[i++]));
+          break;
+        case 'q':
+          result.push(
+            OutlineCode.QUADRATIC,
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++])
+          );
+          break;
+        case 'b':
+          result.push(
+            OutlineCode.BEZIER,
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++]),
+            parseInt(parts[i++])
+          );
+          break;
+      }
+    }
+    return result;
   }
 }
 
 export class Glyph extends Element {
+  protected static cache = new GlyphCache();
+
   bbox: BoundingBox = new BoundingBox(0, 0, 0, 0);
   code: string;
   // metrics is initialised in the constructor by either setOptions or reset
@@ -104,19 +189,7 @@ export class Glyph extends Element {
     Below categoryPath can be any metric path under 'glyphs', so stem.up would respolve
     to glyphs.stem.up.shifX, glyphs.stem.up.shiftY, etc.
   */
-  static lookupFontMetric({
-    font,
-    category,
-    code,
-    key,
-    defaultValue,
-  }: {
-    font: Font;
-    category: string;
-    code: string;
-    key: string;
-    defaultValue: number;
-  }): number {
+  static lookupFontMetric(font: Font, category: string, code: string, key: string, defaultValue: number): number {
     let value = font.lookupMetric(`glyphs.${category}.${code}.${key}`, undefined);
     if (value === undefined) {
       value = font.lookupMetric(`glyphs.${category}.${key}`, defaultValue);
@@ -143,50 +216,37 @@ export class Glyph extends Element {
   static loadMetrics(fontStack: Font[], code: string, category?: string): GlyphMetrics {
     const { glyph, font } = Glyph.lookupGlyph(fontStack, code);
 
+    if (!glyph.o) throw new RuntimeError('BadGlyph', `Glyph ${code} has no outline defined.`);
+
     let x_shift = 0;
     let y_shift = 0;
     let scale = 1;
     if (category && font) {
-      x_shift = Glyph.lookupFontMetric({ font, category, code, key: 'shiftX', defaultValue: 0 });
-      y_shift = Glyph.lookupFontMetric({ font, category, code, key: 'shiftY', defaultValue: 0 });
-      scale = Glyph.lookupFontMetric({ font, category, code, key: 'scale', defaultValue: 1 });
+      x_shift = Glyph.lookupFontMetric(font, category, code, 'shiftX', 0);
+      y_shift = Glyph.lookupFontMetric(font, category, code, 'shiftY', 0);
+      scale = Glyph.lookupFontMetric(font, category, code, 'scale', 1);
     }
 
     const x_min = glyph.x_min;
     const x_max = glyph.x_max;
     const ha = glyph.ha;
 
-    let outline: string[];
-
-    const CACHE = true;
-    if (glyph.o) {
-      if (CACHE) {
-        if (glyph.cached_outline) {
-          outline = glyph.cached_outline;
-        } else {
-          outline = glyph.o.split(' ');
-          glyph.cached_outline = outline;
-        }
-      } else {
-        if (glyph.cached_outline) delete glyph.cached_outline;
-        outline = glyph.o.split(' ');
-      }
-
-      return {
-        x_min,
-        x_max,
-        x_shift,
-        y_shift,
-        scale,
-        ha,
-        outline,
-        font,
-        width: x_max - x_min,
-        height: ha,
-      };
-    } else {
-      throw new RuntimeError('BadGlyph', `Glyph ${code} has no outline defined.`);
+    if (!glyph.cached_outline) {
+      glyph.cached_outline = GlyphOutline.parse(glyph.o);
     }
+
+    return {
+      x_min,
+      x_max,
+      x_shift,
+      y_shift,
+      scale,
+      ha,
+      outline: glyph.cached_outline,
+      font,
+      width: x_max - x_min,
+      height: ha,
+    };
   }
 
   /**
@@ -210,16 +270,12 @@ export class Glyph extends Element {
       fontStack: Flow.DEFAULT_FONT_STACK,
       ...options,
     };
-    const metrics = Glyph.loadMetrics(params.fontStack, val, params.category);
-    if (params.category && metrics.font) {
-      point = Glyph.lookupFontMetric({
-        font: metrics.font,
-        category: params.category,
-        code: val,
-        key: 'point',
-        defaultValue: point,
-      });
+    const data = Glyph.cache.lookup(params.fontStack, val, params.category);
+    const metrics = data.metrics;
+    if (data.point != -1) {
+      point = data.point;
     }
+
 
     const scale = (point * 72.0) / (metrics.font.getResolution() * 100.0);
 
@@ -227,7 +283,7 @@ export class Glyph extends Element {
     return metrics;
   }
 
-  static renderOutline(ctx: RenderContext, outline: string[], scale: number, x_pos: number, y_pos: number): void {
+  static renderOutline(ctx: RenderContext, outline: number[], scale: number, x_pos: number, y_pos: number): void {
     const go = new GlyphOutline(outline, x_pos, y_pos, scale);
 
     ctx.beginPath();
@@ -235,18 +291,18 @@ export class Glyph extends Element {
     let x, y: number;
     while (!go.done()) {
       switch (go.next()) {
-        case 'm':
+        case OutlineCode.MOVE:
           ctx.moveTo(go.nextX(), go.nextY());
           break;
-        case 'l':
+        case OutlineCode.LINE:
           ctx.lineTo(go.nextX(), go.nextY());
           break;
-        case 'q':
+        case OutlineCode.QUADRATIC:
           x = go.nextX();
           y = go.nextY();
           ctx.quadraticCurveTo(go.nextX(), go.nextY(), x, y);
           break;
-        case 'b':
+        case OutlineCode.BEZIER:
           x = go.nextX();
           y = go.nextY();
           ctx.bezierCurveTo(go.nextX(), go.nextY(), go.nextX(), go.nextY(), x, y);
@@ -256,7 +312,7 @@ export class Glyph extends Element {
     ctx.fill();
   }
 
-  static getOutlineBoundingBox(outline: string[], scale: number, x_pos: number, y_pos: number): BoundingBox {
+  static getOutlineBoundingBox(outline: number[], scale: number, x_pos: number, y_pos: number): BoundingBox {
     const go = new GlyphOutline(outline, x_pos, y_pos, scale);
     const bboxComp = new BoundingBoxComputation();
 
@@ -266,25 +322,25 @@ export class Glyph extends Element {
     let x, y: number;
     while (!go.done()) {
       switch (go.next()) {
-        case 'm':
+        case OutlineCode.MOVE:
           // Note that we don't add any points to the bounding box until a srroke is actually drawn.
           penX = go.nextX();
           penY = go.nextY();
           break;
-        case 'l':
+        case OutlineCode.LINE:
           bboxComp.addPoint(penX, penY);
           penX = go.nextX();
           penY = go.nextY();
           bboxComp.addPoint(penX, penY);
           break;
-        case 'q':
+        case OutlineCode.QUADRATIC:
           x = go.nextX();
           y = go.nextY();
           bboxComp.addQuadraticCurve(penX, penY, go.nextX(), go.nextY(), x, y);
           penX = x;
           penY = y;
           break;
-        case 'b':
+        case OutlineCode.BEZIER:
           x = go.nextX();
           y = go.nextY();
           bboxComp.addBezierCurve(penX, penY, go.nextX(), go.nextY(), go.nextX(), go.nextY(), x, y);
@@ -295,6 +351,15 @@ export class Glyph extends Element {
     }
 
     return new BoundingBox(bboxComp.getX1(), bboxComp.getY1(), bboxComp.width(), bboxComp.height());
+  }
+
+  static getWidth(fontStack: Font[], code: string, point: number, category?: string): number {
+    const data = Glyph.cache.lookup(fontStack, code, category);
+    if (data.point != -1) {
+      point = data.point;
+    }
+    const scale = (point * 72) / (data.metrics.font.getResolution() * 100);
+    return data.bbox.getW() * scale;
   }
 
   /**
@@ -356,24 +421,19 @@ export class Glyph extends Element {
   }
 
   reset(): void {
-    this.metrics = Glyph.loadMetrics(this.options.fontStack, this.code, this.options.category);
+    const data = Glyph.cache.lookup(this.options.fontStack, this.code, this.options.category);
+    this.metrics = data.metrics;
     // Override point from metrics file
-    if (this.options.category) {
-      this.point = Glyph.lookupFontMetric({
-        category: this.options.category,
-        font: this.metrics.font,
-        code: this.code,
-        key: 'point',
-        defaultValue: this.point,
-      });
+    if (data.point != -1) {
+      this.point = data.point;
     }
 
     this.scale = (this.point * 72) / (this.metrics.font.getResolution() * 100);
-    this.bbox = Glyph.getOutlineBoundingBox(
-      this.metrics.outline,
-      this.scale * this.metrics.scale,
-      this.metrics.x_shift,
-      this.metrics.y_shift
+    this.bbox = new BoundingBox(
+      data.bbox.getX() * this.scale,
+      data.bbox.getY() * this.scale,
+      data.bbox.getW() * this.scale,
+      data.bbox.getH() * this.scale
     );
   }
 

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -3,6 +3,7 @@
 /* eslint-disable key-spacing */
 
 import { ArticulationStruct } from './articulation';
+import { Flow } from './flow';
 import { Fonts } from './font';
 import { Fraction } from './fraction';
 import { Glyph } from './glyph';
@@ -317,6 +318,9 @@ const accidentals: Record<string, { code: string; parenRightPaddingAdjustment: n
   accidentalWilsonPlus: { code: 'accidentalWilsonPlus', parenRightPaddingAdjustment: -1 },
   accidentalWilsonMinus: { code: 'accidentalWilsonMinus', parenRightPaddingAdjustment: -1 },
 };
+
+// eslint-disable-next-line
+let duration_codes: Record<string, any>;
 
 export const Tables = {
   STEM_WIDTH: 1.5,
@@ -801,8 +805,7 @@ export const Tables = {
     type?: string
   ): // eslint-disable-next-line
   any {
-    // eslint-disable-next-line
-    const duration_codes: Record<string, any> = {
+    duration_codes = duration_codes || {
       '1/2': {
         common: {
           stem: false,
@@ -821,14 +824,14 @@ export const Tables = {
             // Breve note
             code_head: 'noteheadDoubleWhole',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDoubleWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDoubleWhole', scale);
             },
           },
           h: {
             // Breve note harmonic
             code_head: 'unpitchedPercussionClef1',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('unpitchedPercussionClef1', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'unpitchedPercussionClef1', scale);
             },
           },
           m: {
@@ -836,7 +839,7 @@ export const Tables = {
             code_head: 'vexNoteHeadMutedBreve',
             stem_offset: 0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('vexNoteHeadMutedBreve', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'vexNoteHeadMutedBreve', scale);
             },
           },
           r: {
@@ -846,7 +849,7 @@ export const Tables = {
             position: 'B/5',
             dot_shiftY: 0.5,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('restDoubleWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'restDoubleWhole', scale);
             },
           },
           s: {
@@ -875,14 +878,14 @@ export const Tables = {
             // Whole note
             code_head: 'noteheadWhole',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadWhole', scale);
             },
           },
           h: {
             // Whole note harmonic
             code_head: 'noteheadDiamondWhole',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondWhole', scale);
             },
           },
           m: {
@@ -890,7 +893,7 @@ export const Tables = {
             code_head: 'noteheadXWhole',
             stem_offset: -3,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXWhole', scale);
             },
           },
           r: {
@@ -900,7 +903,7 @@ export const Tables = {
             position: 'D/5',
             dot_shiftY: 0.5,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('restWhole', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'restWhole', scale);
             },
           },
           s: {
@@ -929,14 +932,14 @@ export const Tables = {
             // Half note
             code_head: 'noteheadHalf',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadHalf', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadHalf', scale);
             },
           },
           h: {
             // Half note harmonic
             code_head: 'noteheadDiamondHalf',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondHalf', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondHalf', scale);
             },
           },
           m: {
@@ -944,7 +947,7 @@ export const Tables = {
             code_head: 'noteheadXHalf',
             stem_offset: -3,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXHalf', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXHalf', scale);
             },
           },
           r: {
@@ -955,7 +958,7 @@ export const Tables = {
             position: 'B/4',
             dot_shiftY: -0.5,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('restHalf', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'restHalf', scale);
             },
           },
           s: {
@@ -984,21 +987,21 @@ export const Tables = {
             // Quarter note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Quarter harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Quarter muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1011,7 +1014,7 @@ export const Tables = {
             line_above: 1.5,
             line_below: 1.5,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('restQuarter', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'restQuarter', scale);
             },
           },
           s: {
@@ -1043,21 +1046,21 @@ export const Tables = {
             // Eighth note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Eighth note harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Eighth note muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1071,7 +1074,7 @@ export const Tables = {
             line_above: 1.0,
             line_below: 1.0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('rest8th', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'rest8th', scale);
             },
           },
           s: {
@@ -1103,21 +1106,21 @@ export const Tables = {
             // Sixteenth note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Sixteenth note harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Sixteenth note muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1131,7 +1134,7 @@ export const Tables = {
             line_above: 1.0,
             line_below: 2.0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('rest16th', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'rest16th', scale);
             },
           },
           s: {
@@ -1163,21 +1166,21 @@ export const Tables = {
             // Thirty-second note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Thirty-second harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Thirty-second muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1191,7 +1194,7 @@ export const Tables = {
             line_above: 2.0,
             line_below: 2.0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('rest32nd', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'rest32nd', scale);
             },
           },
           s: {
@@ -1223,21 +1226,21 @@ export const Tables = {
             // Sixty-fourth note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Sixty-fourth harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Sixty-fourth muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1251,7 +1254,7 @@ export const Tables = {
             line_above: 2.0,
             line_below: 3.0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('rest64th', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'rest64th', scale);
             },
           },
           s: {
@@ -1283,21 +1286,21 @@ export const Tables = {
             // Hundred-twenty-eight note
             code_head: 'noteheadBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadBlack', scale);
             },
           },
           h: {
             // Hundred-twenty-eight harmonic
             code_head: 'noteheadDiamondBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadDiamondBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadDiamondBlack', scale);
             },
           },
           m: {
             // Hundred-twenty-eight muted
             code_head: 'noteheadXBlack',
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('noteheadXBlack', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'noteheadXBlack', scale);
             },
           },
           r: {
@@ -1311,7 +1314,7 @@ export const Tables = {
             line_above: 3.0,
             line_below: 3.0,
             getWidth(scale = Tables.DEFAULT_NOTATION_FONT_SCALE): number | undefined {
-              return new Glyph('rest128th', scale).getMetrics().width;
+              return Glyph.getWidth(Flow.DEFAULT_FONT_STACK, 'rest128th', scale);
             },
           },
           s: {

--- a/tests/boundingboxcomputation_tests.ts
+++ b/tests/boundingboxcomputation_tests.ts
@@ -205,18 +205,7 @@ const BoundingBoxComputationTests = {
 
     // Regression test for a prior bug: compute the bounding box again,
     // this time using the Glyph.getOutlineBoundingBox code path.
-    const o = [
-      OutlineCode.MOVE,
-      x0,
-      -y0,
-      OutlineCode.BEZIER,
-      x3,
-      -y3,
-      x1,
-      -y1,
-      x2,
-      -y2,
-    ];
+    const o = [OutlineCode.MOVE, x0, -y0, OutlineCode.BEZIER, x3, -y3, x1, -y1, x2, -y2];
     const bbox = VF.Glyph.getOutlineBoundingBox(o, 1, 0, 0);
     rect(ctx, '#fa0', 1, bbox.x, bbox.y, bbox.w, bbox.h);
 

--- a/tests/boundingboxcomputation_tests.ts
+++ b/tests/boundingboxcomputation_tests.ts
@@ -6,6 +6,7 @@
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { QUnit, ok, test, equal } from './declarations';
 import { RenderContext } from 'types/common';
+import { OutlineCode } from 'glyph';
 
 function createCanvas(options: TestOptions): RenderContext {
   const points = options.params.points;
@@ -154,7 +155,7 @@ const BoundingBoxComputationTests = {
 
     // Regression test for a prior bug: compute the bounding box again,
     // this time using the Glyph.getOutlineBoundingBox code path.
-    const o = ['m', x0.toString(), -y0.toString(), 'q', x2.toString(), -y2.toString(), x1.toString(), -y1.toString()];
+    const o = [OutlineCode.MOVE, x0, -y0, OutlineCode.QUADRATIC, x2, -y2, x1, -y1];
     const bbox = VF.Glyph.getOutlineBoundingBox(o, 1, 0, 0);
     rect(ctx, '#fa0', 1, bbox.x, bbox.y, bbox.w, bbox.h);
 
@@ -205,16 +206,16 @@ const BoundingBoxComputationTests = {
     // Regression test for a prior bug: compute the bounding box again,
     // this time using the Glyph.getOutlineBoundingBox code path.
     const o = [
-      'm',
-      x0.toString(),
-      -y0.toString(),
-      'b',
-      x3.toString(),
-      -y3.toString(),
-      x1.toString(),
-      -y1.toString(),
-      x2.toString(),
-      -y2.toString(),
+      OutlineCode.MOVE,
+      x0,
+      -y0,
+      OutlineCode.BEZIER,
+      x3,
+      -y3,
+      x1,
+      -y1,
+      x2,
+      -y2,
     ];
     const bbox = VF.Glyph.getOutlineBoundingBox(o, 1, 0, 0);
     rect(ctx, '#fa0', 1, bbox.x, bbox.y, bbox.w, bbox.h);


### PR DESCRIPTION
These optimisations speed up the time spent during parsing and rendering the "Bach demo" test by a factor of approximately 1.6 in both Chrome and Firefox on my machine. The total time spent running all tests is reduced from approximately 16 seconds to 12 seconds.

Some more details:
 - Convert the cached outline from an array of strings to an array of integers. This avoids repeatedly calling `parseInt` whenever the outline is processed.
 - Cache the glyph metrics and bounding box, which avoids repeatedly loading the metrics and parsing the outline data.
 - Add a static `Glyph.getWidth` method that calculates the width from the cached bounding box rather than creating a complete `Glyph` object when only the width is needed.
 - Replace all the implementation of the `getWidth` calls in `tables.ts` to use the new `Glyph.getWidth` method.
 - I also made `duration_codes` in `tables.ts` a global variable that gets lazily initialised on the first call to `getGlyphProps`. Even though `duration_codes` is marked `const`, the compiled JS code was creating new instances of the object literal every single time the function was called.