### PR TITLE
Rename check<T>() to defined<T>().

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -500,9 +500,7 @@ export class Accidental extends Modifier {
     };
 
     this.accidental = Flow.accidentalCodes(this.type);
-    if (!this.accidental) {
-      throw new RuntimeError('ArgumentError', `Unknown accidental type: ${type}`);
-    }
+    defined(this.accidental, 'ArgumentError', `Unknown accidental type: ${type}`);
 
     // Cautionary accidentals have parentheses around them
     this.cautionary = false;
@@ -546,9 +544,7 @@ export class Accidental extends Modifier {
 
   /** Attach this accidental to `note`, which must be a `StaveNote`. */
   setNote(note: Note): this {
-    if (!note) {
-      throw new RuntimeError('ArgumentError', `Bad note value: ${note}`);
-    }
+    defined(note, 'ArgumentError', `Bad note value: ${note}`);
 
     this.note = note;
 

--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -3,7 +3,7 @@
 // @author Mohit Cheppudira
 // @author Greg Ristow (modifications)
 
-import { RuntimeError, log, defined } from './util';
+import { log, defined } from './util';
 import { Fraction } from './fraction';
 import { Flow } from './flow';
 import { Music } from './music';

--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -3,7 +3,7 @@
 // @author Mohit Cheppudira
 // @author Greg Ristow (modifications)
 
-import { RuntimeError, log, check } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Fraction } from './fraction';
 import { Flow } from './flow';
 import { Music } from './music';
@@ -531,8 +531,8 @@ export class Accidental extends Modifier {
   /** Get width in pixels. */
   getWidth(): number {
     const parenWidth = this.cautionary
-      ? check<Glyph>(this.parenLeft).getMetrics().width +
-        check<Glyph>(this.parenRight).getMetrics().width +
+      ? defined<Glyph>(this.parenLeft).getMetrics().width +
+        defined<Glyph>(this.parenRight).getMetrics().width +
         this.render_options.parenLeftPadding +
         this.render_options.parenRightPadding
       : 0;
@@ -593,14 +593,14 @@ export class Accidental extends Modifier {
       glyph.render(ctx, accX, accY);
     } else {
       // Render the accidental in parentheses.
-      check<Glyph>(parenRight).render(ctx, accX, accY);
-      accX -= check<Glyph>(parenRight).getMetrics().width;
+      defined<Glyph>(parenRight).render(ctx, accX, accY);
+      accX -= defined<Glyph>(parenRight).getMetrics().width;
       accX -= parenRightPadding;
       accX -= this.accidental.parenRightPaddingAdjustment;
       glyph.render(ctx, accX, accY);
       accX -= glyph.getMetrics().width;
       accX -= parenLeftPadding;
-      check<Glyph>(parenLeft).render(ctx, accX, accY);
+      defined<Glyph>(parenLeft).render(ctx, accX, accY);
     }
   }
 }

--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -530,14 +530,18 @@ export class Accidental extends Modifier {
 
   /** Get width in pixels. */
   getWidth(): number {
-    const parenWidth = this.cautionary
-      ? defined<Glyph>(this.parenLeft).getMetrics().width +
-        defined<Glyph>(this.parenRight).getMetrics().width +
+    if (this.cautionary) {
+      const parenLeft = defined(this.parenLeft);
+      const parenRight = defined(this.parenRight);
+      const parenWidth =
+        parenLeft.getMetrics().width +
+        parenRight.getMetrics().width +
         this.render_options.parenLeftPadding +
-        this.render_options.parenRightPadding
-      : 0;
-
-    return this.glyph.getMetrics().width + parenWidth;
+        this.render_options.parenRightPadding;
+      return this.glyph.getMetrics().width + parenWidth;
+    } else {
+      return this.glyph.getMetrics().width;
+    }
   }
 
   /** Attach this accidental to `note`, which must be a `StaveNote`. */
@@ -574,8 +578,6 @@ export class Accidental extends Modifier {
       x_shift,
       y_shift,
       glyph,
-      parenLeft,
-      parenRight,
       render_options: { parenLeftPadding, parenRightPadding },
     } = this;
 
@@ -592,15 +594,18 @@ export class Accidental extends Modifier {
     if (!cautionary) {
       glyph.render(ctx, accX, accY);
     } else {
+      const parenLeft = defined(this.parenLeft);
+      const parenRight = defined(this.parenRight);
+
       // Render the accidental in parentheses.
-      defined<Glyph>(parenRight).render(ctx, accX, accY);
-      accX -= defined<Glyph>(parenRight).getMetrics().width;
+      parenRight.render(ctx, accX, accY);
+      accX -= parenRight.getMetrics().width;
       accX -= parenRightPadding;
       accX -= this.accidental.parenRightPaddingAdjustment;
       glyph.render(ctx, accX, accY);
       accX -= glyph.getMetrics().width;
       accX -= parenLeftPadding;
-      defined<Glyph>(parenLeft).render(ctx, accX, accY);
+      parenLeft.render(ctx, accX, accY);
     }
   }
 }

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -212,7 +212,7 @@ export class Articulation extends Modifier {
     const getIncrement = (articulation: Articulation, line: number, position: number) =>
       roundToNearestHalf(
         getRoundingFunction(line, position),
-        defined<number>(articulation.glyph.getMetrics().height) / 10 + margin
+        defined(articulation.glyph.getMetrics().height) / 10 + margin
       );
 
     articulations.filter(isAbove).forEach((articulation) => {
@@ -281,7 +281,7 @@ export class Articulation extends Modifier {
       (this.position === ABOVE ? this.articulation.aboveCode : this.articulation.belowCode) || this.articulation.code;
     this.glyph = new Glyph(code ?? '', this.render_options.font_scale);
 
-    this.setWidth(defined<number>(this.glyph.getMetrics().width));
+    this.setWidth(defined(this.glyph.getMetrics().width));
   }
 
   /** Get element category string. */

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -2,7 +2,7 @@
 // Author: Larry Kuhns.
 // MIT License
 
-import { RuntimeError, log, check } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Flow } from './flow';
 import { Modifier } from './modifier';
 import { Glyph } from './glyph';
@@ -212,7 +212,7 @@ export class Articulation extends Modifier {
     const getIncrement = (articulation: Articulation, line: number, position: number) =>
       roundToNearestHalf(
         getRoundingFunction(line, position),
-        check<number>(articulation.glyph.getMetrics().height) / 10 + margin
+        defined<number>(articulation.glyph.getMetrics().height) / 10 + margin
       );
 
     articulations.filter(isAbove).forEach((articulation) => {
@@ -281,7 +281,7 @@ export class Articulation extends Modifier {
       (this.position === ABOVE ? this.articulation.aboveCode : this.articulation.belowCode) || this.articulation.code;
     this.glyph = new Glyph(code ?? '', this.render_options.font_scale);
 
-    this.setWidth(check<number>(this.glyph.getMetrics().width));
+    this.setWidth(defined<number>(this.glyph.getMetrics().width));
   }
 
   /** Get element category string. */

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -273,12 +273,8 @@ export class Articulation extends Modifier {
 
   protected reset(): void {
     this.articulation = Flow.articulationCodes(this.type);
-    if (!this.articulation) {
-      throw new RuntimeError('ArgumentError', `Articulation not found: ${this.type}`);
-    }
-
-    const code =
-      (this.position === ABOVE ? this.articulation.aboveCode : this.articulation.belowCode) || this.articulation.code;
+    const articulation = defined(this.articulation, 'ArgumentError', `Articulation not found: ${this.type}`);
+    const code = (this.position === ABOVE ? articulation.aboveCode : articulation.belowCode) || articulation.code;
     this.glyph = new Glyph(code ?? '', this.render_options.font_scale);
 
     this.setWidth(defined(this.glyph.getMetrics().width));

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -172,7 +172,6 @@ export class Clef extends StaveModifier {
     if (this.type === 'tab' && !this.stave) {
       throw new RuntimeError('ClefError', "Can't get width without stave.");
     }
-
     return this.width;
   }
 
@@ -194,22 +193,22 @@ export class Clef extends StaveModifier {
   /** Render clef. */
   draw(): void {
     if (!this.x) throw new RuntimeError('ClefError', "Can't draw clef without x.");
-    if (!this.stave) throw new RuntimeError('ClefError', "Can't draw clef without stave.");
     if (!this.glyph) throw new RuntimeError('ClefError', "Can't draw clef without glyph.");
+    const stave = this.checkStave();
     this.setRendered();
 
-    this.glyph.setStave(this.stave);
-    this.glyph.setContext(this.stave.getContext());
+    this.glyph.setStave(stave);
+    this.glyph.setContext(stave.getContext());
     if (this.clef.line !== undefined) {
-      this.placeGlyphOnLine(this.glyph, this.stave, this.clef.line);
+      this.placeGlyphOnLine(this.glyph, stave, this.clef.line);
     }
 
     this.glyph.renderToStave(this.x);
 
     if (this.annotation !== undefined && this.attachment !== undefined) {
-      this.placeGlyphOnLine(this.attachment, this.stave, this.annotation.line);
-      this.attachment.setStave(this.stave);
-      this.attachment.setContext(this.stave.getContext());
+      this.placeGlyphOnLine(this.attachment, stave, this.annotation.line);
+      this.attachment.setStave(stave);
+      this.attachment.setContext(stave.getContext());
       this.attachment.renderToStave(this.x);
     }
   }

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -192,7 +192,6 @@ export class Clef extends StaveModifier {
 
   /** Render clef. */
   draw(): void {
-    // TODO: Is this line buggy? this.x is a number, so !this.x returns true when x is 0.
     if (!this.x) throw new RuntimeError('ClefError', "Can't draw clef without x.");
     const glyph = defined(this.glyph, 'ClefError', "Can't draw clef without glyph.");
     const stave = this.checkStave();

--- a/src/element.ts
+++ b/src/element.ts
@@ -2,7 +2,7 @@
 // @author Mohit Cheppudira
 // MIT License
 
-import { RuntimeError } from './util';
+import { defined } from './util';
 import { Registry } from './registry';
 import { BoundingBox } from './boundingbox';
 import { Font } from './font';
@@ -203,6 +203,11 @@ export abstract class Element {
     return this;
   }
 
+  /** Get the boundingBox. */
+  getBoundingBox(): BoundingBox | undefined {
+    return this.boundingBox;
+  }
+
   /** Return the context. */
   getContext(): RenderContext | undefined {
     return this.context;
@@ -214,16 +219,8 @@ export abstract class Element {
     return this;
   }
 
-  /** Get the boundingBox. */
-  getBoundingBox(): BoundingBox | undefined {
-    return this.boundingBox;
-  }
-
   /** Validate and return the context. */
   checkContext(): RenderContext {
-    if (!this.context) {
-      throw new RuntimeError('NoContext', 'No rendering context attached to instance.');
-    }
-    return this.context;
+    return defined(this.context, 'NoContext', 'No rendering context attached to instance.');
   }
 }

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,4 +1,4 @@
-import { RuntimeError } from './util';
+import { defined } from './util';
 import { loadBravura } from '@bravura';
 import { loadGonville } from '@gonville';
 import { loadPetaluma } from '@petaluma';
@@ -61,57 +61,58 @@ class Font {
   }
 
   getResolution(): number {
-    if (!this.fontDataMetrics.fontData) throw new RuntimeError('Missing metrics or font data');
-    return this.fontDataMetrics.fontData.resolution;
+    return this.getFontData().resolution;
   }
 
   // eslint-disable-next-line
   getMetrics(): Record<string, any> {
-    if (!this.fontDataMetrics.metrics) throw new RuntimeError('Missing metrics or font data');
-    return this.fontDataMetrics.metrics;
+    return defined(this.fontDataMetrics.metrics, 'FontError', 'Missing metrics');
   }
 
+  /**
+   * Use the provided key to look up a value in this font's metrics file (e.g., bravura_metrics.ts, petaluma_metrics.ts).
+   * @param key is a string separated by periods (e.g., stave.endPaddingMax, clef.lineCount.'5'.shiftY).
+   * @param defaultValue is returned if the lookup fails.
+   * @returns the retrieved value (or `defaultValue` if the lookup fails).
+   */
   // eslint-disable-next-line
   lookupMetric(key: string, defaultValue?: Record<string, any> | number): any {
-    if (!this.fontDataMetrics.metrics) throw new RuntimeError('Missing metrics or font data');
-    const parts = key.split('.');
-    let val = this.fontDataMetrics.metrics;
     // console.log('lookupMetric:', key);
-    for (let i = 0; i < parts.length; i++) {
-      if (val[parts[i]] === undefined) {
+
+    const keyParts = key.split('.');
+
+    // Start with the top level font metrics object, and keep looking deeper into the object (via each part of the period-delimited key).
+    let currObj = this.getMetrics();
+    for (let i = 0; i < keyParts.length; i++) {
+      const keyPart = keyParts[i];
+      const value = currObj[keyPart];
+      if (value === undefined) {
+        // If the key lookup fails, we fall back to the defaultValue.
         return defaultValue;
       }
-      val = val[parts[i]];
+      // The most recent lookup succeeded, so we drill deeper into the object.
+      currObj = value;
     }
 
-    // console.log('found:', key, val);
-    return val;
+    // After checking every part of the key (i.e., the loop completed), return the most recently retrieved value.
+    // console.log('found:', key, currObj);
+    return currObj;
   }
 
   getFontData(): FontData {
-    if (!this.fontDataMetrics.fontData) throw new RuntimeError('Missing metrics or font data');
-    return this.fontDataMetrics.fontData;
+    return defined(this.fontDataMetrics.fontData, 'FontError', 'Missing font data');
   }
 
   getGlyphs(): Record<string, FontGlyph> {
-    if (!this.fontDataMetrics.fontData) throw new RuntimeError('Missing metrics or font data');
-    return this.fontDataMetrics.fontData.glyphs;
+    return this.getFontData().glyphs;
   }
 }
 
 const Fonts = {
-  Bravura: (): Font => {
-    return new Font('Bravura');
-  },
-  Gonville: (): Font => {
-    return new Font('Gonville');
-  },
-  Petaluma: (): Font => {
-    return new Font('Petaluma');
-  },
-  Custom: (): Font => {
-    return new Font('Custom');
-  },
+  Bravura: (): Font => new Font('Bravura'),
+  Gonville: (): Font => new Font('Gonville'),
+  Petaluma: (): Font => new Font('Petaluma'),
+  Custom: (): Font => new Font('Custom'),
 };
 
 export { Fonts, Font };

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -736,8 +736,7 @@ export class Formatter {
         if (index > 0) {
           const contextX = context.getX();
           const ideal = idealDistances[index];
-          const errorPx =
-            defined<Tickable>(ideal.fromTickable).getX() + ideal.expectedDistance - (contextX + spaceAccum);
+          const errorPx = defined(ideal.fromTickable).getX() + ideal.expectedDistance - (contextX + spaceAccum);
 
           let negativeShiftPx = 0;
           if (errorPx > 0) {
@@ -928,7 +927,7 @@ export class Formatter {
         }
       }
 
-      shift *= defined<{ alpha: number }>(options).alpha;
+      shift *= defined(options).alpha;
       this.totalShift += shift;
     });
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,7 +1,7 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
-import { RuntimeError, midLine, log, check } from './util';
+import { RuntimeError, midLine, log, defined } from './util';
 import { Beam } from './beam';
 import { Flow } from './flow';
 import { Fraction } from './fraction';
@@ -736,7 +736,8 @@ export class Formatter {
         if (index > 0) {
           const contextX = context.getX();
           const ideal = idealDistances[index];
-          const errorPx = check<Tickable>(ideal.fromTickable).getX() + ideal.expectedDistance - (contextX + spaceAccum);
+          const errorPx =
+            defined<Tickable>(ideal.fromTickable).getX() + ideal.expectedDistance - (contextX + spaceAccum);
 
           let negativeShiftPx = 0;
           if (errorPx > 0) {
@@ -927,7 +928,7 @@ export class Formatter {
         }
       }
 
-      shift *= check<{ alpha: number }>(options).alpha;
+      shift *= defined<{ alpha: number }>(options).alpha;
       this.totalShift += shift;
     });
 

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -1,6 +1,6 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Element } from './element';
 import { BoundingBoxComputation } from './boundingboxcomputation';
 import { BoundingBox } from './boundingbox';
@@ -494,6 +494,10 @@ export class Glyph extends Element {
     this.restoreStyle(ctx);
   }
 
+  checkStave(): Stave {
+    return defined(this.stave, 'NoStave', 'No stave attached to instance.');
+  }
+
   renderToStave(x: number): void {
     const context = this.checkContext();
 
@@ -501,9 +505,7 @@ export class Glyph extends Element {
       throw new RuntimeError('BadGlyph', `Glyph ${this.code} is not initialized.`);
     }
 
-    if (!this.stave) {
-      throw new RuntimeError('GlyphError', 'No valid stave');
-    }
+    const stave = this.checkStave();
 
     const outline = this.metrics.outline;
     const scale = this.scale * this.metrics.scale;
@@ -515,7 +517,7 @@ export class Glyph extends Element {
       outline,
       scale,
       x + this.x_shift + this.metrics.x_shift,
-      this.stave.getYForGlyphs() + this.y_shift + this.metrics.y_shift
+      stave.getYForGlyphs() + this.y_shift + this.metrics.y_shift
     );
     this.restoreStyle();
   }

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -200,9 +200,7 @@ export class Glyph extends Element {
   }
 
   static lookupGlyph(fontStack: Font[], code: string): { font: Font; glyph: FontGlyph } {
-    if (!fontStack) {
-      throw new RuntimeError('BAD_FONTSTACK', 'Font stack is misconfigured');
-    }
+    defined(fontStack, 'BadFontStack', 'Font stack is misconfigured');
 
     let glyph: FontGlyph;
     let font: Font;

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -282,7 +282,7 @@ export class KeySignature extends StaveModifier {
     this.width = 0;
     this.glyphs = [];
     this.xPositions = [0]; // initialize with initial x position
-    this.accList = Flow.keySignature(defined<string>(this.keySpec));
+    this.accList = Flow.keySignature(defined(this.keySpec));
     const accList = this.accList;
     const firstAccidentalType = accList.length > 0 ? accList[0].type : undefined;
     let cancelAccList;

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -313,9 +313,7 @@ export class KeySignature extends StaveModifier {
       throw new RuntimeError('KeySignatureError', "Can't draw key signature without x.");
     }
 
-    if (!this.stave) {
-      throw new RuntimeError('KeySignatureError', "Can't draw key signature without stave.");
-    }
+    const stave = this.checkStave();
 
     if (!this.formatted) this.format();
     this.setRendered();
@@ -323,8 +321,8 @@ export class KeySignature extends StaveModifier {
     for (let i = 0; i < this.glyphs.length; i++) {
       const glyph = this.glyphs[i];
       const x = this.x + this.xPositions[i];
-      glyph.setStave(this.stave);
-      glyph.setContext(this.stave.checkContext());
+      glyph.setStave(stave);
+      glyph.setContext(stave.checkContext());
       glyph.renderToStave(x);
     }
   }

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -6,7 +6,7 @@
 // This file implements key signatures. A key signature sits on a stave
 // and indicates the notes with implicit accidentals.
 
-import { check, RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Flow } from './flow';
 import { StaveModifier } from './stavemodifier';
 import { Glyph } from './glyph';
@@ -282,7 +282,7 @@ export class KeySignature extends StaveModifier {
     this.width = 0;
     this.glyphs = [];
     this.xPositions = [0]; // initialize with initial x position
-    this.accList = Flow.keySignature(check<string>(this.keySpec));
+    this.accList = Flow.keySignature(defined<string>(this.keySpec));
     const accList = this.accList;
     const firstAccidentalType = accList.length > 0 ? accList[0].type : undefined;
     let cancelAccList;

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -103,16 +103,16 @@ export class Modifier extends Element {
 
   /** Get attached note (`StaveNote`, `TabNote`, etc.) */
   getNote(): Note {
-    if (!this.note) throw new RuntimeError('NoNote', 'Modifier has no note.');
-    return this.note;
+    return defined(this.note, 'NoNote', 'Modifier has no note.');
   }
 
-  /** Check and get attached note (`StaveNote`, `TabNote`, etc.) */
+  /**
+   * Used in draw() to check and get the attached note (`StaveNote`, `TabNote`, etc.).
+   * Also verifies that the index is valid.
+   */
   checkAttachedNote(): Note {
-    if (!this.note || this.index === undefined) {
-      throw new RuntimeError('NoAttachedNote', `Can't draw ${this.getCategory()} without a note and index.`);
-    }
-    return this.note;
+    defined(this.index, 'NoIndex', `Can't draw ${this.getCategory()} without an index.`);
+    return defined(this.note, 'NoNote', `Can't draw ${this.getCategory()} without a note.`);
   }
 
   /**
@@ -131,10 +131,7 @@ export class Modifier extends Element {
 
   /** Check and get note index, which is a specific note in a chord. */
   checkIndex(): number {
-    if (this.index === undefined) {
-      throw new RuntimeError('NoIndex', 'Modifier has an invalid index.');
-    }
-    return this.index;
+    return defined(this.index, 'NoIndex', 'Modifier has an invalid index.');
   }
 
   /** Set note index, which is a specific note in a chord. */

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -1,7 +1,7 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Element } from './element';
 import { ModifierContext } from './modifiercontext';
 import { Note } from './note';
@@ -150,8 +150,7 @@ export class Modifier extends Element {
 
   /** Check and get `ModifierContext`. */
   checkModifierContext(): ModifierContext {
-    if (!this.modifierContext) throw new RuntimeError('NoModifierContext', 'Modifier Context Required');
-    return this.modifierContext;
+    return defined(this.modifierContext, 'NoModifierContext', 'Modifier Context Required');
   }
 
   /** Every modifier must be part of a `ModifierContext`. */

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -3,7 +3,7 @@
 //
 // This class implements multiple measure rests
 
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Flow } from './flow';
 import { Element } from './element';
 import { Glyph } from './glyph';
@@ -117,11 +117,15 @@ export class MultiMeasureRest extends Element {
     return this.stave;
   }
 
+  // checkStave(): Stave {
+  //   if (!this.stave) {
+  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
+  //   }
+  //   return this.stave;
+  // }
+
   checkStave(): Stave {
-    if (!this.stave) {
-      throw new RuntimeError('NoStave', 'No stave attached to instance');
-    }
-    return this.stave;
+    return defined(this.stave);
   }
 
   drawLine(ctx: RenderContext, left: number, right: number, sbl: number): void {

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -3,7 +3,7 @@
 //
 // This class implements multiple measure rests
 
-import { defined, RuntimeError } from './util';
+import { defined } from './util';
 import { Flow } from './flow';
 import { Element } from './element';
 import { Glyph } from './glyph';
@@ -117,15 +117,8 @@ export class MultiMeasureRest extends Element {
     return this.stave;
   }
 
-  // checkStave(): Stave {
-  //   if (!this.stave) {
-  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
-  //   }
-  //   return this.stave;
-  // }
-
   checkStave(): Stave {
-    return defined(this.stave);
+    return defined(this.stave, 'NoStave', 'No stave attached to instance.');
   }
 
   drawLine(ctx: RenderContext, left: number, right: number, sbl: number): void {

--- a/src/note.ts
+++ b/src/note.ts
@@ -340,15 +340,8 @@ export abstract class Note extends Tickable {
   }
 
   /** Check and get the target stave. */
-  // checkStave(): Stave {
-  //   if (!this.stave) {
-  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
-  //   }
-  //   return this.stave;
-  // }
-
   checkStave(): Stave {
-    return defined(this.stave);
+    return defined(this.stave, 'NoStave', 'No stave attached to instance.');
   }
 
   /** Set the target stave. */

--- a/src/note.ts
+++ b/src/note.ts
@@ -2,6 +2,7 @@
 // MIT License
 
 import { Beam } from './beam';
+import { RuntimeError, drawDot, defined } from './util';
 import { Flow } from './flow';
 import { Fraction } from './fraction';
 import { GlyphProps } from './glyph';
@@ -11,7 +12,6 @@ import { Stroke } from './strokes';
 import { Tickable } from './tickable';
 import { TickContext } from './tickcontext';
 import { KeyProps, RenderContext } from './types/common';
-import { drawDot, RuntimeError } from './util';
 import { Voice } from './voice';
 
 export interface NoteMetrics {
@@ -340,11 +340,15 @@ export abstract class Note extends Tickable {
   }
 
   /** Check and get the target stave. */
+  // checkStave(): Stave {
+  //   if (!this.stave) {
+  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
+  //   }
+  //   return this.stave;
+  // }
+
   checkStave(): Stave {
-    if (!this.stave) {
-      throw new RuntimeError('NoStave', 'No stave attached to instance');
-    }
-    return this.stave;
+    return defined(this.stave);
   }
 
   /** Set the target stave. */

--- a/src/note.ts
+++ b/src/note.ts
@@ -462,8 +462,7 @@ export abstract class Note extends Tickable {
 
   /** Get the `TickContext` for this note. */
   getTickContext(): TickContext {
-    if (!this.tickContext) throw new RuntimeError('NoTickContext', 'Note has no tick context.');
-    return this.tickContext;
+    return this.checkTickContext();
   }
 
   /** Set the `TickContext` for this note. */
@@ -594,12 +593,9 @@ export abstract class Note extends Tickable {
    * looking for the post-formatted x-position.
    */
   getAbsoluteX(): number {
-    if (!this.tickContext) {
-      throw new RuntimeError('NoTickContext', 'Note needs a TickContext assigned for an x-value.');
-    }
-
+    const tickContext = this.checkTickContext(`Can't getAbsoluteX() without a TickContext.`);
     // Position note to left edge of tick context.
-    let x = this.tickContext.getX();
+    let x = tickContext.getX();
     if (this.stave) {
       x += this.stave.getNoteStartX() + this.musicFont.lookupMetric('stave.padding');
     }

--- a/src/note.ts
+++ b/src/note.ts
@@ -499,10 +499,7 @@ export abstract class Note extends Tickable {
 
   /** Check and get the beam. */
   checkBeam(): Beam {
-    if (!this.beam) {
-      throw new RuntimeError('NoBeam', 'No beam attached to instance');
-    }
-    return this.beam;
+    return defined(this.beam, 'NoBeam', 'No beam attached to instance');
   }
 
   /** Check it has a beam. */

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -1,7 +1,7 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
-import { RuntimeError, log } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Flow } from './flow';
 import { Note, NoteStruct } from './note';
 import { Stem } from './stem';
@@ -135,12 +135,7 @@ export class NoteHead extends Note {
     // Get glyph code based on duration and note type. This could be
     // regular notes, rests, or other custom codes.
     this.glyph = Flow.getGlyphProps(this.duration, this.note_type);
-    if (!this.glyph) {
-      throw new RuntimeError(
-        'BadArguments',
-        `No glyph found for duration '${this.duration}' and type '${this.note_type}'`
-      );
-    }
+    defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.note_type}'`);
 
     this.glyph_code = this.glyph.code_head;
     this.x_shift = head_options.x_shift || 0;

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -2,7 +2,7 @@
 // Author: Cyril Silverman
 // MIT License
 
-import { RuntimeError, log } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Flow } from './flow';
 import { Modifier } from './modifier';
 import { TickContext } from './tickcontext';
@@ -83,10 +83,8 @@ export class Ornament extends Modifier {
       if (Ornament.ornamentArticulation.indexOf(ornament.type) >= 0) {
         // Unfortunately we don't know the stem direction.  So we base it
         // on the line number, but also allow it to be overridden.
-        if (!ornament.note) {
-          throw new RuntimeError('NoAttachedNote');
-        }
-        if (ornament.note.getLineNumber() >= 3 || ornament.getPosition() === Modifier.Position.ABOVE) {
+        const ornamentNote = defined(ornament.note, 'NoAttachedNote');
+        if (ornamentNote.getLineNumber() >= 3 || ornament.getPosition() === Modifier.Position.ABOVE) {
           state.top_text_line += increment;
           ornament.y_shift += yOffset;
           yOffset -= ornament.glyph.bbox.getH();

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -3,7 +3,7 @@
 // ## Description
 // A base class for stave modifiers (e.g. clefs, key signatures)
 
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Element } from './element';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
@@ -58,11 +58,15 @@ export class StaveModifier extends Element {
     return this.stave;
   }
 
+  // checkStave(): Stave {
+  //   if (!this.stave) {
+  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
+  //   }
+  //   return this.stave;
+  // }
+
   checkStave(): Stave {
-    if (!this.stave) {
-      throw new RuntimeError('NoStave', 'No stave attached to instance');
-    }
-    return this.stave;
+    return defined(this.stave);
   }
 
   setStave(stave: Stave): this {
@@ -114,9 +118,8 @@ export class StaveModifier extends Element {
     return this.layoutMetrics;
   }
 
-  draw(
-    // eslint-disable-next-line
-    element?: Element, x_shift?: number): void {
+  // eslint-disable-next-line
+  draw(element?: Element, x_shift?: number): void {
     // do nothing
   }
 }

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -3,7 +3,7 @@
 // ## Description
 // A base class for stave modifiers (e.g. clefs, key signatures)
 
-import { defined, RuntimeError } from './util';
+import { defined } from './util';
 import { Element } from './element';
 import { Glyph } from './glyph';
 import { Stave } from './stave';

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -33,6 +33,7 @@ export class StaveModifier extends Element {
   protected position: StaveModifierPosition;
   protected stave?: Stave;
   protected layoutMetrics?: LayoutMetrics;
+
   static get Position(): typeof StaveModifierPosition {
     return StaveModifierPosition;
   }
@@ -58,15 +59,8 @@ export class StaveModifier extends Element {
     return this.stave;
   }
 
-  // checkStave(): Stave {
-  //   if (!this.stave) {
-  //     throw new RuntimeError('NoStave', 'No stave attached to instance');
-  //   }
-  //   return this.stave;
-  // }
-
   checkStave(): Stave {
-    return defined(this.stave);
+    return defined(this.stave, 'NoStave', 'No stave attached to instance.');
   }
 
   setStave(stave: Stave): this {

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -9,7 +9,7 @@
 //
 // See `tests/stavenote_tests.ts` for usage examples.
 
-import { RuntimeError, log, midLine, warn } from './util';
+import { RuntimeError, log, midLine, warn, defined } from './util';
 import { Flow } from './flow';
 import { BoundingBox } from './boundingbox';
 import { Stem } from './stem';
@@ -373,15 +373,9 @@ export class StaveNote extends StemmableNote {
     this.clef = noteStruct.clef ?? 'treble';
     this.octave_shift = noteStruct.octave_shift ?? 0;
 
-    // Pull note rendering properties
+    // Pull note rendering properties.
     this.glyph = Flow.getGlyphProps(this.duration, this.noteType);
-
-    if (!this.glyph) {
-      throw new RuntimeError(
-        'BadArguments',
-        `Invalid note initialization data (No glyph found): ${JSON.stringify(noteStruct)}`
-      );
-    }
+    defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.noteType}'`);
 
     // if true, displace note to right
     this.displaced = false;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -893,16 +893,12 @@ export class StaveNote extends StemmableNote {
 
   // Get all accidentals in the `ModifierContext`
   getAccidentals(): Accidental[] {
-    if (!this.modifierContext)
-      throw new RuntimeError('NoModifierContext', 'No modifier context attached to this note.');
-    return this.modifierContext.getMembers('accidentals') as Accidental[];
+    return this.checkModifierContext().getMembers('accidentals') as Accidental[];
   }
 
   // Get all dots in the `ModifierContext`
   getDots(): Dot[] {
-    if (!this.modifierContext)
-      throw new RuntimeError('NoModifierContext', 'No modifier context attached to this note.');
-    return this.modifierContext.getMembers('dots') as Dot[];
+    return this.checkModifierContext().getMembers('dots') as Dot[];
   }
 
   // Get the width of the note if it is displaced. Used for `Voice`

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -800,11 +800,8 @@ export const Tables = {
   },
 
   // Return a glyph given duration and type. The type can be a custom glyph code from customNoteHeads.
-  getGlyphProps(
-    duration: string,
-    type?: string
-  ): // eslint-disable-next-line
-  any {
+  // eslint-disable-next-line
+  getGlyphProps(duration: string, type?: string): any {
     duration_codes = duration_codes || {
       '1/2': {
         common: {

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -15,7 +15,7 @@ import { Stave } from './stave';
 import { StaveNoteStruct } from './stavenote';
 import { Stem } from './stem';
 import { StemmableNote } from './stemmablenote';
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 
 export interface TabNotePosition {
   // For example, on a six stringed instrument, `str` ranges from 1 to 6.
@@ -164,13 +164,7 @@ export class TabNote extends StemmableNote {
     };
 
     this.glyph = Flow.getGlyphProps(this.duration, this.noteType);
-
-    if (!this.glyph) {
-      throw new RuntimeError(
-        'BadArguments',
-        `Invalid note initialization data (No glyph found): ${JSON.stringify(tab_struct)}`
-      );
-    }
+    defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.noteType}'`);
 
     this.buildStem();
 

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -97,7 +97,7 @@ export class TextDynamics extends Note {
       const glyph_data = TextDynamics.GLYPHS[letter];
       if (!glyph_data) throw new RuntimeError('Invalid dynamics character: ' + letter);
 
-      const size = defined<number>(this.render_options.glyph_font_size);
+      const size = defined(this.render_options.glyph_font_size);
       const glyph = new Glyph(glyph_data.code, size, { category: 'textNote' });
 
       // Add the glyph

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -1,7 +1,7 @@
 // [VexFlow](http://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
-import { RuntimeError, log, check } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Note } from './note';
 import { Glyph } from './glyph';
 import { TextNoteStruct } from './textnote';
@@ -97,7 +97,7 @@ export class TextDynamics extends Note {
       const glyph_data = TextDynamics.GLYPHS[letter];
       if (!glyph_data) throw new RuntimeError('Invalid dynamics character: ' + letter);
 
-      const size = check<number>(this.render_options.glyph_font_size);
+      const size = defined<number>(this.render_options.glyph_font_size);
       const glyph = new Glyph(glyph_data.code, size, { category: 'textNote' });
 
       // Add the glyph

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -152,7 +152,7 @@ export class TextNote extends Note {
   /** Pre-render formatting. */
   preFormat(): void {
     if (this.preFormatted) return;
-    if (!this.tickContext) throw new RuntimeError('NoTickContext', "Can't preformat without a TickContext.");
+    const tickContext = this.checkTickContext(`Can't preformat without a TickContext.`);
 
     if (this.smooth) {
       this.setWidth(0);
@@ -173,7 +173,7 @@ export class TextNote extends Note {
     }
 
     // We reposition to the center of the note head
-    this.rightDisplacedHeadPx = this.tickContext.getMetrics().glyphPx / 2;
+    this.rightDisplacedHeadPx = tickContext.getMetrics().glyphPx / 2;
     this.setPreFormatted(true);
   }
 
@@ -181,12 +181,12 @@ export class TextNote extends Note {
   draw(): void {
     const ctx = this.checkContext();
     const stave = this.checkStave();
-    if (!this.tickContext) throw new RuntimeError('NoTickContext', "Can't draw without a TickContext.");
+    const tickContext = this.checkTickContext(`Can't draw without a TickContext.`);
 
     this.setRendered();
 
     // Reposition to center of note head
-    let x = this.getAbsoluteX() + this.tickContext.getMetrics().glyphPx / 2;
+    let x = this.getAbsoluteX() + tickContext.getMetrics().glyphPx / 2;
 
     // Align based on tick-context width.
     const width = this.getWidth();

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -156,11 +156,8 @@ export abstract class Tickable extends Element {
 
   /** Get `x` position of this tick context. */
   getX(): number {
-    if (!this.tickContext) {
-      throw new RuntimeError('NoTickContext', 'Note needs a TickContext assigned for an X-Value');
-    }
-
-    return this.tickContext.getX() + this.x_shift;
+    const tickContext = this.checkTickContext(`Can't getX() without a TickContext.`);
+    return tickContext.getX() + this.x_shift;
   }
 
   /** Return the formatterMetrics. */
@@ -293,10 +290,14 @@ export abstract class Tickable extends Element {
     return this.modifiers;
   }
 
-  /** Set the Tick Contxt. */
+  /** Set the Tick Context. */
   setTickContext(tc: TickContext): void {
     this.tickContext = tc;
     this.setPreFormatted(false);
+  }
+
+  checkTickContext(message = 'Tickable has no tick context.'): TickContext {
+    return defined(this.tickContext, 'NoTickContext', message);
   }
 
   /** Preformat the Tickable. */
@@ -352,10 +353,8 @@ export abstract class Tickable extends Element {
   }
 
   getAbsoluteX(): number {
-    if (!this.tickContext) {
-      throw new RuntimeError('NoTickContext', 'Tickable needs a TickContext assigned for an x-value.');
-    }
-    return this.tickContext.getX();
+    const tickContext = this.checkTickContext(`Can't getAbsoluteX() without a TickContext.`);
+    return tickContext.getX();
   }
 
   /** Attach this note to a modifier context. */

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -9,7 +9,7 @@ import { Modifier } from './modifier';
 import { ModifierContext } from './modifiercontext';
 import { TickContext } from './tickcontext';
 import { Tuplet } from './tuplet';
-import { RuntimeError } from './util';
+import { defined, RuntimeError } from './util';
 import { Voice } from './voice';
 
 /** Formatter metrics interface */
@@ -199,8 +199,7 @@ export abstract class Tickable extends Element {
    * This allows formatters and preFormatter to associate them with the right modifierContexts.
    */
   getVoice(): Voice {
-    if (!this.voice) throw new RuntimeError('NoVoice', 'Tickable has no voice.');
-    return this.voice;
+    return defined(this.voice, 'NoVoice', 'Tickable has no voice.');
   }
 
   /** Set the associated voice. */
@@ -368,6 +367,11 @@ export abstract class Tickable extends Element {
   /** Get `ModifierContext`. */
   getModifierContext(): ModifierContext | undefined {
     return this.modifierContext;
+  }
+
+  /** Check and get `ModifierContext`. */
+  checkModifierContext(): ModifierContext {
+    return defined(this.modifierContext, 'NoModifierContext', 'No modifier context attached to this tickable.');
   }
 
   /** Get the target stave. */

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -38,7 +38,7 @@ export class TimeSignatureGlyph extends Glyph {
       const botGlyph = new Glyph('timeSig' + num, this.timeSignature.point);
 
       this.botGlyphs.push(botGlyph);
-      botWidth += defined<number>(botGlyph.getMetrics().width);
+      botWidth += defined(botGlyph.getMetrics().width);
     }
 
     this.width = Math.max(topWidth, botWidth);
@@ -68,7 +68,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + this.x_shift,
         stave.getYForLine(this.timeSignature.topLine)
       );
-      start_x += defined<number>(glyph.getMetrics().width);
+      start_x += defined(glyph.getMetrics().width);
     }
 
     start_x = x + this.botStartX;
@@ -82,7 +82,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + glyph.getMetrics().x_shift,
         stave.getYForLine(this.timeSignature.bottomLine)
       );
-      start_x += defined<number>(glyph.getMetrics().width);
+      start_x += defined(glyph.getMetrics().width);
     }
   }
 }

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -1,7 +1,6 @@
 import { defined } from './util';
 import { Glyph, GlyphMetrics } from './glyph';
 import { TimeSignature } from './timesignature';
-import { Stave } from './stave';
 
 export class TimeSignatureGlyph extends Glyph {
   timeSignature: TimeSignature;
@@ -57,7 +56,8 @@ export class TimeSignatureGlyph extends Glyph {
   }
 
   renderToStave(x: number): void {
-    const stave = defined<Stave>(this.stave);
+    const stave = this.checkStave();
+
     let start_x = x + this.topStartX;
     for (let i = 0; i < this.topGlyphs.length; ++i) {
       const glyph = this.topGlyphs[i];

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -1,4 +1,4 @@
-import { check } from './util';
+import { defined } from './util';
 import { Glyph, GlyphMetrics } from './glyph';
 import { TimeSignature } from './timesignature';
 import { Stave } from './stave';
@@ -38,7 +38,7 @@ export class TimeSignatureGlyph extends Glyph {
       const botGlyph = new Glyph('timeSig' + num, this.timeSignature.point);
 
       this.botGlyphs.push(botGlyph);
-      botWidth += check<number>(botGlyph.getMetrics().width);
+      botWidth += defined<number>(botGlyph.getMetrics().width);
     }
 
     this.width = Math.max(topWidth, botWidth);
@@ -57,7 +57,7 @@ export class TimeSignatureGlyph extends Glyph {
   }
 
   renderToStave(x: number): void {
-    const stave = check<Stave>(this.stave);
+    const stave = defined<Stave>(this.stave);
     let start_x = x + this.topStartX;
     for (let i = 0; i < this.topGlyphs.length; ++i) {
       const glyph = this.topGlyphs[i];
@@ -68,7 +68,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + this.x_shift,
         stave.getYForLine(this.timeSignature.topLine)
       );
-      start_x += check<number>(glyph.getMetrics().width);
+      start_x += defined<number>(glyph.getMetrics().width);
     }
 
     start_x = x + this.botStartX;
@@ -82,7 +82,7 @@ export class TimeSignatureGlyph extends Glyph {
         start_x + glyph.getMetrics().x_shift,
         stave.getYForLine(this.timeSignature.bottomLine)
       );
-      start_x += check<number>(glyph.getMetrics().width);
+      start_x += defined<number>(glyph.getMetrics().width);
     }
   }
 }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -73,7 +73,7 @@ export class TimeSignature extends StaveModifier {
     this.bottomLine = 4 + fontLineShift;
     this.setPosition(StaveModifier.Position.BEGIN);
     this.info = this.parseTimeSpec(timeSpec);
-    this.setWidth(defined<number>(this.info.glyph.getMetrics().width));
+    this.setWidth(defined(this.info.glyph.getMetrics().width));
     this.setPadding(padding);
   }
 

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -5,7 +5,7 @@
 // See tables.js for the internal time signatures
 // representation
 
-import { RuntimeError, check } from './util';
+import { RuntimeError, defined } from './util';
 import { Glyph } from './glyph';
 import { StaveModifier } from './stavemodifier';
 import { TimeSignatureGlyph } from './timesigglyph';
@@ -73,7 +73,7 @@ export class TimeSignature extends StaveModifier {
     this.bottomLine = 4 + fontLineShift;
     this.setPosition(StaveModifier.Position.BEGIN);
     this.info = this.parseTimeSpec(timeSpec);
-    this.setWidth(check<number>(this.info.glyph.getMetrics().width));
+    this.setWidth(defined<number>(this.info.glyph.getMetrics().width));
     this.setPadding(padding);
   }
 

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -104,8 +104,7 @@ export class TimeSignature extends StaveModifier {
   }
 
   makeTimeSignatureGlyph(topDigits: string[], botDigits: string[]): Glyph {
-    const glyph = new TimeSignatureGlyph(this, topDigits, botDigits, 'timeSig0', this.point);
-    return glyph;
+    return new TimeSignatureGlyph(this, topDigits, botDigits, 'timeSig0', this.point);
   }
 
   getInfo(): TimeSignatureInfo {
@@ -122,14 +121,12 @@ export class TimeSignature extends StaveModifier {
       throw new RuntimeError('TimeSignatureError', "Can't draw time signature without x.");
     }
 
-    if (!this.stave) {
-      throw new RuntimeError('TimeSignatureError', "Can't draw time signature without stave.");
-    }
+    const stave = this.checkStave();
 
     this.setRendered();
-    this.info.glyph.setStave(this.stave);
-    this.info.glyph.setContext(this.stave.getContext());
-    this.placeGlyphOnLine(this.info.glyph, this.stave, this.info.line);
+    this.info.glyph.setStave(stave);
+    this.info.glyph.setContext(stave.getContext());
+    this.placeGlyphOnLine(this.info.glyph, stave, this.info.line);
     this.info.glyph.renderToStave(this.x);
   }
 }

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -313,7 +313,7 @@ export class Tuplet extends Element {
     // determine y value for tuplet
     this.y_pos = this.getYPosition();
 
-    const addGlyphWidth = (width: number, glyph: Glyph) => width + defined<number>(glyph.getMetrics().width);
+    const addGlyphWidth = (width: number, glyph: Glyph) => width + defined(glyph.getMetrics().width);
 
     // calculate total width of tuplet notation
     let width = this.numerator_glyphs.reduce(addGlyphWidth, 0);
@@ -354,7 +354,7 @@ export class Tuplet extends Element {
     let x_offset = 0;
     this.numerator_glyphs.forEach((glyph) => {
       glyph.render(ctx, notation_start_x + x_offset, this.y_pos + this.point / 3 - 2 + shiftY);
-      x_offset += defined<number>(glyph.getMetrics().width);
+      x_offset += defined(glyph.getMetrics().width);
     });
 
     // display colon and denominator if the ratio is to be shown
@@ -372,7 +372,7 @@ export class Tuplet extends Element {
       x_offset += this.point * 0.32;
       this.denom_glyphs.forEach((glyph) => {
         glyph.render(ctx, notation_start_x + x_offset, this.y_pos + this.point / 3 - 2 + shiftY);
-        x_offset += defined<number>(glyph.getMetrics().width);
+        x_offset += defined(glyph.getMetrics().width);
       });
     }
   }

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -44,7 +44,7 @@
  * }
  */
 
-import { RuntimeError, check } from './util';
+import { RuntimeError, defined } from './util';
 import { Element } from './element';
 import { Formatter } from './formatter';
 import { Glyph } from './glyph';
@@ -313,7 +313,7 @@ export class Tuplet extends Element {
     // determine y value for tuplet
     this.y_pos = this.getYPosition();
 
-    const addGlyphWidth = (width: number, glyph: Glyph) => width + check<number>(glyph.getMetrics().width);
+    const addGlyphWidth = (width: number, glyph: Glyph) => width + defined<number>(glyph.getMetrics().width);
 
     // calculate total width of tuplet notation
     let width = this.numerator_glyphs.reduce(addGlyphWidth, 0);
@@ -354,7 +354,7 @@ export class Tuplet extends Element {
     let x_offset = 0;
     this.numerator_glyphs.forEach((glyph) => {
       glyph.render(ctx, notation_start_x + x_offset, this.y_pos + this.point / 3 - 2 + shiftY);
-      x_offset += check<number>(glyph.getMetrics().width);
+      x_offset += defined<number>(glyph.getMetrics().width);
     });
 
     // display colon and denominator if the ratio is to be shown
@@ -372,7 +372,7 @@ export class Tuplet extends Element {
       x_offset += this.point * 0.32;
       this.denom_glyphs.forEach((glyph) => {
         glyph.render(ctx, notation_start_x + x_offset, this.y_pos + this.point / 3 - 2 + shiftY);
-        x_offset += check<number>(glyph.getMetrics().width);
+        x_offset += defined<number>(glyph.getMetrics().width);
       });
     }
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ export class RuntimeError extends Error {
  * Check that `x` is of type `T` and not `undefined`.
  * If `x` is `undefined`, throw a RuntimeError with the optionally provided error code and message.
  */
-export function check<T>(x?: T, code: string = 'undefined', message: string = ''): T {
+export function defined<T>(x?: T, code: string = 'undefined', message: string = ''): T {
   if (x === undefined) {
     throw new RuntimeError(code, message);
   }

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -2,11 +2,11 @@
 // MIT License
 
 import { BoundingBox } from './boundingbox';
+import { RuntimeError, defined } from './util';
 import { Element } from './element';
 import { Flow } from './flow';
 import { Fraction } from './fraction';
 import { RenderContext } from './types/common';
-import { RuntimeError, check } from './util';
 import { Stave } from './stave';
 import { Tickable } from './tickable';
 
@@ -159,7 +159,7 @@ export class Voice extends Element {
   /** Get the bounding box for the voice. */
   getBoundingBox(): BoundingBox | undefined {
     if (!this.boundingBox) {
-      const stave = check<Stave>(this.stave);
+      const stave = defined<Stave>(this.stave);
       let boundingBox = undefined;
       for (let i = 0; i < this.tickables.length; ++i) {
         const tickable = this.tickables[i];
@@ -269,7 +269,7 @@ export class Voice extends Element {
   /** Preformat the voice by applying the voice's stave to each note. */
   preFormat(): this {
     if (this.preFormatted) return this;
-    const stave = check<Stave>(this.stave);
+    const stave = defined<Stave>(this.stave);
     this.tickables.forEach((tickable) => {
       if (!tickable.getStave()) {
         tickable.setStave(stave);

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -301,9 +301,7 @@ export class Voice extends Element {
       if (stave) {
         tickable.setStave(stave);
       }
-      if (!tickable.getStave()) {
-        throw new RuntimeError('MissingStave', 'The voice cannot draw tickables without staves.');
-      }
+      defined(tickable.getStave(), 'MissingStave', 'The voice cannot draw tickables without staves.');
       const bb = tickable.getBoundingBox();
       if (bb) {
         boundingBox = boundingBox ? boundingBox.mergeWith(bb) : bb;

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -159,7 +159,7 @@ export class Voice extends Element {
   /** Get the bounding box for the voice. */
   getBoundingBox(): BoundingBox | undefined {
     if (!this.boundingBox) {
-      const stave = defined<Stave>(this.stave);
+      const stave = this.checkStave();
       let boundingBox = undefined;
       for (let i = 0; i < this.tickables.length; ++i) {
         const tickable = this.tickables[i];
@@ -269,7 +269,7 @@ export class Voice extends Element {
   /** Preformat the voice by applying the voice's stave to each note. */
   preFormat(): this {
     if (this.preFormatted) return this;
-    const stave = defined<Stave>(this.stave);
+    const stave = this.checkStave();
     this.tickables.forEach((tickable) => {
       if (!tickable.getStave()) {
         tickable.setStave(stave);
@@ -277,6 +277,10 @@ export class Voice extends Element {
     });
     this.preFormatted = true;
     return this;
+  }
+
+  checkStave(): Stave {
+    return defined(this.stave, 'NoStave', 'No stave attached to instance.');
   }
 
   /**


### PR DESCRIPTION
Also omit type `<T>` from calls to `defined(...)` when possible.

Some classes already have `checkStave()`. Implement `checkStave()` as a convenience method in other classes.