### PR TITLE
Minor gruntfile fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = (grunt) => {
       module: {
         rules: [
           {
-            test: /(\.ts?$|\.js?$)/,
+            test: /(\.ts$|\.js$)/,
             exclude: /node_modules/,
             use: [
               {


### PR DESCRIPTION
Fix a minor regex bug in `Gruntfile.js`. The regex was previously matching files that end in `.t`, .`ts`, `.j` or `.js`. Fix it to only match `.ts` and `.js`.