### PR TITLE
Fix a test case that permanently modified Vex.Flow.STAVE_LINE_THICKNESS

### DIFF
--- a/tests/staveconnector_tests.ts
+++ b/tests/staveconnector_tests.ts
@@ -19,7 +19,7 @@ const StaveConnectorTests = {
     const run = VexFlowTests.runTests;
     test('VF.* API', this.VF_Prefix);
     run('Single Draw Test', this.drawSingle);
-    run('Single Draw Test, 1px Stave Line Thickness', this.drawSingle1pxBarlines);
+    run('Single Draw Test, 4px Stave Line Thickness', this.drawSingle4pxStaveLines);
     run('Single Both Sides Test', this.drawSingleBoth);
     run('Double Draw Test', this.drawDouble);
     run('Bold Double Line Left Draw Test', this.drawRepeatBegin);
@@ -54,8 +54,9 @@ const StaveConnectorTests = {
     ok(true, 'all pass');
   },
 
-  drawSingle1pxBarlines(options: TestOptions, contextBuilder: ContextBuilder): void {
-    VF.STAVE_LINE_THICKNESS = 1;
+  drawSingle4pxStaveLines(options: TestOptions, contextBuilder: ContextBuilder): void {
+    const oldThickness = VF.STAVE_LINE_THICKNESS;
+    VF.STAVE_LINE_THICKNESS = 4;
     const ctx = contextBuilder(options.elementId, 400, 300);
     const stave = new Stave(25, 10, 300);
     const stave2 = new Stave(25, 120, 300);
@@ -67,7 +68,7 @@ const StaveConnectorTests = {
     stave.draw();
     stave2.draw();
     connector.draw();
-    VF.STAVE_LINE_THICKNESS = 2;
+    VF.STAVE_LINE_THICKNESS = oldThickness;
 
     ok(true, 'all pass');
   },


### PR DESCRIPTION
Summary: doing so allows us to alphabetically sort the tests and test imports in `run.ts` without breaking things.

---

In an older version of VexFlow, ( circa Oct 2015 / commit b8d27229d2ac69d732d7b8df0b4b75c1b6c8a609 ) `STAVE_LINE_THICKNESS` was 2 by default. Currently it is 1.

`staveconnector_tests` had a test case that temporarily set the thickness to 1, and then changed it back to 2. This worked back in the day, but now that the default is 1, it has the problem of permanently changing the thickness away from the default for all test cases that come after the StaveConnectorTests.



This PR results in 363 visual diffs, all related to the stave lines in test cases that were run after `StaveConnectorTests.Start()`;
The *reference images were wrong* because they do not render the stave lines correctly.

This fixes https://github.com/0xfe/vexflow/issues/1109