### PR TITLE
Clean up EasyScore & Parser.

### DIFF
--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -400,6 +400,25 @@ export interface EasyScoreDefaults {
 }
 
 /**
+ * Commit hook used by EasyScore.setOptions().
+ */
+function setId(options: { id?: string }, note: StaveNote) {
+  if (options.id === undefined) return;
+  note.setAttribute('id', options.id);
+}
+
+// Used by setClass() below.
+const commaSeparatedRegex = /\s*,\s*/;
+
+/**
+ * Commit hook used by EasyScore.setOptions().
+ */
+function setClass(options: { class?: string }, note: StaveNote) {
+  if (options.class === undefined) return;
+  options.class.split(commaSeparatedRegex).forEach((className: string) => note.addClass(className));
+}
+
+/**
  * EasyScore implements a parser for a simple language to generate VexFlow objects.
  */
 export class EasyScore {
@@ -501,16 +520,3 @@ export class EasyScore {
     this.builder.addCommitHook(commitHook);
   }
 }
-
-//#region Commit Hooks
-function setId(options: { id?: string }, note: StaveNote) {
-  if (options.id === undefined) return;
-  note.setAttribute('id', options.id);
-}
-
-const commaSeparatedRegex = /\s*,\s*/;
-function setClass(options: { class?: string }, note: StaveNote) {
-  if (options.class === undefined) return;
-  options.class.split(commaSeparatedRegex).forEach((className: string) => note.addClass(className));
-}
-//#endregion

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -661,21 +661,21 @@ export class Factory {
   }
 
   /**
-   * Creates EasyScore. Normally the first step after constructing a factory.
+   * Creates EasyScore. Normally the first step after constructing a Factory.
    *
    * Example:
    *
    * `const vf: Factory = new Vex.Flow.Factory({renderer: { elementId: 'boo', width: 1200, height: 600 }});`
    *
    * `const score: EasyScore = vf.EasyScore();`
-   * @param params.factory not required
-   * @param params.builder instance of Builder
-   * @param params.commitHooks function to call after a note element is created
-   * @param params.throwOnError throw error in case of parsing error
+   * @param options.factory optional instance of Factory
+   * @param options.builder instance of Builder
+   * @param options.commitHooks function to call after a note element is created
+   * @param options.throwOnError throw error in case of parsing error
    */
-  EasyScore(params: EasyScoreOptions = {}): EasyScore {
-    params.factory = this;
-    return new EasyScore(params);
+  EasyScore(options: Partial<EasyScoreOptions> = {}): EasyScore {
+    options.factory = this;
+    return new EasyScore(options);
   }
 
   PedalMarking(paramsP: { notes?: StaveNote[]; options?: { style: string } } = {}): PedalMarking {

--- a/src/music.ts
+++ b/src/music.ts
@@ -158,7 +158,7 @@ export class Music {
     };
   }
 
-  /** Accidentals abreviations. */
+  /** Accidentals abbreviations. */
   static get accidentals(): string[] {
     return ['bb', 'b', 'n', '#', '##'];
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,7 +3,6 @@
 // A generic text parsing class for VexFlow.
 
 import { RuntimeError, log } from './util';
-import { Grammar } from './easyscore';
 
 // To enable logging for this class. Set `Vex.Flow.Parser.DEBUG` to `true`.
 // eslint-disable-next-line
@@ -64,6 +63,10 @@ function flattenMatches(r: Result | Result[]): Match {
   return results.map(flattenMatches); // nested array
 }
 
+export interface Grammar {
+  begin(): RuleFunction;
+}
+
 // This is the base parser class. Given an arbitrary context-free grammar, it
 // can parse any line and execute code when specific rules are met (e.g.,
 // when a string is terminated.)
@@ -120,10 +123,7 @@ export class Parser {
         pos: this.pos,
       };
     } else {
-      return {
-        success: false,
-        pos: this.pos,
-      };
+      return { success: false, pos: this.pos };
     }
   }
 
@@ -253,9 +253,7 @@ export class Parser {
     const matches: Match[] = [];
     result.matches = matches;
     if (result.results) {
-      result.results.forEach((r) => {
-        matches.push(flattenMatches(r));
-      });
+      result.results.forEach((r) => matches.push(flattenMatches(r)));
     }
     if (rule.run && result.success) {
       rule.run({ matches });

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -17,8 +17,8 @@ import { StaveNote } from 'stavenote';
 
 const ChordSymbolTests = {
   Start(): void {
-    const run = VexFlowTests.runTests;
     QUnit.module('ChordSymbol');
+    const run = VexFlowTests.runTests;
     run('Chord Symbol Font Size Tests', fontSize);
     run('Chord Symbol Kerning Tests', kern);
     run('Top Chord Symbols', top);


### PR DESCRIPTION
Use TypeScript's Partial<Type> for EasyScoreOptions.
Use spread operator instead of Object.assign, as discussed in https://github.com/0xfe/vexflow/pull/999#discussion_r641946148
Parser should not know about EasyScore. Grammar is now a simple interface with one required begin() function.