### PR TITLE
`TickContext` not extending `Tickable`

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -493,7 +493,7 @@ export class Factory {
   }
 
   TickContext(): TickContext {
-    return new TickContext().setContext(this.context);
+    return new TickContext();
   }
 
   ModifierContext(): ModifierContext {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -608,7 +608,6 @@ export class Formatter {
     // Pass 1: Give each note maximum width requested by context.
     contextList.forEach((tick) => {
       const context = contextMap[tick];
-      if (renderingContext) context.setContext(renderingContext);
 
       // Make sure that all tickables in this context have calculated their
       // space requirements.

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -47,6 +47,7 @@ export class TickContext {
   protected preFormatted: boolean = false;
   protected postFormatted: boolean = false;
   protected width: number;
+  protected formatterMetrics: FormatterMetrics;
 
   static getNextContext(tContext: TickContext): TickContext | undefined {
     const contexts = tContext.tContexts;
@@ -83,6 +84,27 @@ export class TickContext {
     this.tContexts = []; // Parent array of tick contexts
 
     this.width = 0;
+    this.formatterMetrics = {
+      // The freedom of a tickable is the distance it can move without colliding
+      // with neighboring elements. A formatter can set these values during its
+      // formatting pass, which a different formatter can then use to fine tune.
+      freedom: { left: 0, right: 0 },
+
+      // The simplified rational duration of this tick as a string. It can be
+      // used as an index to a map or hashtable.
+      duration: '',
+
+      // The number of formatting iterations undergone.
+      iterations: 0,
+
+      // The space in pixels allocated by this formatter, along with the mean space
+      // for tickables of this duration, and the deviation from the mean.
+      space: {
+        used: 0,
+        mean: 0,
+        deviation: 0,
+      },
+    };
   }
 
   getTickID(): number {
@@ -268,26 +290,6 @@ export class TickContext {
   }
 
   getFormatterMetrics(): FormatterMetrics {
-    return {
-      // The freedom of a tickable is the distance it can move without colliding
-      // with neighboring elements. A formatter can set these values during its
-      // formatting pass, which a different formatter can then use to fine tune.
-      freedom: { left: 0, right: 0 },
-
-      // The simplified rational duration of this tick as a string. It can be
-      // used as an index to a map or hashtable.
-      duration: '',
-
-      // The number of formatting iterations undergone.
-      iterations: 0,
-
-      // The space in pixels allocated by this formatter, along with the mean space
-      // for tickables of this duration, and the deviation from the mean.
-      space: {
-        used: 0,
-        mean: 0,
-        deviation: 0,
-      },
-    };
+    return this.formatterMetrics;
   }
 }

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -5,7 +5,7 @@
 // tabs, etc.
 
 import { RuntimeError } from './util';
-import { FormatterMetrics, Tickable } from './tickable';
+import { Tickable } from './tickable';
 import { Fraction } from './fraction';
 import { NoteMetrics } from './note';
 
@@ -47,7 +47,7 @@ export class TickContext {
   protected preFormatted: boolean = false;
   protected postFormatted: boolean = false;
   protected width: number;
-  protected formatterMetrics: FormatterMetrics;
+  protected formatterMetrics: { freedom: { left: number; right: number } };
 
   static getNextContext(tContext: TickContext): TickContext | undefined {
     const contexts = tContext.tContexts;
@@ -85,25 +85,10 @@ export class TickContext {
 
     this.width = 0;
     this.formatterMetrics = {
-      // The freedom of a tickable is the distance it can move without colliding
+      // The freedom of a tickcontext is the distance it can move without colliding
       // with neighboring elements. A formatter can set these values during its
       // formatting pass, which a different formatter can then use to fine tune.
       freedom: { left: 0, right: 0 },
-
-      // The simplified rational duration of this tick as a string. It can be
-      // used as an index to a map or hashtable.
-      duration: '',
-
-      // The number of formatting iterations undergone.
-      iterations: 0,
-
-      // The space in pixels allocated by this formatter, along with the mean space
-      // for tickables of this duration, and the deviation from the mean.
-      space: {
-        used: 0,
-        mean: 0,
-        deviation: 0,
-      },
     };
   }
 
@@ -289,7 +274,7 @@ export class TickContext {
     return this;
   }
 
-  getFormatterMetrics(): FormatterMetrics {
+  getFormatterMetrics(): { freedom: { left: number; right: number } } {
     return this.formatterMetrics;
   }
 }

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -8,7 +8,6 @@ import { RuntimeError } from './util';
 import { FormatterMetrics, Tickable } from './tickable';
 import { Fraction } from './fraction';
 import { NoteMetrics } from './note';
-import { Stave } from './stave';
 
 export interface TickContextMetrics extends NoteMetrics {
   totalLeftPx: number;


### PR DESCRIPTION
This PR implements the discussion below with @ronyeh. `TickContext`does not extend `Tickable` and it follows the same approach as `ModifierContext`.

**The discussion for reference:**

Let me try my best to analyze it objectively, but I am not familiar with the original intent of `Tickable` and `TickContext`.

---

### There are only two classes that `extends Tickable` (i.e., Note and TickContext). 
If we could make `TickContext` an independent type, then `Tickable` and `Note` could be merged.

So I investigated whether we can make `TickContext` not extend Tickable, by commenting it out `/*extends Tickable*/`.

This produces errors with these missing methods and properties:
```
this.setAttribute('type', 'TickContext'); 
this.width 
this.ignore_ticks = false;
this.setPreFormatted(false);
this.preFormatted
this.postFormatted
```

TickContext has similarities to ModifierContext. In `Formatter`, they are used in preFormat() and postFormat() to lay out tickables on a score. The ModifierContext is actually used inside Note's getMetrics(), which Formatter relies on.

**ModifierContext does NOT extend Modifier.** So if the classes are truly mirrors of each other, maybe TickContext should also not extend Tickable.

It's worth noting that ModifierContext implements its own fields for things like:
```
protected preFormatted: boolean = false;
protected postFormatted: boolean = false;
protected width: number;
```

So maybe TickContext can just implement the fields it needs, without extending Tickable. It does seem weird that a TickContext is a Tickable..... isn't it just a helper class for the Formatter to use?

Looking at the class comment for `Tickable`, we see "Tickable represents a element that sit on a score and has a duration, i.e., Tickables occupy space in the musical rendering dimension."

This suggests that indeed TickContext shouldn't really be a Tickable, since I don't think the TickContext sits on the score.

So what else could extend Tickable?

We could argue that some classes that extend Note should actually be extending Tickable instead. For example, is a Crescendo a Note? **Shouldn't Crescendo extend Tickable?** The class comment for Note includes "Notes have some common properties: All of them have a value (e.g., pitch, fret, etc.)" So while a crescendo has a duration like Notes and Tickables, it doesn't really have a pitch.


--- 

So in my professional, extremely biased opinion, I think we can merge the current Tickables PR, and then continue to think about what things should `extends Tickable` vs `extends Note`.

My hunch is that Tickable and Note should still be separate entities, but that TickContext should not extend Tickable, and implement the fields it needs to help the Formatter do its magic.

_Originally posted by @ronyeh in https://github.com/0xfe/vexflow/issues/1097#issuecomment-908556689_