### PR TITLE
Clean up text measuring & add a text measurement cache to SVGContext

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -83,6 +83,8 @@ export class CanvasContext implements RenderContext {
 
     const fontArray = font.split(' ');
     const size = Number(fontArray[0].match(/\d+/));
+    // The font size is specified in points, scale it to canvas units.
+    // CSS specifies dpi to be 96 and there are 72 points to an inch: 96/72 == 4/3.
     this.textHeight = (size * 4) / 3;
 
     return this;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -33,13 +33,6 @@ export class Renderer {
     DOWN: 3, // Downward leg
   };
 
-  /**
-   * Set this to true if you're using VexFlow inside a runtime
-   * that does not allow modifying canvas objects. There is a small
-   * performance degradation due to the extra indirection.
-   */
-  static readonly USE_CANVAS_PROXY = false;
-
   static lastContext?: RenderContext = undefined;
 
   static buildContext(
@@ -67,43 +60,6 @@ export class Renderer {
 
   static getSVGContext(elementId: string, width: number, height: number, background?: string): RenderContext {
     return Renderer.buildContext(elementId, Renderer.Backends.SVG, width, height, background);
-  }
-
-  // eslint-disable-next-line
-  static bolsterCanvasContext(ctx: any): RenderContext {
-    if (Renderer.USE_CANVAS_PROXY) {
-      return new CanvasContext(ctx);
-    }
-
-    // Modify the CanvasRenderingContext2D to include the following methods, if they do not already exist.
-    // TODO: Is a Proxy object appropriate here?
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
-    const methodNames = [
-      'clear',
-      'setFont',
-      'setRawFont',
-      'setFillStyle',
-      'setBackgroundFillStyle',
-      'setStrokeStyle',
-      'setShadowColor',
-      'setShadowBlur',
-      'setLineWidth',
-      'setLineCap',
-      'openGroup',
-      'closeGroup',
-      'getGroup',
-    ];
-
-    ctx.vexFlowCanvasContext = ctx;
-
-    methodNames.forEach((methodName) => {
-      if (!(methodName in ctx)) {
-        // eslint-disable-next-line
-        ctx[methodName] = (CanvasContext.prototype as any)[methodName];
-      }
-    });
-
-    return ctx;
   }
 
   // Draw a dashed line (horizontal, vertical or diagonal
@@ -172,7 +128,7 @@ export class Renderer {
       if (!canvasElement.getContext) {
         throw new RuntimeError('BadElement', `Can't get canvas context from element: ${canvasId}`);
       }
-      this.ctx = Renderer.bolsterCanvasContext(canvasElement.getContext('2d'));
+      this.ctx = new CanvasContext(canvasElement.getContext('2d')!);
     } else if (this.backend === Renderer.Backends.SVG) {
       this.ctx = new SVGContext(this.element);
     } else {

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -14,7 +14,7 @@ import { StaveTempo, StaveTempoOptions } from './stavetempo';
 import { StaveText } from './stavetext';
 import { Volta } from './stavevolta';
 import { TimeSignature } from './timesignature';
-import { FontInfo } from './types/common';
+import { Bounds, FontInfo } from './types/common';
 import { RuntimeError } from './util';
 
 export interface StaveLineConfig {
@@ -60,6 +60,7 @@ export class Stave extends Element {
   protected end_x: number;
   protected measure: number;
   protected font: FontInfo;
+  protected bounds: Bounds;
   protected readonly modifiers: StaveModifier[];
 
   protected defaultLedgerLineStyle: ElementStyle;
@@ -113,6 +114,7 @@ export class Stave extends Element {
       bottom_text_position: 4, // in staff lines
       line_config: [],
     };
+    this.bounds = { x: this.x, y: this.y, w: this.width, h: 0 };
     this.options = { ...this.options, ...options };
     this.defaultLedgerLineStyle = {};
 

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -14,7 +14,7 @@ import { StaveTempo, StaveTempoOptions } from './stavetempo';
 import { StaveText } from './stavetext';
 import { Volta } from './stavevolta';
 import { TimeSignature } from './timesignature';
-import { Bounds, FontInfo } from './types/common';
+import { FontInfo } from './types/common';
 import { RuntimeError } from './util';
 
 export interface StaveLineConfig {
@@ -60,7 +60,6 @@ export class Stave extends Element {
   protected end_x: number;
   protected measure: number;
   protected font: FontInfo;
-  protected bounds: Bounds;
   protected readonly modifiers: StaveModifier[];
 
   protected defaultLedgerLineStyle: ElementStyle;
@@ -114,7 +113,6 @@ export class Stave extends Element {
       bottom_text_position: 4, // in staff lines
       line_config: [],
     };
-    this.bounds = { x: this.x, y: this.y, w: this.width, h: 0 };
     this.options = { ...this.options, ...options };
     this.defaultLedgerLineStyle = {};
 

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -85,7 +85,9 @@ class MeasureTextCache {
     const bbox = this.txt.getBBox();
     svg.removeChild(this.txt);
 
-    // Remove the trailing 'pt' from the font size and scale to convert from pt to pixels.
+    // Remove the trailing 'pt' from the font size and scale to convert from points
+    // to canvas units.
+    // CSS specifies dpi to be 96 and there are 72 points to an inch: 96/72 == 4/3.
     const fontSize = attributes['font-size'];
     const height = (fontSize.substring(0, fontSize.length - 2) * 4) / 3;
     return {
@@ -169,6 +171,12 @@ export class SVGContext implements RenderContext {
     this.state_stack = [];
   }
 
+  /**
+   * Use one of the overload signatures to create an SVG element of a specific type.
+   * The last overload accepts an arbitrary string, and is identical to the
+   * implementation signature.
+   * Feel free to add new overloads for other SVG element types as required.
+   */
   create(svgElementType: 'g'): SVGGElement;
   create(svgElementType: 'path'): SVGPathElement;
   create(svgElementType: 'rect'): SVGRectElement;
@@ -181,7 +189,7 @@ export class SVGContext implements RenderContext {
 
   // Allow grouping elements in containers for interactivity.
   openGroup(cls: string, id?: string, attrs?: { pointerBBox: boolean }): SVGGElement {
-    const group: SVGGElement = this.create('g');
+    const group = this.create('g');
     this.groups.push(group);
     this.parent.appendChild(group);
     this.parent = group;
@@ -432,7 +440,7 @@ export class SVGContext implements RenderContext {
     }
 
     // Create the rect & style it:
-    const rectangle: SVGRectElement = this.create('rect');
+    const rectangle = this.create('rect');
     if (typeof attributes === 'undefined') {
       attributes = {
         fill: 'none',

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -3,7 +3,7 @@
 // @author Gregory Ristow (2015)
 
 import { RuntimeError, prefix } from './util';
-import { RenderContext } from './types/common';
+import { RenderContext, TextMeasure } from './types/common';
 
 // eslint-disable-next-line
 type Attributes = { [key: string]: any };
@@ -41,10 +41,66 @@ interface State {
   lineWidth: number;
 }
 
+class MeasureTextCache {
+  protected txt: SVGTextElement;
+
+  // The cache is keyed first by the text string, then by the font attributes
+  // joined together.
+  protected cache: Record<string, Record<string, TextMeasure>> = {};
+
+  constructor() {
+    // Create the SVG elements that will be used to measure the text in the event
+    // of a cache miss.
+    this.txt = document.createElementNS(SVG_NS, 'text');
+  }
+
+  lookup(text: string, svg: SVGSVGElement, attributes: Attributes): TextMeasure {
+    let entries = this.cache[text];
+    if (entries === undefined) {
+      entries = {};
+      this.cache[text] = entries;
+    }
+
+    const family = attributes['font-family'];
+    const size = attributes['font-size'];
+    const style = attributes['font-style'];
+    const weight = attributes['font-weight'];
+
+    const key = `${family}%${size}%${style}%${weight}`;
+    let entry = entries[key];
+    if (entry === undefined) {
+      entry = this.measureImpl(text, svg, attributes);
+      entries[key] = entry;
+    }
+    return entry;
+  }
+
+  measureImpl(text: string, svg: SVGSVGElement, attributes: Attributes): TextMeasure {
+    this.txt.textContent = text;
+    this.txt.setAttributeNS(null, 'font-family', attributes['font-family']);
+    this.txt.setAttributeNS(null, 'font-size', attributes['font-size']);
+    this.txt.setAttributeNS(null, 'font-style', attributes['font-style']);
+    this.txt.setAttributeNS(null, 'font-weight', attributes['font-weight']);
+    svg.appendChild(this.txt);
+    const bbox = this.txt.getBBox();
+    svg.removeChild(this.txt);
+
+    // Remove the trailing 'pt' from the font size and scale to convert from pt to pixels.
+    const fontSize = attributes['font-size'];
+    const height = (fontSize.substring(0, fontSize.length - 2) * 4) / 3;
+    return {
+      width: bbox.width,
+      height: height,
+    };
+  }
+}
+
 /**
  * SVG rendering context with an API similar to CanvasRenderingContext2D.
  */
 export class SVGContext implements RenderContext {
+  protected static measureTextCache = new MeasureTextCache();
+
   element: HTMLElement; // the parent DOM object
   svg: SVGSVGElement;
   width: number = 0;
@@ -60,13 +116,11 @@ export class SVGContext implements RenderContext {
   parent: SVGGElement;
   groups: SVGGElement[];
   fontString: string = '';
-  fontSize: number = 0;
-  ie: boolean = false; // true if the browser is Internet Explorer.
 
   constructor(element: HTMLElement) {
     this.element = element;
 
-    const svg = this.create('svg') as SVGSVGElement;
+    const svg = this.create('svg');
     // Add it to the canvas:
     this.element.appendChild(svg);
 
@@ -113,18 +167,21 @@ export class SVGContext implements RenderContext {
     };
 
     this.state_stack = [];
-
-    // Test for Internet Explorer
-    this.iePolyfill();
   }
 
+  create(svgElementType: 'g'): SVGGElement;
+  create(svgElementType: 'path'): SVGPathElement;
+  create(svgElementType: 'rect'): SVGRectElement;
+  create(svgElementType: 'svg'): SVGSVGElement;
+  create(svgElementType: 'text'): SVGTextElement;
+  create(svgElementType: string): SVGElement;
   create(svgElementType: string): SVGElement {
     return document.createElementNS(SVG_NS, svgElementType);
   }
 
   // Allow grouping elements in containers for interactivity.
   openGroup(cls: string, id?: string, attrs?: { pointerBBox: boolean }): SVGGElement {
-    const group: SVGGElement = this.create('g') as SVGGElement;
+    const group: SVGGElement = this.create('g');
     this.groups.push(group);
     this.parent.appendChild(group);
     this.parent = group;
@@ -144,19 +201,6 @@ export class SVGContext implements RenderContext {
 
   add(elem: SVGElement): void {
     this.parent.appendChild(elem);
-  }
-
-  // Tests if the browser is Internet Explorer; if it is,
-  // we do some tricks to improve text layout. See the
-  // note at ieMeasureTextFix() for details.
-  iePolyfill(): void {
-    if (typeof navigator !== 'undefined') {
-      this.ie =
-        /MSIE 9/i.test(navigator.userAgent) ||
-        /MSIE 10/i.test(navigator.userAgent) ||
-        /rv:11\.0/i.test(navigator.userAgent) ||
-        /Trident/i.test(navigator.userAgent);
-    }
   }
 
   // ### Styling & State Methods:
@@ -195,9 +239,6 @@ export class SVGContext implements RenderContext {
       'font-style': foundItalic ? 'italic' : 'normal',
     };
 
-    // Store the font size so that if the browser is Internet
-    // Explorer we can fix its calculations of text width.
-    this.fontSize = Number(size);
     // Currently this.fontString only supports size & family. See setRawFont().
     this.fontString = `${size}pt ${family}`;
     this.attributes = { ...this.attributes, ...fontAttributes };
@@ -220,9 +261,6 @@ export class SVGContext implements RenderContext {
     this.attributes['font-family'] = family;
     this.state['font-family'] = family;
 
-    // Saves fontSize for IE polyfill.
-    // Use the Number() function to parse the array returned by String.prototype.match()!
-    this.fontSize = Number(size.match(/\d+/));
     return this;
   }
 
@@ -394,7 +432,7 @@ export class SVGContext implements RenderContext {
     }
 
     // Create the rect & style it:
-    const rectangle: SVGRectElement = this.create('rect') as SVGRectElement;
+    const rectangle: SVGRectElement = this.create('rect');
     if (typeof attributes === 'undefined') {
       attributes = {
         fill: 'none',
@@ -599,51 +637,8 @@ export class SVGContext implements RenderContext {
   }
 
   // ## Text Methods:
-  measureText(text: string): SVGRect {
-    const txt = this.create('text') as SVGTextElement;
-    if (typeof txt.getBBox !== 'function') {
-      return { x: 0, y: 0, width: 0, height: 0 } as SVGRect;
-    }
-
-    txt.textContent = text;
-    this.applyAttributes(txt, this.attributes);
-
-    // Temporarily add it to the document for measurement.
-    this.svg.appendChild(txt);
-
-    let bbox: SVGRect = txt.getBBox();
-    if (this.ie && text !== '' && this.attributes['font-style'] === 'italic') {
-      bbox = this.ieMeasureTextFix(bbox);
-    }
-
-    this.svg.removeChild(txt);
-    return bbox;
-  }
-
-  ieMeasureTextFix(bbox: DOMRect): SVGRect {
-    // Internet Explorer over-pads text in italics,
-    // resulting in giant width estimates for measureText.
-    // To fix this, we use this formula, tested against
-    // ie 11:
-    // overestimate (in pixels) = FontSize(in pt) * 1.196 + 1.96
-    // And then subtract the overestimate from calculated width.
-
-    const fontSize = Number(this.fontSize);
-    const m = 1.196;
-    const b = 1.9598;
-    const widthCorrection = m * fontSize + b;
-    const width = bbox.width - widthCorrection;
-    const height = bbox.height - 1.5;
-
-    // Get non-protected copy:
-    const box = {
-      x: bbox.x,
-      y: bbox.y,
-      width,
-      height,
-    };
-
-    return box as SVGRect;
+  measureText(text: string): TextMeasure {
+    return SVGContext.measureTextCache.lookup(text, this.svg, this.attributes);
   }
 
   fillText(text: string, x: number, y: number): this {

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -174,8 +174,9 @@ export class TextBracket extends Element {
     ctx.fillText(this.text, start.x, start.y);
 
     // Get the width and height for the octave number
-    const main_width = ctx.measureText(this.text).width;
-    const main_height = ctx.measureText('M').width;
+    const main_measure = ctx.measureText(this.text);
+    const main_width = main_measure.width;
+    const main_height = main_measure.height;
 
     // Calculate the y position for the super script
     const super_y = start.y - main_height / 2.5;
@@ -185,8 +186,9 @@ export class TextBracket extends Element {
     ctx.fillText(this.superscript, start.x + main_width + 1, super_y);
 
     // Determine width and height of the superscript
-    const superscript_width = ctx.measureText(this.superscript).width;
-    const super_height = ctx.measureText('M').width;
+    const super_measure = ctx.measureText(this.superscript);
+    const super_width = super_measure.width;
+    const super_height = super_measure.height;
 
     // Setup initial coordinates for the bracket line
     let start_x = start.x;
@@ -195,14 +197,14 @@ export class TextBracket extends Element {
 
     // Adjust x and y coordinates based on position
     if (this.position === TextBracket.Position.TOP) {
-      start_x += main_width + superscript_width + 5;
+      start_x += main_width + super_width + 5;
       line_y -= super_height / 2.7;
     } else if (this.position === TextBracket.Position.BOTTOM) {
       line_y += super_height / 2.7;
       start_x += main_width + 2;
 
       if (!this.render_options.underline_superscript) {
-        start_x += superscript_width;
+        start_x += super_width;
       }
     }
 

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -207,23 +207,18 @@ export class TextNote extends Note {
       ctx.setFont(this.font.family, this.font.size, this.font.weight);
       ctx.fillText(this.text, x, y);
 
-      let height = ctx.measureText(this.text).height;
-      // CanvasRenderingContext2D.measureText() does not have a height field.
-      if (typeof height === 'undefined') {
-        // TODO: Consolidate calls to ctx.measureText('M').
-        height = ctx.measureText('M').width;
-      }
+      const height = ctx.measureText(this.text).height;
 
       // Write superscript
       if (this.superscript) {
         ctx.setFont(this.font.family, this.font.size / 1.3, this.font.weight);
-        ctx.fillText(this.superscript, x + width + 2, y - height / 2.2);
+        ctx.fillText(this.superscript, x + this.width + 2, y - height / 2.2);
       }
 
       // Write subscript
       if (this.subscript) {
         ctx.setFont(this.font.family, this.font.size / 1.3, this.font.weight);
-        ctx.fillText(this.subscript, x + width + 2, y + height / 2.2 - 1);
+        ctx.fillText(this.subscript, x + this.width + 2, y + height / 2.2 - 1);
       }
 
       this.restoreStyle(ctx);

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -7,11 +7,9 @@ export interface FontInfo {
   style?: string;
 }
 
-export interface Bounds {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
+export interface TextMeasure {
+  width: number;
+  height: number;
 }
 
 export interface KeyProps {
@@ -84,8 +82,7 @@ export interface RenderContext {
   closeGroup(): void;
   add(child: any): void;
 
-  /** canvas returns TextMetrics and SVG returns SVGRect. */
-  measureText(text: string): { width: number; height?: number };
+  measureText(text: string): TextMeasure;
 
   /** Maintain compatibility with the CanvasRenderingContext2D API. */
   font: string;

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -12,6 +12,13 @@ export interface TextMeasure {
   height: number;
 }
 
+export interface Bounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
 export interface KeyProps {
   stem_down_x_offset: number;
   stem_up_x_offset: number;


### PR DESCRIPTION
While investigating #1127, I noticed that measuring text in the `SVGContext` is quite slow because it forces a DOM reflow, so I added a cache. This reduces the time taken to run all tests from _12.5 seconds_ to _10.5 seconds_ on my machine.

In real world use cases that lay out systems one time only, this change will probably only have a marginal effect. In interactive cases, where the same page is repeatedly laid out with only minor changes each time (like my personal use case), this will greatly speed up all text measurement.

Changes in this PR:
 - Return a `TextMeasure` object from `RenderContext.measureText` that has both `width` & `height`. Previously, either a `SVGRect` or `TextMetrics` object would be returned depending on whether the context was canvas or SVG. In particular, `height` is always set (it was missing from the `TextMetrics` returned by `CanvasContext.measureText`.
 - `CanvasContext.measureText` calculates the text height directly from the font size.

I also fixed a bug in `TextNote` where the tick context width was incorrectly being used to position superscript and subscript text instead of the main text's width.

To make this PR simpler, I removed a couple of features:
 - Removed `Renderer.bolsterCanvasContext` and always return a `CanvasContext`. I measured and this does not make any measurable difference to the performance: actually very little time is spent in the calls to the render contexts themselves. This avoids having to do an ugly hack to make `measureText` work because that method already exists on `CanvasRenderingContext2D`.
 - Removed the IE polyfill for italic text: IE is no longer supported since #1108.

I also removed the `bounds` attribute from `Stave` because it isn't actually used for anything.