### PR TITLE
Standardize `CATEGORY` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ Please help test this beta release and [report issues on GitHub](https://github.
 
 ## Breaking
 
-- The tsconfig.json `compilerOptions.target` has been updated to ES6 / ES2015. If you are targeting an older environment such as Internet Explorer, you will need to build directly from source code (and change the target back to ES5).
+- The tsconfig.json `compilerOptions.target` has been updated to ES6 / ES2015. If you are targeting an older environment, you will need to build directly from source code (and change the target back to ES5).
 - `Stave.setNumLines(n: number)` requires a number. Previously, a string would also work. See: [stave.ts](https://github.com/0xfe/vexflow/blob/master/src/stave.ts) and [#1083](https://github.com/0xfe/vexflow/issues/1083).
 - `Note.addModifier(modifier: Modifier, index?: number): this` now throws a RuntimeError if the parameters are reversed.
 - `TickContext.getTickableForVoice(voiceIndex: number): Tickable` was previously named `getTickablesForVoice(voiceIndex: number): Note`. We removed the `s` because the method returns a single Tickable. You will need to update calls to this function if you are upgrading from a build from between April 2020 to August 2021.
-- Changed `Modifier.CATEGORY` to `'Modifier'` instead of `'none'`. The static property `.CATEGORY` is used by VexFlow internally to differentiate objects.
+- `Element` and its subclasses have a static `CATEGORY` string property, used by VexFlow internally to differentiate objects. This string has been standardized to be singular, with UpperCamelCase capitalization.
+  - Examples:
+    - `Accidental.CATEGORY` is now `'Accidental'` instead of `'accidentals'`.
+    - `Modifier.CATEGORY` is now `'Modifier'` instead of `'none'`.
 
 # 3.0.9 / 2020-04-21
 

--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -9,14 +9,12 @@ import { Flow } from './flow';
 import { Music } from './music';
 import { Modifier } from './modifier';
 import { Glyph } from './glyph';
-import { GraceNoteGroup } from './gracenotegroup';
-import { GraceNote } from './gracenote';
 import { ModifierContextState } from './modifiercontext';
 import { Voice } from './voice';
 import { Note } from './note';
 import { StaveNote } from './stavenote';
 import { Tickable } from './tickable';
-import { isCategory, isStaveNote } from './typeguard';
+import { isCategory, isGraceNote, isGraceNoteGroup, isStaveNote } from './typeguard';
 
 type Line = {
   column: number;
@@ -63,7 +61,7 @@ export class Accidental extends Modifier {
 
   /** Accidentals category string. */
   static get CATEGORY(): string {
-    return 'accidentals';
+    return 'Accidental';
   }
 
   /** Arrange accidentals inside a ModifierContext. */
@@ -462,9 +460,8 @@ export class Accidental extends Modifier {
 
         // process grace notes
         staveNote.getModifiers().forEach((modifier: Modifier) => {
-          // TODO: Replace with isCategory()?
-          if (modifier.getCategory() === GraceNoteGroup.CATEGORY) {
-            (modifier as GraceNoteGroup).getGraceNotes().forEach(processNote);
+          if (isGraceNoteGroup(modifier)) {
+            modifier.getGraceNotes().forEach(processNote);
           }
         });
       };
@@ -480,7 +477,6 @@ export class Accidental extends Modifier {
    */
   constructor(type: string) {
     super();
-    this.setAttribute('type', 'Accidental');
 
     L('New accidental: ', type);
 
@@ -521,11 +517,6 @@ export class Accidental extends Modifier {
     }
   }
 
-  /** Get element category string. */
-  getCategory(): string {
-    return Accidental.CATEGORY;
-  }
-
   /** Get width in pixels. */
   getWidth(): number {
     if (this.cautionary) {
@@ -549,7 +540,7 @@ export class Accidental extends Modifier {
     this.note = note;
 
     // Accidentals attached to grace notes are rendered smaller.
-    if (note.getCategory() === GraceNote.CATEGORY) {
+    if (isGraceNote(note)) {
       this.render_options.font_scale = 25;
       this.reset();
     }

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -46,7 +46,7 @@ export class Annotation extends Modifier {
 
   /** Annotations category string. */
   static get CATEGORY(): string {
-    return 'annotations';
+    return 'Annotation';
   }
 
   /** Text annotations can be positioned and justified relative to the note. */
@@ -108,7 +108,6 @@ export class Annotation extends Modifier {
    */
   constructor(text: string) {
     super();
-    this.setAttribute('type', 'Annotation');
 
     this.text = text;
     this.justification = Annotation.Justify.CENTER;
@@ -117,11 +116,6 @@ export class Annotation extends Modifier {
 
     // The default width is calculated from the text.
     this.setWidth(Flow.textWidth(text));
-  }
-
-  /** Get element category string. */
-  getCategory(): string {
-    return Annotation.CATEGORY;
   }
 
   /** Set font family, size, and weight. E.g., `Arial`, `10pt`, `Bold`. */

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -38,12 +38,6 @@ export class Annotation extends Modifier {
   /** To enable logging for this class. Set `Vex.Flow.Annotation.DEBUG` to `true`. */
   static DEBUG: boolean;
 
-  protected justification: Justify;
-  protected vert_justification: VerticalJustify;
-  protected text: string;
-  // Initialized by the constructor via this.setFont('Arial', 10)
-  protected font!: FontInfo;
-
   /** Annotations category string. */
   static get CATEGORY(): string {
     return 'Annotation';
@@ -53,10 +47,10 @@ export class Annotation extends Modifier {
   static Justify = Justify;
 
   static JustifyString: Record<string, number> = {
-    left: Annotation.Justify.LEFT,
-    right: Annotation.Justify.RIGHT,
-    center: Annotation.Justify.CENTER,
-    centerStem: Annotation.Justify.CENTER_STEM,
+    left: Justify.LEFT,
+    right: Justify.RIGHT,
+    center: Justify.CENTER,
+    centerStem: Justify.CENTER_STEM,
   };
 
   static VerticalJustify = VerticalJustify;
@@ -101,6 +95,12 @@ export class Annotation extends Modifier {
     return true;
   }
 
+  protected justification: Justify;
+  protected vert_justification: VerticalJustify;
+  protected text: string;
+  // Initialized by the constructor via this.setFont('Arial', 10).
+  protected font!: FontInfo;
+
   /**
    * Annotations inherit from `Modifier` and is positioned correctly when
    * in a `ModifierContext`.
@@ -110,7 +110,7 @@ export class Annotation extends Modifier {
     super();
 
     this.text = text;
-    this.justification = Annotation.Justify.CENTER;
+    this.justification = Justify.CENTER;
     this.vert_justification = Annotation.VerticalJustify.TOP;
     this.setFont('Arial', 10);
 

--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -19,15 +19,19 @@ function L(...args: any[]) {
  * See `tests/barnote_tests.ts` for usage examples.
  */
 export class BarNote extends Note {
-  protected metrics: { widths: Record<string, number> };
   /** To enable logging for this class. Set `Vex.Flow.BarNote.DEBUG` to `true`. */
   static DEBUG: boolean;
+
+  static get CATEGORY(): string {
+    return 'BarNote';
+  }
+
+  protected metrics: { widths: Record<string, number> };
   // Initialized by the constructor via this.setType(type)
   protected type!: BarlineType;
 
   constructor(type = BarlineType.SINGLE) {
     super({ duration: 'b' });
-    this.setAttribute('type', 'BarNote');
 
     this.metrics = {
       widths: {},

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -23,14 +23,8 @@ export interface BendRenderOptions {
 
 /** Bend implements tablature bends. */
 export class Bend extends Modifier {
-  protected text: string;
-  protected release: boolean;
-  protected phrase: BendPhrase[];
-  protected font: string;
-  protected render_options: BendRenderOptions;
-
   static get CATEGORY(): string {
-    return 'bends';
+    return 'Bend';
   }
 
   static get UP(): number {
@@ -41,7 +35,6 @@ export class Bend extends Modifier {
     return 1;
   }
 
-  // ## Static Methods
   // Arrange bends in `ModifierContext`
   static format(bends: Bend[], state: ModifierContextState): boolean {
     if (!bends || bends.length === 0) return false;
@@ -63,9 +56,15 @@ export class Bend extends Modifier {
     return true;
   }
 
+  protected text: string;
+  protected release: boolean;
+  protected phrase: BendPhrase[];
+  protected font: string;
+  protected render_options: BendRenderOptions;
+
   /**
-   * Constructor.
    * Example of a phrase:
+   * ```
    *    [{
    *     type: UP,
    *     text: "whole"
@@ -91,13 +90,13 @@ export class Bend extends Modifier {
    *     text: "1 1/2"
    *     width: 8;
    *   }]
+   * ```
    * @param text text for bend ("Full", "Half", etc.) (DEPRECATED)
    * @param release if true, render a release. (DEPRECATED)
    * @param phrase if set, ignore "text" and "release", and use the more sophisticated phrase specified
    */
   constructor(text: string, release: boolean = false, phrase?: BendPhrase[]) {
     super();
-    this.setAttribute('type', 'Bend');
 
     this.text = text;
     this.x_shift = 0;
@@ -119,11 +118,6 @@ export class Bend extends Modifier {
     }
 
     this.updateWidth();
-  }
-
-  /** Get element category string. */
-  getCategory(): string {
-    return Bend.CATEGORY;
   }
 
   /** Set horizontal shift in pixels. */

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -35,6 +35,11 @@ function L(...args: any[]): void {
 
 export class ChordSymbol extends Modifier {
   static DEBUG: boolean = false;
+
+  static get CATEGORY(): string {
+    return 'ChordSymbol';
+  }
+
   protected static noFormat: boolean;
 
   protected symbolBlocks: ChordSymbolBlock[];
@@ -45,10 +50,6 @@ export class ChordSymbol extends Modifier {
   protected reportWidth: boolean;
   protected font: FontInfo;
   protected textFont: TextFont;
-
-  static get CATEGORY(): string {
-    return 'chordSymbol';
-  }
 
   // Chord symbols can be positioned and justified relative to the note.
   static readonly horizontalJustify = {
@@ -356,7 +357,6 @@ export class ChordSymbol extends Modifier {
   // This is the modifier version, meaning it is attached to an existing note.
   constructor() {
     super();
-    this.setAttribute('type', 'ChordSymbol');
     this.symbolBlocks = [];
     this.horizontal = ChordSymbol.horizontalJustify.LEFT;
     this.vertical = ChordSymbol.verticalJustify.TOP;
@@ -620,10 +620,6 @@ export class ChordSymbol extends Modifier {
     parameters.symbolType = ChordSymbol.symbolTypes.LINE;
     parameters.width = width;
     return this.addSymbolBlock(parameters);
-  }
-
-  getCategory(): string {
-    return ChordSymbol.CATEGORY;
   }
 
   // Set font family, size, and weight. E.g., `Arial`, `10pt`, `Bold`.

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -3,7 +3,7 @@
 // MIT License
 
 import { RuntimeError, log, defined } from './util';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 
@@ -121,7 +121,7 @@ export class Clef extends StaveModifier {
   constructor(type: string, size?: string, annotation?: string) {
     super();
 
-    this.setPosition(StaveModifier.Position.BEGIN);
+    this.setPosition(StaveModifierPosition.BEGIN);
     this.setType(type, size, annotation);
     this.setWidth(this.musicFont.lookupMetric(`clef.${this.size}.width`));
     L('Creating clef:', type);

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -27,7 +27,6 @@ export class Clef extends StaveModifier {
   /** To enable logging for this class, set `Vex.Flow.Clef.DEBUG` to `true`. */
   static DEBUG: boolean;
 
-  /** Clefs category string. */
   static get CATEGORY(): string {
     return 'Clef';
   }

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -27,6 +27,11 @@ export class Clef extends StaveModifier {
   /** To enable logging for this class, set `Vex.Flow.Clef.DEBUG` to `true`. */
   static DEBUG: boolean;
 
+  /** Clefs category string. */
+  static get CATEGORY(): string {
+    return 'Clef';
+  }
+
   annotation?: {
     code: string;
     line: number;
@@ -44,11 +49,6 @@ export class Clef extends StaveModifier {
   protected attachment?: Glyph;
   protected size?: string;
   protected type?: string;
-
-  /** Clefs category string. */
-  static get CATEGORY(): string {
-    return 'clefs';
-  }
 
   /**
    * Every clef name is associated with a glyph code from the font file
@@ -121,17 +121,11 @@ export class Clef extends StaveModifier {
   /** Create a new clef. */
   constructor(type: string, size?: string, annotation?: string) {
     super();
-    this.setAttribute('type', 'Clef');
 
     this.setPosition(StaveModifier.Position.BEGIN);
     this.setType(type, size, annotation);
     this.setWidth(this.musicFont.lookupMetric(`clef.${this.size}.width`));
     L('Creating clef:', type);
-  }
-
-  /** Get element category string. */
-  getCategory(): string {
-    return Clef.CATEGORY;
   }
 
   /** Set clef type, size and annotation. */

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -12,13 +12,13 @@ import { ModifierContext } from './modifiercontext';
 
 /** ClefNote implements clef annotations in measures. */
 export class ClefNote extends Note {
-  protected clef_obj: Clef;
-  protected type: string;
-  protected clef: ClefType;
-
   static get CATEGORY(): string {
     return 'ClefNote';
   }
+
+  protected clef_obj: Clef;
+  protected type: string;
+  protected clef: ClefType;
 
   constructor(type: string, size?: string, annotation?: string) {
     super({ duration: 'b' });

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -17,12 +17,11 @@ export class ClefNote extends Note {
   protected clef: ClefType;
 
   static get CATEGORY(): string {
-    return 'clefnote';
+    return 'ClefNote';
   }
 
   constructor(type: string, size?: string, annotation?: string) {
     super({ duration: 'b' });
-    this.setAttribute('type', 'ClefNote');
 
     this.type = type;
     this.clef_obj = new Clef(type, size, annotation);
@@ -66,11 +65,6 @@ export class ClefNote extends Note {
   addToModifierContext(mc: ModifierContext): this {
     // DO NOTHING.
     return this;
-  }
-
-  /** Get element category string. */
-  getCategory(): string {
-    return ClefNote.CATEGORY;
   }
 
   /** Set preformatted. */

--- a/src/crescendo.ts
+++ b/src/crescendo.ts
@@ -53,6 +53,11 @@ function renderHairpin(ctx: RenderContext, params: CrescendoParams) {
 export class Crescendo extends Note {
   static DEBUG: boolean;
 
+  /** Crescendo category string. */
+  static get CATEGORY(): string {
+    return 'Crescendo';
+  }
+
   protected decrescendo: boolean;
   protected height: number;
   protected line: number;
@@ -67,7 +72,6 @@ export class Crescendo extends Note {
   // Initialize the crescendo's properties
   constructor(noteStruct: NoteStruct) {
     super(noteStruct);
-    this.setAttribute('type', 'Crescendo');
 
     // Whether the object is a decrescendo
     this.decrescendo = false;

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -23,6 +23,10 @@ export enum CurvePosition {
 }
 
 export class Curve extends Element {
+  static get CATEGORY(): string {
+    return 'Curve';
+  }
+
   protected readonly render_options: CurveOptions;
   protected from: Note;
   protected to: Note;
@@ -46,7 +50,6 @@ export class Curve extends Element {
   //    y_shift: pixels to shift
   constructor(from: Note, to: Note, options: Partial<CurveOptions>) {
     super();
-    this.setAttribute('type', 'Curve');
 
     this.render_options = {
       thickness: 2,

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -6,18 +6,16 @@
 import { RuntimeError } from './util';
 import { Modifier } from './modifier';
 import { Note } from './note';
-import { TabNote } from './tabnote';
 import { ModifierContextState } from './modifiercontext';
-import { GraceNote } from './gracenote';
-import { isStaveNote, isTabNote } from './typeguard';
+import { isGraceNote, isStaveNote, isTabNote } from './typeguard';
 
 export class Dot extends Modifier {
+  static get CATEGORY(): string {
+    return 'Dot';
+  }
+
   protected radius: number;
   protected dot_shiftY: number;
-
-  static get CATEGORY(): string {
-    return 'dots';
-  }
 
   // Arrange dots inside a ModifierContext.
   static format(dots: Dot[], state: ModifierContextState): boolean {
@@ -107,12 +105,8 @@ export class Dot extends Modifier {
     return true;
   }
 
-  /**
-   * @constructor
-   */
   constructor() {
     super();
-    this.setAttribute('type', 'Dot');
 
     this.position = Modifier.Position.RIGHT;
 
@@ -121,13 +115,9 @@ export class Dot extends Modifier {
     this.dot_shiftY = 0;
   }
 
-  getCategory(): string {
-    return Dot.CATEGORY;
-  }
-
   setNote(note: Note): this {
     this.note = note;
-    if (note.getCategory() === GraceNote.CATEGORY) {
+    if (isGraceNote(note)) {
       this.radius *= 0.5;
       this.setWidth(3);
     }
@@ -149,8 +139,8 @@ export class Dot extends Modifier {
 
     const start = note.getModifierStartXY(this.position, this.index, { forceFlagRight: true });
 
-    // Set the starting y coordinate to the base of the stem for TabNotes
-    if (note.getCategory() === TabNote.CATEGORY) {
+    // Set the starting y coordinate to the base of the stem for TabNotes.
+    if (isTabNote(note)) {
       start.y = note.getStemExtents().baseY;
     }
 

--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -13,6 +13,7 @@ import { StaveNote } from './stavenote';
 import { TupletOptions } from './tuplet';
 import { Voice } from './voice';
 import { Music } from './music';
+import { Stem } from 'stem';
 
 // To enable logging for this class. Set `Vex.Flow.EasyScore.DEBUG` to `true`.
 // eslint-disable-next-line
@@ -359,7 +360,7 @@ export class Builder {
 
     // Build a StaveNote using the information we gathered.
     const note = factory.StaveNote({ keys, duration, dots, type, clef, auto_stem });
-    if (!auto_stem) note.setStemDirection(stem === 'up' ? StaveNote.STEM_UP : StaveNote.STEM_DOWN);
+    if (!auto_stem) note.setStemDirection(stem === 'up' ? Stem.UP : Stem.DOWN);
 
     // Attach accidentals.
     const accidentals: (Accidental | undefined)[] = [];

--- a/src/element.ts
+++ b/src/element.ts
@@ -35,6 +35,14 @@ export interface ElementStyle {
  */
 export abstract class Element {
   protected static ID: number = 1000;
+  protected static newID(): string {
+    return `auto${Element.ID++}`;
+  }
+
+  static get CATEGORY(): string {
+    return 'Element';
+  }
+
   private context?: RenderContext;
   protected rendered: boolean;
   protected style?: ElementStyle;
@@ -46,24 +54,27 @@ export abstract class Element {
   protected fontStack!: Font[];
   protected musicFont!: Font;
 
-  protected static newID(): string {
-    return `auto${Element.ID++}`;
-  }
-
-  /** Constructor. */
-  constructor({ type }: { type?: string } = {}) {
+  constructor(/*{ type }: { type?: string } = {}*/) {
     this.attrs = {
       id: Element.newID(),
       el: undefined,
-      type: type || 'Base',
+      type: this.getCategory(),
       classes: {},
     };
+
+    // TODO: Do we need to call .setAttribute() if we already set type: this.getCategory() above?
+    // this.setAttribute('type', this.getCategory());
 
     this.rendered = false;
     this.setFontStack(Flow.DEFAULT_FONT_STACK);
 
     // If a default registry exist, then register with it right away.
     Registry.getDefaultRegistry()?.register(this);
+  }
+
+  /** Get element category string. */
+  getCategory(): string {
+    return (<typeof Element>this.constructor).CATEGORY;
   }
 
   /** Set music fonts stack. */

--- a/src/element.ts
+++ b/src/element.ts
@@ -34,13 +34,13 @@ export interface ElementStyle {
  * of general functions and properties that can be inherited by all VexFlow elements.
  */
 export abstract class Element {
+  static get CATEGORY(): string {
+    return 'Element';
+  }
+
   protected static ID: number = 1000;
   protected static newID(): string {
     return `auto${Element.ID++}`;
-  }
-
-  static get CATEGORY(): string {
-    return 'Element';
   }
 
   private context?: RenderContext;
@@ -54,16 +54,13 @@ export abstract class Element {
   protected fontStack!: Font[];
   protected musicFont!: Font;
 
-  constructor(/*{ type }: { type?: string } = {}*/) {
+  constructor() {
     this.attrs = {
       id: Element.newID(),
       el: undefined,
       type: this.getCategory(),
       classes: {},
     };
-
-    // TODO: Do we need to call .setAttribute() if we already set type: this.getCategory() above?
-    // this.setAttribute('type', this.getCategory());
 
     this.rendered = false;
     this.setFontStack(Flow.DEFAULT_FONT_STACK);
@@ -148,28 +145,24 @@ export abstract class Element {
   /** Add a class label (An element can have multiple class labels).  */
   addClass(className: string): this {
     this.attrs.classes[className] = true;
-    if (this.registry) {
-      this.registry.onUpdate({
-        id: this.attrs.id,
-        name: 'class',
-        value: className,
-        oldValue: undefined,
-      });
-    }
+    this.registry?.onUpdate({
+      id: this.attrs.id,
+      name: 'class',
+      value: className,
+      oldValue: undefined,
+    });
     return this;
   }
 
   /** Remove a class label (An element can have multiple class labels).  */
   removeClass(className: string): this {
     delete this.attrs.classes[className];
-    if (this.registry) {
-      this.registry.onUpdate({
-        id: this.attrs.id,
-        name: 'class',
-        value: undefined,
-        oldValue: className,
-      });
-    }
+    this.registry?.onUpdate({
+      id: this.attrs.id,
+      name: 'class',
+      value: undefined,
+      oldValue: className,
+    });
     return this;
   }
 
@@ -207,10 +200,8 @@ export abstract class Element {
     const oldID = this.attrs.id;
     const oldValue = this.attrs[name];
     this.attrs[name] = value;
-    if (this.registry) {
-      // Register with old id to support id changes.
-      this.registry.onUpdate({ id: oldID, name, value, oldValue });
-    }
+    // Register with old id to support id changes.
+    this.registry?.onUpdate({ id: oldID, name, value, oldValue });
     return this;
   }
 

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -9,11 +9,8 @@ import { RuntimeError } from './util';
 /** Fraction represents a rational number. */
 export class Fraction {
   static get CATEGORY(): string {
-    return 'fractions';
+    return 'Fraction';
   }
-
-  numerator: number = 1;
-  denominator: number = 1;
 
   // Cached objects for comparisons.
   private static __staticFractionA = new Fraction();
@@ -57,16 +54,15 @@ export class Fraction {
     }
   }
 
-  /** Construct providing numerator and denominator. */
+  numerator: number = 1;
+  denominator: number = 1;
+
+  /** Set the numerator and denominator. */
   constructor(numerator?: number, denominator?: number) {
     this.set(numerator, denominator);
   }
 
-  getCategory(): string {
-    return Fraction.CATEGORY;
-  }
-
-  /** Set numerator and denominator. */
+  /** Set the numerator and denominator. */
   set(numerator: number = 1, denominator: number = 1): this {
     this.numerator = numerator;
     this.denominator = denominator;

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -11,11 +11,6 @@ import { Builder } from './easyscore';
 import { ModifierContextState } from './modifiercontext';
 
 export class FretHandFinger extends Modifier {
-  protected finger: string;
-  protected x_offset: number;
-  protected y_offset: number;
-  protected font: FontInfo;
-
   static get CATEGORY(): string {
     return 'FretHandFinger';
   }
@@ -101,10 +96,8 @@ export class FretHandFinger extends Modifier {
   }
 
   static easyScoreHook({ fingerings }: { fingerings?: string } = {}, note: StaveNote, builder: Builder): void {
-    if (!fingerings) return;
-
     fingerings
-      .split(',')
+      ?.split(',')
       .map((fingeringString: string) => {
         const split = fingeringString.trim().split('.');
         const params: { number: string; position?: string } = { number: split[0] };
@@ -113,6 +106,11 @@ export class FretHandFinger extends Modifier {
       })
       .map((fingering: Modifier, index: number) => note.addModifier(fingering, index));
   }
+
+  protected finger: string;
+  protected x_offset: number;
+  protected y_offset: number;
+  protected font: FontInfo;
 
   constructor(finger: string) {
     super();

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -10,9 +10,6 @@ import { StaveNote } from './stavenote';
 import { Builder } from './easyscore';
 import { ModifierContextState } from './modifiercontext';
 
-/**
- * @constructor
- */
 export class FretHandFinger extends Modifier {
   protected finger: string;
   protected x_offset: number;
@@ -20,7 +17,7 @@ export class FretHandFinger extends Modifier {
   protected font: FontInfo;
 
   static get CATEGORY(): string {
-    return 'frethandfinger';
+    return 'FretHandFinger';
   }
 
   // Arrange fingerings inside a ModifierContext.
@@ -119,7 +116,6 @@ export class FretHandFinger extends Modifier {
 
   constructor(finger: string) {
     super();
-    this.setAttribute('type', 'FretHandFinger');
 
     this.finger = finger;
     this.width = 7;
@@ -133,10 +129,6 @@ export class FretHandFinger extends Modifier {
       size: 9,
       weight: 'bold',
     };
-  }
-
-  getCategory(): string {
-    return FretHandFinger.CATEGORY;
   }
 
   setFretHandFinger(finger: string): this {

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -8,30 +8,29 @@ import { Stave } from './stave';
 import { NoteStruct } from './note';
 import { ModifierContext } from './modifiercontext';
 
+const ERROR_MSG = 'Ghost note must have valid initialization data to identify duration.';
+
 export class GhostNote extends StemmableNote {
-  /** @constructor */
+  static get CATEGORY(): string {
+    return 'GhostNote';
+  }
+
   constructor(parameter: string | NoteStruct) {
-    // Sanity check
     if (!parameter) {
-      throw new RuntimeError('BadArguments', 'Ghost note must have valid initialization data to identify duration.');
+      throw new RuntimeError('BadArguments', ERROR_MSG);
     }
 
     let noteStruct;
-
-    // Preserve backwards-compatibility
     if (typeof parameter === 'string') {
+      // Preserve backwards-compatibility
       noteStruct = { duration: parameter };
     } else if (typeof parameter === 'object') {
       noteStruct = parameter;
     } else {
-      throw new RuntimeError(
-        'BadArguments',
-        'Ghost note must have valid initialization data to identify ' + 'duration.'
-      );
+      throw new RuntimeError('BadArguments', ERROR_MSG);
     }
 
     super(noteStruct);
-    this.setAttribute('type', 'GhostNote');
 
     // Note properties
     this.setWidth(0);

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -42,10 +42,12 @@ export interface GlyphProps {
 
   getMetrics(): GlyphMetrics;
 }
+
 export interface GlyphOptions {
   fontStack: Font[];
   category?: string;
 }
+
 export interface GlyphMetrics {
   width: number;
   height: number;
@@ -162,6 +164,10 @@ class GlyphOutline {
 }
 
 export class Glyph extends Element {
+  static get CATEGORY(): string {
+    return 'Glyph';
+  }
+
   protected static cache = new GlyphCache();
 
   bbox: BoundingBox = new BoundingBox(0, 0, 0, 0);
@@ -373,7 +379,6 @@ export class Glyph extends Element {
    */
   constructor(code: string, point: number, options?: { category: string }) {
     super();
-    this.setAttribute('type', 'Glyph');
 
     this.code = code;
     this.point = point;

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -10,6 +10,10 @@ export interface GlyphNoteOptions {
 }
 
 export class GlyphNote extends Note {
+  static get CATEGORY(): string {
+    return 'GlyphNote';
+  }
+
   protected options: GlyphNoteOptions;
 
   constructor(glyph: Glyph | undefined, noteStruct: Partial<NoteStruct>, options?: GlyphNoteOptions) {
@@ -19,7 +23,6 @@ export class GlyphNote extends Note {
       line: 2,
       ...options,
     };
-    this.setAttribute('type', 'GlyphNote');
 
     // Note properties
     this.ignore_ticks = this.options.ignoreTicks as boolean;
@@ -56,6 +59,7 @@ export class GlyphNote extends Note {
     }
     ctx.closeGroup();
   }
+
   draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -8,12 +8,10 @@ import { Flow } from './flow';
 export interface GraceNoteStruct extends StaveNoteStruct {
   slash: boolean;
 }
-export class GraceNote extends StaveNote {
-  protected slash: boolean;
-  protected slur: boolean;
 
+export class GraceNote extends StaveNote {
   static get CATEGORY(): string {
-    return 'gracenotes';
+    return 'GraceNote';
   }
 
   static get LEDGER_LINE_OFFSET(): number {
@@ -24,6 +22,9 @@ export class GraceNote extends StaveNote {
     return 0.66;
   }
 
+  protected slash: boolean;
+  protected slur: boolean;
+
   constructor(noteStruct: Partial<GraceNoteStruct>) {
     super({
       ...{
@@ -32,7 +33,6 @@ export class GraceNote extends StaveNote {
       },
       ...noteStruct,
     });
-    this.setAttribute('type', 'GraceNote');
 
     this.slash = noteStruct.slash || false;
     this.slur = true;
@@ -58,10 +58,6 @@ export class GraceNote extends StaveNote {
     }
 
     return 0;
-  }
-
-  getCategory(): string {
-    return GraceNote.CATEGORY;
   }
 
   // FIXME: move this to more basic class.
@@ -133,7 +129,7 @@ export class GraceNote extends StaveNote {
         };
       }
 
-      // FIXME: avoide staff lines, leadger lines or others.
+      // FIXME: avoid staff lines, ledger lines or others.
 
       const ctx = this.checkContext();
       ctx.save();

--- a/src/gracetabnote.ts
+++ b/src/gracetabnote.ts
@@ -12,12 +12,11 @@ import { TabNote, TabNoteStruct } from './tabnote';
 
 export class GraceTabNote extends TabNote {
   static get CATEGORY(): string {
-    return 'gracetabnotes';
+    return 'GraceTabNote';
   }
 
   constructor(noteStruct: TabNoteStruct) {
     super(noteStruct, false);
-    this.setAttribute('type', 'GraceTabNote');
 
     this.render_options = {
       ...this.render_options,
@@ -32,10 +31,6 @@ export class GraceTabNote extends TabNote {
     };
 
     this.updateWidth();
-  }
-
-  getCategory(): string {
-    return GraceTabNote.CATEGORY;
   }
 
   draw(): void {

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -13,8 +13,11 @@ import { Glyph } from './glyph';
 import { Stave } from './stave';
 
 export class KeySignature extends StaveModifier {
-  protected glyphFontScale: number;
+  static get CATEGORY(): string {
+    return 'KeySignature';
+  }
 
+  protected glyphFontScale: number;
   protected glyphs: Glyph[];
   protected xPositions: number[];
   protected paddingForced: boolean;
@@ -23,10 +26,6 @@ export class KeySignature extends StaveModifier {
   protected accList: { type: string; line: number }[] = [];
   protected keySpec?: string;
   protected alterKeySpec?: string;
-
-  static get CATEGORY(): string {
-    return 'keysignatures';
-  }
 
   // Space between natural and following accidental depending
   // on vertical position
@@ -92,7 +91,6 @@ export class KeySignature extends StaveModifier {
   // Create a new Key Signature based on a `key_spec`
   constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string) {
     super();
-    this.setAttribute('type', 'KeySignature');
 
     this.setKeySig(keySpec, cancelKeySpec, alterKeySpec);
     this.setPosition(StaveModifier.Position.BEGIN);
@@ -100,10 +98,6 @@ export class KeySignature extends StaveModifier {
     this.glyphs = [];
     this.xPositions = []; // relative to this.x
     this.paddingForced = false;
-  }
-
-  getCategory(): string {
-    return KeySignature.CATEGORY;
   }
 
   // Add an accidental glyph to the `KeySignature` instance which represents

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -8,7 +8,7 @@
 
 import { defined, RuntimeError } from './util';
 import { Flow } from './flow';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 
@@ -93,7 +93,7 @@ export class KeySignature extends StaveModifier {
     super();
 
     this.setKeySig(keySpec, cancelKeySpec, alterKeySpec);
-    this.setPosition(StaveModifier.Position.BEGIN);
+    this.setPosition(StaveModifierPosition.BEGIN);
     this.glyphFontScale = 38; // TODO(0xFE): Should this match StaveNote?
     this.glyphs = [];
     this.xPositions = []; // relative to this.x
@@ -289,7 +289,7 @@ export class KeySignature extends StaveModifier {
 
     if (this.accList.length > 0) {
       const clef =
-        (this.position === StaveModifier.Position.END ? stave.getEndClef() : stave.getClef()) || stave.getClef();
+        (this.position === StaveModifierPosition.END ? stave.getEndClef() : stave.getClef()) || stave.getClef();
       if (cancelAccList) {
         this.convertAccLines(clef, cancelAccList.type, cancelAccList.accList);
       }

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -6,11 +6,14 @@ import { KeySignature } from './keysignature';
 import { ModifierContext } from './modifiercontext';
 
 export class KeySigNote extends Note {
+  static get CATEGORY(): string {
+    return 'KeySigNote';
+  }
+
   protected keySignature: KeySignature;
 
   constructor(keySpec: string, cancelKeySpec: string, alterKeySpec: string) {
     super({ duration: 'b' });
-    this.setAttribute('type', 'KeySigNote');
 
     this.keySignature = new KeySignature(keySpec, cancelKeySpec, alterKeySpec);
 

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -43,7 +43,10 @@ export class Modifier extends Element {
   private spacingFromNextModifier: number;
   private modifierContext?: ModifierContext;
 
-  /** Modifiers category string. */
+  /**
+   * Modifiers category string. Every modifier has a different category.
+   * The `ModifierContext` uses this to determine the type and order of the modifiers.
+   */
   static get CATEGORY(): string {
     return 'Modifier';
   }
@@ -65,7 +68,6 @@ export class Modifier extends Element {
 
   constructor() {
     super();
-    this.setAttribute('type', 'Modifier');
 
     this.width = 0;
 
@@ -80,14 +82,6 @@ export class Modifier extends Element {
   /** Called when position changes. */
   protected reset(): void {
     // DO NOTHING.
-  }
-
-  /**
-   * Every modifier has a category. The `ModifierContext` uses this to determine
-   * the type and order of the modifiers.
-   */
-  getCategory(): string {
-    return Modifier.CATEGORY;
   }
 
   /** Get modifier widths. */
@@ -111,8 +105,9 @@ export class Modifier extends Element {
    * Also verifies that the index is valid.
    */
   checkAttachedNote(): Note {
-    defined(this.index, 'NoIndex', `Can't draw ${this.getCategory()} without an index.`);
-    return defined(this.note, 'NoNote', `Can't draw ${this.getCategory()} without a note.`);
+    const category = this.getCategory();
+    defined(this.index, 'NoIndex', `Can't draw ${category} without an index.`);
+    return defined(this.note, 'NoNote', `Can't draw ${category} without a note.`);
   }
 
   /**

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -30,19 +30,6 @@ export enum ModifierPosition {
  * `ModifierContext`. This ensures that multiple voices don't trample all over each other.
  */
 export class Modifier extends Element {
-  // Modifiers are attached to a note and an index. An index is a specific head in a chord.
-  protected note?: Note;
-  protected index?: number;
-
-  protected width: number;
-  protected text_line: number;
-  protected position: ModifierPosition;
-  protected y_shift: number;
-  protected x_shift: number;
-
-  private spacingFromNextModifier: number;
-  private modifierContext?: ModifierContext;
-
   /**
    * Modifiers category string. Every modifier has a different category.
    * The `ModifierContext` uses this to determine the type and order of the modifiers.
@@ -58,13 +45,26 @@ export class Modifier extends Element {
 
   static get PositionString(): Record<string, number> {
     return {
-      center: Modifier.Position.CENTER,
-      above: Modifier.Position.ABOVE,
-      below: Modifier.Position.BELOW,
-      left: Modifier.Position.LEFT,
-      right: Modifier.Position.RIGHT,
+      center: ModifierPosition.CENTER,
+      above: ModifierPosition.ABOVE,
+      below: ModifierPosition.BELOW,
+      left: ModifierPosition.LEFT,
+      right: ModifierPosition.RIGHT,
     };
   }
+
+  // Modifiers are attached to a note and an index. An index is a specific head in a chord.
+  protected note?: Note;
+  protected index?: number;
+
+  protected width: number;
+  protected text_line: number;
+  protected position: ModifierPosition;
+  protected y_shift: number;
+  protected x_shift: number;
+
+  private spacingFromNextModifier: number;
+  private modifierContext?: ModifierContext;
 
   constructor() {
     super();

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -104,6 +104,12 @@ export class ModifierContext {
     return this.addMember(member);
   }
 
+  /**
+   * this.members maps CATEGORY strings to arrays of Tickable | Modifier | StaveNote | TabNote.
+   * Here we add a new member to this.members, and create a new array if needed.
+   * @param member
+   * @returns this
+   */
   addMember(member: ModifierContextMember): this {
     const category = member.getCategory();
     if (!this.members[category]) {
@@ -115,6 +121,9 @@ export class ModifierContext {
     return this;
   }
 
+  /**
+   * @deprecated
+   */
   getModifiers(category: string): ModifierContextMember[] {
     L('getModifiers is deprecated, use getMembers instead.');
     return this.getMembers(category);

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -12,7 +12,7 @@ import { StaveModifier } from './stavemodifier';
 import { TimeSignature } from './timesignature';
 import { Stave } from './stave';
 import { RenderContext } from './types/common';
-import { Barline } from './stavebarline';
+import { isBarline } from 'typeguard';
 
 export interface MultimeasureRestRenderOptions {
   number_of_measures?: number;
@@ -49,6 +49,10 @@ function get_semibrave_rest() {
 }
 
 export class MultiMeasureRest extends Element {
+  static get CATEGORY(): string {
+    return 'MultiMeasureRest';
+  }
+
   protected render_options: MultimeasureRestRenderOptions;
   protected xs: { left: number; right: number };
   protected number_of_measures: number;
@@ -72,7 +76,6 @@ export class MultiMeasureRest extends Element {
   //   * `semibrave_rest_glyph_scale` - Size of the semibrave(1-bar) rest symbol.
   constructor(number_of_measures: number, options: Partial<MultimeasureRestRenderOptions>) {
     super();
-    this.setAttribute('type', 'MultiMeasureRest');
 
     const point = this.musicFont.lookupMetric('digits.point');
     const fontLineShift = this.musicFont.lookupMetric('digits.shiftLine', 0);
@@ -220,7 +223,8 @@ export class MultiMeasureRest extends Element {
     // FIXME: getNoteStartX() returns x+5(barline width) and
     // getNoteEndX() returns x + width(no barline width) by default. how to fix?
     const begModifiers = stave.getModifiers(StaveModifier.Position.BEGIN);
-    if (begModifiers.length === 1 && begModifiers[0].getCategory() === Barline.CATEGORY) {
+
+    if (begModifiers.length === 1 && isBarline(begModifiers[0])) {
       left -= begModifiers[0].getWidth();
     }
 

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -8,7 +8,7 @@ import { Flow } from './flow';
 import { Element } from './element';
 import { Glyph } from './glyph';
 import { NoteHead } from './notehead';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifierPosition } from './stavemodifier';
 import { TimeSignature } from './timesignature';
 import { Stave } from './stave';
 import { RenderContext } from './types/common';
@@ -222,7 +222,7 @@ export class MultiMeasureRest extends Element {
 
     // FIXME: getNoteStartX() returns x+5(barline width) and
     // getNoteEndX() returns x + width(no barline width) by default. how to fix?
-    const begModifiers = stave.getModifiers(StaveModifier.Position.BEGIN);
+    const begModifiers = stave.getModifiers(StaveModifierPosition.BEGIN);
 
     if (begModifiers.length === 1 && isBarline(begModifiers[0])) {
       left -= begModifiers[0].getWidth();

--- a/src/note.ts
+++ b/src/note.ts
@@ -83,6 +83,10 @@ export interface NoteStruct {
  * array of them. All notes also have a rendering context and belong to a stave.
  */
 export abstract class Note extends Tickable {
+  static get CATEGORY(): string {
+    return 'Note';
+  }
+
   keys: string[];
   keyProps: KeyProps[];
 
@@ -100,10 +104,6 @@ export abstract class Note extends Tickable {
   protected customTypes: string[];
   protected playNote?: Note;
   protected beam?: Beam;
-
-  static get CATEGORY(): string {
-    return 'note';
-  }
 
   /** Debug helper. Displays various note metrics for the given note. */
   static plotMetrics(ctx: RenderContext, note: Tickable, yPos: number): void {
@@ -231,11 +231,11 @@ export abstract class Note extends Tickable {
   /**
    * Every note is a tickable, i.e., it can be mutated by the `Formatter` class for
    * positioning and layout.
-   * To create a new note you need to provide a `noteStruct`.
+   *
+   * @param noteStruct To create a new note you need to provide a `noteStruct`.
    */
   constructor(noteStruct: Partial<NoteStruct>) {
     super();
-    this.setAttribute('type', 'Note');
 
     if (!noteStruct) {
       throw new RuntimeError('BadArguments', 'Note must have valid initialization data to identify duration and type.');
@@ -353,14 +353,6 @@ export abstract class Note extends Tickable {
     this.setYs([stave.getYForLine(0)]); // Update Y values if the stave is changed.
     this.setContext(this.stave.getContext());
     return this;
-  }
-
-  /**
-   * `Note` is not really a modifier, but is used in
-   * a `ModifierContext`.
-   */
-  getCategory(): string {
-    return Note.CATEGORY;
   }
 
   /** Get spacing to the left of the notes. */

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -5,7 +5,6 @@ import { RuntimeError, log, defined } from './util';
 import { Flow } from './flow';
 import { Note, NoteStruct } from './note';
 import { Stem } from './stem';
-import { StaveNote } from './stavenote';
 import { Glyph, GlyphProps } from './glyph';
 import { RenderContext } from './types/common';
 import { BoundingBox } from './boundingbox';
@@ -100,6 +99,10 @@ export class NoteHead extends Note {
   /** To enable logging for this class. Set `Vex.Flow.NoteHead.DEBUG` to `true`. */
   static DEBUG: boolean;
 
+  static get CATEGORY(): string {
+    return 'NoteHead';
+  }
+
   glyph_code: string;
 
   protected custom_glyph: boolean = false;
@@ -115,13 +118,8 @@ export class NoteHead extends Note {
   protected index?: number;
   protected slashed: boolean;
 
-  static get CATEGORY(): string {
-    return 'notehead';
-  }
-
   constructor(head_options: NoteHeadStruct) {
     super(head_options);
-    this.setAttribute('type', 'NoteHead');
 
     this.index = head_options.index;
     this.x = head_options.x || 0;
@@ -129,7 +127,7 @@ export class NoteHead extends Note {
     this.note_type = head_options.note_type;
     this.duration = head_options.duration;
     this.displaced = head_options.displaced || false;
-    this.stem_direction = head_options.stem_direction || StaveNote.STEM_UP;
+    this.stem_direction = head_options.stem_direction || Stem.UP;
     this.line = head_options.line || 0;
 
     // Get glyph code based on duration and note type. This could be
@@ -160,10 +158,6 @@ export class NoteHead extends Note {
     };
 
     this.setWidth(this.glyph.getWidth(this.render_options.glyph_font_scale));
-  }
-
-  getCategory(): string {
-    return NoteHead.CATEGORY;
   }
 
   /** Get the width of the notehead. */

--- a/src/notesubgroup.ts
+++ b/src/notesubgroup.ts
@@ -17,7 +17,7 @@ import { RenderContext } from './types/common';
 
 export class NoteSubGroup extends Modifier {
   static get CATEGORY(): string {
-    return 'notesubgroup';
+    return 'NoteSubGroup';
   }
 
   // Arrange groups inside a `ModifierContext`
@@ -42,7 +42,6 @@ export class NoteSubGroup extends Modifier {
 
   constructor(subNotes: Note[]) {
     super();
-    this.setAttribute('type', 'NoteSubGroup');
 
     this.position = Modifier.Position.LEFT;
     this.subNotes = subNotes;
@@ -59,10 +58,6 @@ export class NoteSubGroup extends Modifier {
     }).setStrict(false);
 
     this.voice.addTickables(this.subNotes);
-  }
-
-  getCategory(): string {
-    return NoteSubGroup.CATEGORY;
   }
 
   preFormat(): void {

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -6,11 +6,11 @@ import { RuntimeError, log, defined } from './util';
 import { Flow } from './flow';
 import { Modifier } from './modifier';
 import { TickContext } from './tickcontext';
-import { StaveNote } from './stavenote';
 import { Glyph } from './glyph';
 import { StemmableNote } from './stemmablenote';
 import { ModifierContextState } from './modifiercontext';
-import { TabNote } from './tabnote';
+import { Stem } from 'stem';
+import { isTabNote } from 'typeguard';
 
 // eslint-disable-next-line
 function L(...args: any[]) {
@@ -27,6 +27,11 @@ function L(...args: any[]) {
 export class Ornament extends Modifier {
   /** To enable logging for this class. Set `Vex.Flow.Ornament.DEBUG` to `true`. */
   static DEBUG: boolean;
+
+  /** Ornaments category string. */
+  static get CATEGORY(): string {
+    return 'Ornament';
+  }
 
   protected ornament: {
     code: string;
@@ -47,11 +52,6 @@ export class Ornament extends Modifier {
   protected accidentalUpper?: Glyph;
   protected accidentalLower?: Glyph;
   protected delayXShift?: number;
-
-  /** Ornaments category string. */
-  static get CATEGORY(): string {
-    return 'ornaments';
-  }
 
   /** Arrange ornaments inside `ModifierContext` */
   static format(ornaments: Ornament[], state: ModifierContextState): boolean {
@@ -163,7 +163,6 @@ export class Ornament extends Modifier {
    */
   constructor(type: string) {
     super();
-    this.setAttribute('type', 'Ornament');
 
     this.type = type;
     this.delayed = false;
@@ -215,11 +214,6 @@ export class Ornament extends Modifier {
     }
   }
 
-  /** Get element category string. */
-  getCategory(): string {
-    return Ornament.CATEGORY;
-  }
-
   /** Set whether the ornament is to be delayed. */
   setDelayed(delayed: boolean): this {
     this.delayed = delayed;
@@ -256,12 +250,12 @@ export class Ornament extends Modifier {
 
     // Get stem extents
     const stemExtents = note.checkStem().getExtents();
-    let y = stemDir === StaveNote.STEM_DOWN ? stemExtents.baseY : stemExtents.topY;
+    let y = stemDir === Stem.DOWN ? stemExtents.baseY : stemExtents.topY;
 
     // TabNotes don't have stems attached to them. Tab stems are rendered outside the stave.
-    if (note.getCategory() === TabNote.CATEGORY) {
+    if (isTabNote(note)) {
       if (note.hasStem()) {
-        if (stemDir === StaveNote.STEM_DOWN) {
+        if (stemDir === Stem.DOWN) {
           y = stave.getYForTopText(this.text_line);
         }
       } else {
@@ -270,7 +264,7 @@ export class Ornament extends Modifier {
       }
     }
 
-    const isPlacedOnNoteheadSide = stemDir === StaveNote.STEM_DOWN;
+    const isPlacedOnNoteheadSide = stemDir === Stem.DOWN;
     const spacing = stave.getSpacingBetweenLines();
     let lineSpacing = 1;
 

--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -34,6 +34,10 @@ export class PedalMarking extends Element {
   /** To enable logging for this class. Set `Vex.Flow.PedalMarking.DEBUG` to `true`. */
   static DEBUG: boolean;
 
+  static get CATEGORY(): string {
+    return 'PedalMarking';
+  }
+
   protected line: number;
   protected type: number;
   protected custom_depress_text: string;
@@ -75,16 +79,6 @@ export class PedalMarking extends Element {
     mixed: PedalMarking.type.MIXED,
   };
 
-  /** Set pedal type. */
-  setType(type: string | number): this {
-    type = typeof type === 'string' ? PedalMarking.typeString[type] : type;
-
-    if (type >= PedalMarking.type.TEXT && type <= PedalMarking.type.MIXED) {
-      this.type = type;
-    }
-    return this;
-  }
-
   /**
    * Create a sustain pedal marking. Returns the defaults PedalMarking.
    * Which uses the traditional "Ped" and "*"" markings.
@@ -112,7 +106,6 @@ export class PedalMarking extends Element {
 
   constructor(notes: StaveNote[]) {
     super();
-    this.setAttribute('type', 'PedalMarking');
 
     this.notes = notes;
     this.type = PedalMarking.type.TEXT;
@@ -134,6 +127,16 @@ export class PedalMarking extends Element {
       bracket_line_width: 1,
       color: 'black',
     };
+  }
+
+  /** Set pedal type. */
+  setType(type: string | number): this {
+    type = typeof type === 'string' ? PedalMarking.typeString[type] : type;
+
+    if (type >= PedalMarking.type.TEXT && type <= PedalMarking.type.MIXED) {
+      this.type = type;
+    }
+    return this;
   }
 
   /**

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -127,8 +127,14 @@ export class Renderer {
       const canvasElement = this.element as HTMLCanvasElement;
       if (!canvasElement.getContext) {
         throw new RuntimeError('BadElement', `Can't get canvas context from element: ${canvasId}`);
+      } else {
+        const context = canvasElement.getContext('2d');
+        if (context) {
+          this.ctx = new CanvasContext(context);
+        } else {
+          throw new RuntimeError('BadElement', `Can't get canvas context from element: ${canvasId}`);
+        }
       }
-      this.ctx = new CanvasContext(canvasElement.getContext('2d')!);
     } else if (this.backend === Renderer.Backends.SVG) {
       this.ctx = new SVGContext(this.element);
     } else {
@@ -143,8 +149,7 @@ export class Renderer {
 
       // Scale the canvas size by the device pixel ratio clamping to the maximum
       // supported size.
-      [width, height] = CanvasContext.SanitizeCanvasDims(width * devicePixelRatio,
-                                                         height * devicePixelRatio);
+      [width, height] = CanvasContext.SanitizeCanvasDims(width * devicePixelRatio, height * devicePixelRatio);
 
       // Divide back down by the pixel ratio and convert to integers.
       width = (width / devicePixelRatio) | 0;

--- a/src/repeatnote.ts
+++ b/src/repeatnote.ts
@@ -5,18 +5,21 @@ import { Glyph } from './glyph';
 import { NoteStruct } from './note';
 import { GlyphNoteOptions } from './glyphnote';
 
-export class RepeatNote extends GlyphNote {
-  constructor(type: string, noteStruct?: Partial<NoteStruct>, options?: GlyphNoteOptions) {
-    // Smufl Codes
-    const CODES = {
-      '1': 'repeat1Bar',
-      '2': 'repeat2Bars',
-      '4': 'repeat4Bars',
-      slash: 'repeatBarSlash',
-    } as Record<string, string>;
+// Map `type` to SMuFL glyph code.
+const CODES: Record<string, string> = {
+  '1': 'repeat1Bar',
+  '2': 'repeat2Bars',
+  '4': 'repeat4Bars',
+  slash: 'repeatBarSlash',
+};
 
+export class RepeatNote extends GlyphNote {
+  static get CATEGORY(): string {
+    return 'RepeatNote';
+  }
+
+  constructor(type: string, noteStruct?: Partial<NoteStruct>, options?: GlyphNoteOptions) {
     super(undefined, { duration: 'q', align_center: type !== 'slash', ...noteStruct }, options);
-    this.setAttribute('type', 'RepeatNote');
 
     const glyphCode = CODES[type] || 'repeat1Bar';
     const glyph = new Glyph(glyphCode, this.musicFont.lookupMetric('repeatNote.point', 40), { category: 'repeatNote' });

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -8,7 +8,7 @@ import { Element, ElementStyle } from './element';
 import { Flow } from './flow';
 import { KeySignature } from './keysignature';
 import { Barline, BarlineType } from './stavebarline';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Repetition } from './staverepetition';
 import { StaveSection } from './stavesection';
 import { StaveTempo, StaveTempoOptions } from './stavetempo';
@@ -44,6 +44,23 @@ export interface StaveOptions {
   top_text_position: number;
   num_lines: number;
 }
+
+// Used by Stave.format() to sort the modifiers at the beginning and end of a stave.
+// The keys (computed property names) match the CATEGORY property in the
+// Barline, Clef, KeySignature, TimeSignature classes.
+const SORT_ORDER_BEG_MODIFIERS = {
+  [Barline.CATEGORY]: 0,
+  [Clef.CATEGORY]: 1,
+  [KeySignature.CATEGORY]: 2,
+  [TimeSignature.CATEGORY]: 3,
+};
+
+const SORT_ORDER_END_MODIFIERS = {
+  [TimeSignature.CATEGORY]: 0,
+  [KeySignature.CATEGORY]: 1,
+  [Barline.CATEGORY]: 2,
+  [Clef.CATEGORY]: 3,
+};
 
 export class Stave extends Element {
   static get CATEGORY(): string {
@@ -270,12 +287,12 @@ export class Stave extends Element {
 
     if (!this.formatted) this.format();
 
-    if (this.getModifiers(StaveModifier.Position.BEGIN).length === 1) {
+    if (this.getModifiers(StaveModifierPosition.BEGIN).length === 1) {
       return 0;
     }
 
     // for right position modifiers zero shift seems correct, see 'Volta + Modifier Measure Test'
-    if (this.modifiers[index].getPosition() === StaveModifier.Position.RIGHT) {
+    if (this.modifiers[index].getPosition() === StaveModifierPosition.RIGHT) {
       return 0;
     }
 
@@ -411,7 +428,7 @@ export class Stave extends Element {
   }
 
   addEndModifier(modifier: StaveModifier): this {
-    this.addModifier(modifier, StaveModifier.Position.END);
+    this.addModifier(modifier, StaveModifierPosition.END);
     return this;
   }
 
@@ -437,10 +454,10 @@ export class Stave extends Element {
 
   setClef(clefSpec: string, size?: string, annotation?: string, position?: number): this {
     if (position === undefined) {
-      position = StaveModifier.Position.BEGIN;
+      position = StaveModifierPosition.BEGIN;
     }
 
-    if (position === StaveModifier.Position.END) {
+    if (position === StaveModifierPosition.END) {
       this.endClef = clefSpec;
     } else {
       this.clef = clefSpec;
@@ -461,7 +478,7 @@ export class Stave extends Element {
   }
 
   setEndClef(clefSpec: string, size?: string, annotation?: string): this {
-    this.setClef(clefSpec, size, annotation, StaveModifier.Position.END);
+    this.setClef(clefSpec, size, annotation, StaveModifierPosition.END);
     return this;
   }
 
@@ -471,7 +488,7 @@ export class Stave extends Element {
 
   setKeySignature(keySpec: string, cancelKeySpec?: string, position?: number): this {
     if (position === undefined) {
-      position = StaveModifier.Position.BEGIN;
+      position = StaveModifierPosition.BEGIN;
     }
 
     const keySignatures = this.getModifiers(position, KeySignature.CATEGORY) as KeySignature[];
@@ -485,13 +502,13 @@ export class Stave extends Element {
   }
 
   setEndKeySignature(keySpec: string, cancelKeySpec?: string): this {
-    this.setKeySignature(keySpec, cancelKeySpec, StaveModifier.Position.END);
+    this.setKeySignature(keySpec, cancelKeySpec, StaveModifierPosition.END);
     return this;
   }
 
   setTimeSignature(timeSpec: string, customPadding?: number, position?: number): this {
     if (position === undefined) {
-      position = StaveModifier.Position.BEGIN;
+      position = StaveModifierPosition.BEGIN;
     }
 
     const timeSignatures = this.getModifiers(position, TimeSignature.CATEGORY) as TimeSignature[];
@@ -504,8 +521,8 @@ export class Stave extends Element {
     return this;
   }
 
-  setEndTimeSignature(timeSpec: string, customPadding: number): this {
-    this.setTimeSignature(timeSpec, customPadding, StaveModifier.Position.END);
+  setEndTimeSignature(timeSpec: string, customPadding?: number): this {
+    this.setTimeSignature(timeSpec, customPadding, StaveModifierPosition.END);
     return this;
   }
 
@@ -521,7 +538,7 @@ export class Stave extends Element {
    */
   addKeySignature(keySpec: string, cancelKeySpec?: string, position?: number): this {
     if (position === undefined) {
-      position = StaveModifier.Position.BEGIN;
+      position = StaveModifierPosition.BEGIN;
     }
     this.addModifier(new KeySignature(keySpec, cancelKeySpec).setPosition(position), position);
     return this;
@@ -540,9 +557,9 @@ export class Stave extends Element {
    * @returns
    */
   addClef(clef: string, size?: string, annotation?: string, position?: number): this {
-    if (position === undefined || position === StaveModifier.Position.BEGIN) {
+    if (position === undefined || position === StaveModifierPosition.BEGIN) {
       this.clef = clef;
-    } else if (position === StaveModifier.Position.END) {
+    } else if (position === StaveModifierPosition.END) {
       this.endClef = clef;
     }
 
@@ -551,7 +568,7 @@ export class Stave extends Element {
   }
 
   addEndClef(clef: string, size?: string, annotation?: string): this {
-    this.addClef(clef, size, annotation, StaveModifier.Position.END);
+    this.addClef(clef, size, annotation, StaveModifierPosition.END);
     return this;
   }
 
@@ -572,7 +589,7 @@ export class Stave extends Element {
   }
 
   addEndTimeSignature(timeSpec: string, customPadding?: number): this {
-    this.addTimeSignature(timeSpec, customPadding, StaveModifier.Position.END);
+    this.addTimeSignature(timeSpec, customPadding, StaveModifierPosition.END);
     return this;
   }
 
@@ -585,7 +602,7 @@ export class Stave extends Element {
   /**
    * @param position
    * @param category
-   * @returns array of StaveModifiers that match by the provided position and category.
+   * @returns array of StaveModifiers that match the provided position and category.
    */
   getModifiers(position?: number, category?: string): StaveModifier[] {
     const noPosition = position === undefined;
@@ -604,6 +621,10 @@ export class Stave extends Element {
     }
   }
 
+  /**
+   * Use the modifier's `getCategory()` as a key for the `order` array.
+   * The retrieved value is used to sort modifiers from left to right (0 to to 3).
+   */
   sortByCategory(items: StaveModifier[], order: Record<string, number>): void {
     for (let i = items.length - 1; i >= 0; i--) {
       for (let j = 0; j < i; j++) {
@@ -620,22 +641,11 @@ export class Stave extends Element {
     const begBarline = this.modifiers[0] as Barline;
     const endBarline = this.modifiers[1];
 
-    const begModifiers = this.getModifiers(StaveModifier.Position.BEGIN);
-    const endModifiers = this.getModifiers(StaveModifier.Position.END);
+    const begModifiers = this.getModifiers(StaveModifierPosition.BEGIN);
+    const endModifiers = this.getModifiers(StaveModifierPosition.END);
 
-    this.sortByCategory(begModifiers, {
-      barlines: 0,
-      clefs: 1,
-      keysignatures: 2,
-      timesignatures: 3,
-    });
-
-    this.sortByCategory(endModifiers, {
-      timesignatures: 0,
-      keysignatures: 1,
-      barlines: 2,
-      clefs: 3,
-    });
+    this.sortByCategory(begModifiers, SORT_ORDER_BEG_MODIFIERS);
+    this.sortByCategory(endModifiers, SORT_ORDER_END_MODIFIERS);
 
     if (begModifiers.length > 1 && begBarline.getType() === BarlineType.REPEAT_BEGIN) {
       begModifiers.push(begModifiers.splice(0, 1)[0]);

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -17,16 +17,16 @@ export enum BarlineType {
 }
 
 export class Barline extends StaveModifier {
+  static get CATEGORY(): string {
+    return 'Barline';
+  }
+
   protected widths: Record<string, number>;
   protected paddings: Record<string, number>;
   protected layoutMetricsMap: Record<number, LayoutMetrics>;
 
   protected thickness: number;
   protected type!: BarlineType;
-
-  static get CATEGORY(): string {
-    return 'barlines';
-  }
 
   static get type(): typeof BarlineType {
     return BarlineType;
@@ -44,12 +44,8 @@ export class Barline extends StaveModifier {
     };
   }
 
-  /**
-   * @constructor
-   */
   constructor(type: BarlineType | string) {
     super();
-    this.setAttribute('type', 'Barline');
     this.thickness = Flow.STAVE_LINE_THICKNESS;
 
     const TYPE = BarlineType;
@@ -116,10 +112,6 @@ export class Barline extends StaveModifier {
     };
     this.setPosition(StaveModifier.Position.BEGIN);
     this.setType(type);
-  }
-
-  getCategory(): string {
-    return Barline.CATEGORY;
   }
 
   getType(): number {

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -3,7 +3,7 @@
 // Author Larry Kuhns 2011
 
 import { Flow } from './flow';
-import { LayoutMetrics, StaveModifier } from './stavemodifier';
+import { LayoutMetrics, StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Stave } from './stave';
 
 export enum BarlineType {
@@ -110,7 +110,7 @@ export class Barline extends StaveModifier {
       paddingLeft: 5,
       paddingRight: 5,
     };
-    this.setPosition(StaveModifier.Position.BEGIN);
+    this.setPosition(StaveModifierPosition.BEGIN);
     this.setType(type);
   }
 

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -30,6 +30,10 @@ function drawBoldDoubleLine(ctx: RenderContext, type: number, topX: number, topY
 
 /** StaveConnector implements the connector lines between staves of a system. */
 export class StaveConnector extends Element {
+  static get CATEGORY(): string {
+    return 'StaveConnector';
+  }
+
   protected thickness: number;
   protected width: number;
   protected font: FontInfo;
@@ -92,7 +96,6 @@ export class StaveConnector extends Element {
 
   constructor(top_stave: Stave, bottom_stave: Stave) {
     super();
-    this.setAttribute('type', 'StaveConnector');
 
     this.thickness = Flow.STAVE_LINE_THICKNESS;
     this.width = 3;

--- a/src/stavehairpin.ts
+++ b/src/stavehairpin.ts
@@ -22,6 +22,10 @@ export interface StaveHairpinRenderOptions {
 }
 
 export class StaveHairpin extends Element {
+  static get CATEGORY(): string {
+    return 'StaveHairpin';
+  }
+
   protected hairpin: number;
 
   protected position: number;
@@ -54,9 +58,7 @@ export class StaveHairpin extends Element {
    **/
   static FormatByTicksAndDraw(
     ctx: RenderContext,
-    formatter: {
-      pixelsPerTick: number;
-    },
+    formatter: { pixelsPerTick: number },
     notes: Record<string, Note>,
     type: number,
     position: number,
@@ -107,7 +109,6 @@ export class StaveHairpin extends Element {
    */
   constructor(notes: Record<string, Note>, type: number) {
     super();
-    this.setAttribute('type', 'StaveHairpin');
     this.setNotes(notes);
     this.hairpin = type;
     this.position = Modifier.Position.BELOW;

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -148,17 +148,9 @@ interface RenderOptions {
 }
 
 export class StaveLine extends Element {
-  readonly render_options: RenderOptions;
-
-  protected text: string;
-  protected font: FontInfo;
-
-  // These five instance variables are all initialized by the constructor via this.setNotes(notes).
-  protected notes!: StaveLineNotes;
-  protected first_note!: StaveNote;
-  protected first_indices!: number[];
-  protected last_note!: StaveNote;
-  protected last_indices!: number[];
+  static get CATEGORY(): string {
+    return 'StaveLine';
+  }
 
   // Text Positioning
   static readonly TextVerticalPosition = {
@@ -171,6 +163,18 @@ export class StaveLine extends Element {
     CENTER: 2,
     RIGHT: 3,
   };
+
+  readonly render_options: RenderOptions;
+
+  protected text: string;
+  protected font: FontInfo;
+
+  // These five instance variables are all initialized by the constructor via this.setNotes(notes).
+  protected notes!: StaveLineNotes;
+  protected first_note!: StaveNote;
+  protected first_indices!: number[];
+  protected last_note!: StaveNote;
+  protected last_indices!: number[];
 
   // Initialize the StaveLine with the given `notes`.
   //
@@ -186,7 +190,6 @@ export class StaveLine extends Element {
   //  ```
   constructor(notes: StaveLineNotes) {
     super();
-    this.setAttribute('type', 'StaveLine');
 
     this.setNotes(notes);
 
@@ -232,6 +235,7 @@ export class StaveLine extends Element {
     this.font = font;
     return this;
   }
+
   // The the annotation for the `StaveLine`
   setText(text: string): this {
     this.text = text;

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -26,7 +26,6 @@ export enum StaveModifierPosition {
 }
 
 export class StaveModifier extends Element {
-  /** StaveModifier category string. */
   static get CATEGORY(): string {
     return 'StaveModifier';
   }

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -26,6 +26,15 @@ export enum StaveModifierPosition {
 }
 
 export class StaveModifier extends Element {
+  /** StaveModifier category string. */
+  static get CATEGORY(): string {
+    return 'StaveModifier';
+  }
+
+  static get Position(): typeof StaveModifierPosition {
+    return StaveModifierPosition;
+  }
+
   protected width: number = 0;
   protected x: number = 0;
 
@@ -34,13 +43,8 @@ export class StaveModifier extends Element {
   protected stave?: Stave;
   protected layoutMetrics?: LayoutMetrics;
 
-  static get Position(): typeof StaveModifierPosition {
-    return StaveModifierPosition;
-  }
-
   constructor() {
     super();
-    this.setAttribute('type', 'StaveModifier');
 
     this.padding = 10;
     this.position = StaveModifier.Position.ABOVE;
@@ -84,10 +88,6 @@ export class StaveModifier extends Element {
   setX(x: number): this {
     this.x = x;
     return this;
-  }
-
-  getCategory(): string {
-    return '';
   }
 
   placeGlyphOnLine(glyph: Glyph, stave: Stave, line?: number, customShift = 0): void {

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -46,7 +46,7 @@ export class StaveModifier extends Element {
     super();
 
     this.padding = 10;
-    this.position = StaveModifier.Position.ABOVE;
+    this.position = StaveModifierPosition.ABOVE;
   }
 
   getPosition(): number {

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -93,6 +93,33 @@ function centerRest(rest: StaveNoteFormatSettings, noteU: StaveNoteFormatSetting
 export class StaveNote extends StemmableNote {
   static DEBUG: boolean;
 
+  static get CATEGORY(): string {
+    return 'StaveNote';
+  }
+
+  /**
+   * @deprecated Use Stem.UP.
+   */
+  static get STEM_UP(): number {
+    return Stem.UP;
+  }
+
+  /**
+   * @deprecated Use Stem.DOWN.
+   */
+  static get STEM_DOWN(): number {
+    return Stem.DOWN;
+  }
+
+  static get DEFAULT_LEDGER_LINE_OFFSET(): number {
+    return 3;
+  }
+
+  static get minNoteheadPadding(): number {
+    const musicFont = Flow.DEFAULT_FONT_STACK[0];
+    return musicFont.lookupMetric('glyphs.noteHead.minPadding');
+  }
+
   minLine: number = 0;
   maxLine: number = 0;
 
@@ -105,23 +132,6 @@ export class StaveNote extends StemmableNote {
   protected note_heads: NoteHead[];
   protected ledgerLineStyle: ElementStyle;
   protected flagStyle?: ElementStyle;
-
-  static get CATEGORY(): string {
-    return 'stavenotes';
-  }
-  static get STEM_UP(): number {
-    return Stem.UP;
-  }
-  static get STEM_DOWN(): number {
-    return Stem.DOWN;
-  }
-  static get DEFAULT_LEDGER_LINE_OFFSET(): number {
-    return 3;
-  }
-  static get minNoteheadPadding(): number {
-    const musicFont = Flow.DEFAULT_FONT_STACK[0];
-    return musicFont.lookupMetric('glyphs.noteHead.minPadding');
-  }
 
   // ## Static Methods
   //
@@ -365,7 +375,6 @@ export class StaveNote extends StemmableNote {
 
   constructor(noteStruct: Partial<StaveNoteStruct>) {
     super(noteStruct);
-    this.setAttribute('type', 'StaveNote');
 
     this.ledgerLineStyle = {};
 
@@ -432,10 +441,6 @@ export class StaveNote extends StemmableNote {
     this.beam = beam;
     this.calcNoteDisplacements();
     return this;
-  }
-
-  getCategory(): string {
-    return StaveNote.CATEGORY;
   }
 
   // Builds a `Stem` for the note
@@ -886,12 +891,12 @@ export class StaveNote extends StemmableNote {
 
   // Get all accidentals in the `ModifierContext`
   getAccidentals(): Accidental[] {
-    return this.checkModifierContext().getMembers('accidentals') as Accidental[];
+    return this.checkModifierContext().getMembers(Accidental.CATEGORY) as Accidental[];
   }
 
   // Get all dots in the `ModifierContext`
   getDots(): Dot[] {
-    return this.checkModifierContext().getMembers('dots') as Dot[];
+    return this.checkModifierContext().getMembers(Dot.CATEGORY) as Dot[];
   }
 
   // Get the width of the note if it is displaced. Used for `Voice`

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -7,15 +7,10 @@ import { FontInfo } from './types/common';
 import { Stave } from './stave';
 
 export class Repetition extends StaveModifier {
-  protected symbol_type: number;
-
-  protected x_shift: number;
-  protected y_shift: number;
-  protected font: FontInfo;
-
   static get CATEGORY(): string {
-    return 'repetitions';
+    return 'Repetition';
   }
+
   static readonly type = {
     NONE: 1, // no coda or segno
     CODA_LEFT: 2, // coda at beginning of stave
@@ -31,9 +26,14 @@ export class Repetition extends StaveModifier {
     FINE: 12, // Fine at end of stave
   };
 
+  protected symbol_type: number;
+
+  protected x_shift: number;
+  protected y_shift: number;
+  protected font: FontInfo;
+
   constructor(type: number, x: number, y_shift: number) {
     super();
-    this.setAttribute('type', 'Repetition');
 
     this.symbol_type = type;
     this.x = x;
@@ -45,10 +45,6 @@ export class Repetition extends StaveModifier {
       weight: 'bold',
       style: 'italic',
     };
-  }
-
-  getCategory(): string {
-    return Repetition.CATEGORY;
   }
 
   setShiftX(x: number): this {

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -6,18 +6,17 @@ import { StaveModifier } from './stavemodifier';
 import { FontInfo } from './types/common';
 
 export class StaveSection extends StaveModifier {
+  static get CATEGORY(): string {
+    return 'StaveSection';
+  }
+
   protected section: string;
   protected shift_x: number;
   protected shift_y: number;
   protected font: FontInfo;
 
-  static get CATEGORY(): string {
-    return 'stavesection';
-  }
-
   constructor(section: string, x: number, shift_y: number) {
     super();
-    this.setAttribute('type', 'StaveSection');
 
     this.setWidth(16);
     this.section = section;
@@ -29,10 +28,6 @@ export class StaveSection extends StaveModifier {
       size: 12,
       weight: 'bold',
     };
-  }
-
-  getCategory(): string {
-    return StaveSection.CATEGORY;
   }
 
   setStaveSection(section: string): this {

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -2,7 +2,7 @@
 // Author Radosaw Eichler 2012
 
 import { Flow } from './flow';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Glyph } from './glyph';
 import { FontInfo } from './types/common';
 import { Stave } from './stave';
@@ -32,7 +32,7 @@ export class StaveTempo extends StaveModifier {
     super();
 
     this.tempo = tempo;
-    this.position = StaveModifier.Position.ABOVE;
+    this.position = StaveModifierPosition.ABOVE;
     this.x = x;
     this.shift_x = 10;
     this.shift_y = shift_y;

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -15,6 +15,10 @@ export interface StaveTempoOptions {
 }
 
 export class StaveTempo extends StaveModifier {
+  static get CATEGORY(): string {
+    return 'StaveTempo';
+  }
+
   protected font: FontInfo;
   protected render_options: {
     glyph_font_scale: number;
@@ -24,13 +28,8 @@ export class StaveTempo extends StaveModifier {
   protected shift_x: number;
   protected shift_y: number;
 
-  static get CATEGORY(): string {
-    return 'stavetempo';
-  }
-
   constructor(tempo: StaveTempoOptions, x: number, shift_y: number) {
     super();
-    this.setAttribute('type', 'StaveTempo');
 
     this.tempo = tempo;
     this.position = StaveModifier.Position.ABOVE;
@@ -45,10 +44,6 @@ export class StaveTempo extends StaveModifier {
     this.render_options = {
       glyph_font_scale: 30, // font size for note
     };
-  }
-
-  getCategory(): string {
-    return StaveTempo.CATEGORY;
   }
 
   setTempo(tempo: StaveTempoOptions): this {

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -2,8 +2,8 @@
 // Author Taehoon Moon 2014
 
 import { RuntimeError } from './util';
-import { StaveModifier } from './stavemodifier';
-import { TextNote } from './textnote';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
+import { Justification, TextNote } from './textnote';
 import { FontInfo } from './types/common';
 import { Stave } from './stave';
 
@@ -87,20 +87,18 @@ export class StaveText extends StaveModifier {
 
     let x;
     let y;
-    const Position = StaveModifier.Position;
-    const Justification = TextNote.Justification;
     switch (this.position) {
-      case Position.LEFT:
-      case Position.RIGHT:
+      case StaveModifierPosition.LEFT:
+      case StaveModifierPosition.RIGHT:
         y = (stave.getYForLine(0) + stave.getBottomLineY()) / 2 + this.options.shift_y;
-        if (this.position === Position.LEFT) {
+        if (this.position === StaveModifierPosition.LEFT) {
           x = stave.getX() - text_width - 24 + this.options.shift_x;
         } else {
           x = stave.getX() + stave.getWidth() + 24 + this.options.shift_x;
         }
         break;
-      case Position.ABOVE:
-      case Position.BELOW:
+      case StaveModifierPosition.ABOVE:
+      case StaveModifierPosition.BELOW:
         x = stave.getX() + this.options.shift_x;
         if (this.options.justification === Justification.CENTER) {
           x += stave.getWidth() / 2 - text_width / 2;
@@ -108,7 +106,7 @@ export class StaveText extends StaveModifier {
           x += stave.getWidth() - text_width;
         }
 
-        if (this.position === Position.ABOVE) {
+        if (this.position === StaveModifierPosition.ABOVE) {
           y = stave.getYForTopText(2) + this.options.shift_y;
         } else {
           y = stave.getYForBottomText(2) + this.options.shift_y;

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -8,6 +8,10 @@ import { FontInfo } from './types/common';
 import { Stave } from './stave';
 
 export class StaveText extends StaveModifier {
+  static get CATEGORY(): string {
+    return 'StaveText';
+  }
+
   protected options: {
     shift_x: number;
     shift_y: number;
@@ -19,10 +23,6 @@ export class StaveText extends StaveModifier {
   protected shift_x?: number;
   protected shift_y?: number;
 
-  static get CATEGORY(): string {
-    return 'stavetext';
-  }
-
   constructor(
     text: string,
     position: number,
@@ -33,7 +33,6 @@ export class StaveText extends StaveModifier {
     }
   ) {
     super();
-    this.setAttribute('type', 'StaveText');
 
     this.setWidth(16);
     this.text = text;
@@ -50,10 +49,6 @@ export class StaveText extends StaveModifier {
       size: 16,
       weight: 'normal',
     };
-  }
-
-  getCategory(): string {
-    return StaveText.CATEGORY;
   }
 
   setStaveText(text: string): this {

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -9,6 +9,10 @@ import { Element } from './element';
 import { FontInfo, TieNotes } from './types/common';
 
 export class StaveTie extends Element {
+  static get CATEGORY(): string {
+    return 'StaveTie';
+  }
+
   render_options: {
     cp2: number;
     last_x_shift: number;
@@ -43,7 +47,6 @@ export class StaveTie extends Element {
    */
   constructor(notes: TieNotes, text?: string) {
     super();
-    this.setAttribute('type', 'StaveTie');
     this.setNotes(notes);
     this.text = text;
     this.render_options = {

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -14,22 +14,22 @@ export enum VoltaType {
 }
 
 export class Volta extends StaveModifier {
-  protected volta: number;
-  protected number: string;
-
-  protected font: FontInfo;
-  protected y_shift: number;
   static get CATEGORY(): string {
-    return 'voltas';
+    return 'Volta';
   }
 
   static get type(): typeof VoltaType {
     return VoltaType;
   }
 
+  protected volta: number;
+  protected number: string;
+
+  protected font: FontInfo;
+  protected y_shift: number;
+
   constructor(type: number, number: string, x: number, y_shift: number) {
     super();
-    this.setAttribute('type', 'Volta');
     this.volta = type;
     this.x = x;
     this.y_shift = y_shift;
@@ -39,10 +39,6 @@ export class Volta extends StaveModifier {
       size: 9,
       weight: 'bold',
     };
-  }
-
-  getCategory(): string {
-    return Volta.CATEGORY;
   }
 
   setShiftY(y: number): this {
@@ -58,14 +54,14 @@ export class Volta extends StaveModifier {
     const top_y = stave.getYForTopText(stave.getOptions().num_lines) + this.y_shift;
     const vert_height = 1.5 * stave.getOptions().spacing_between_lines_px;
     switch (this.volta) {
-      case Volta.type.BEGIN:
+      case VoltaType.BEGIN:
         ctx.fillRect(this.x + x, top_y, 1, vert_height);
         break;
-      case Volta.type.END:
+      case VoltaType.END:
         width -= 5;
         ctx.fillRect(this.x + x + width, top_y, 1, vert_height);
         break;
-      case Volta.type.BEGIN_END:
+      case VoltaType.BEGIN_END:
         width -= 3;
         ctx.fillRect(this.x + x, top_y, 1, vert_height);
         ctx.fillRect(this.x + x + width, top_y, 1, vert_height);
@@ -74,7 +70,7 @@ export class Volta extends StaveModifier {
         break;
     }
     // If the beginning of a volta, draw measure number
-    if (this.volta === Volta.type.BEGIN || this.volta === Volta.type.BEGIN_END) {
+    if (this.volta === VoltaType.BEGIN || this.volta === VoltaType.BEGIN_END) {
       ctx.save();
       ctx.setFont(this.font.family, this.font.size, this.font.weight);
       ctx.fillText(this.number, this.x + x + 5, top_y + 15);

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -50,7 +50,7 @@ export class Stem extends Element {
   protected renderHeightAdjustment: number;
 
   static get CATEGORY(): string {
-    return 'stem';
+    return 'Stem';
   }
 
   // Stem directions
@@ -73,7 +73,6 @@ export class Stem extends Element {
 
   constructor(options?: StemOptions) {
     super();
-    this.setAttribute('type', 'Stem');
 
     // Default notehead x bounds
     this.x_begin = options?.x_begin || 0;
@@ -134,11 +133,6 @@ export class Stem extends Element {
   setYBounds(y_top: number, y_bottom: number): void {
     this.y_top = y_top;
     this.y_bottom = y_bottom;
-  }
-
-  // The category of the object
-  getCategory(): string {
-    return Stem.CATEGORY;
   }
 
   // Gets the entire height for the stem

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -34,6 +34,26 @@ export interface StemOptions {
 export class Stem extends Element {
   static DEBUG: boolean;
 
+  static get CATEGORY(): string {
+    return 'Stem';
+  }
+
+  // Stem directions
+  static get UP(): number {
+    return 1;
+  }
+  static get DOWN(): number {
+    return -1;
+  }
+
+  // Theme
+  static get WIDTH(): number {
+    return Flow.STEM_WIDTH;
+  }
+  static get HEIGHT(): number {
+    return Flow.STEM_HEIGHT;
+  }
+
   protected hide: boolean;
   protected isStemlet: boolean;
   protected stemletHeight: number;
@@ -48,28 +68,6 @@ export class Stem extends Element {
   protected stem_direction: number;
   protected stem_extension: number;
   protected renderHeightAdjustment: number;
-
-  static get CATEGORY(): string {
-    return 'Stem';
-  }
-
-  // Stem directions
-  static get UP(): number {
-    return 1;
-  }
-
-  static get DOWN(): number {
-    return -1;
-  }
-
-  // Theme
-  static get WIDTH(): number {
-    return Flow.STEM_WIDTH;
-  }
-
-  static get HEIGHT(): number {
-    return Flow.STEM_HEIGHT;
-  }
 
   constructor(options?: StemOptions) {
     super();

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -13,7 +13,7 @@ import { GlyphProps } from './glyph';
 
 export abstract class StemmableNote extends Note {
   static get CATEGORY(): string {
-    return 'stemmablenote';
+    return 'StemmableNote';
   }
 
   stem_direction?: number;
@@ -24,7 +24,6 @@ export abstract class StemmableNote extends Note {
 
   constructor(noteStruct: Partial<NoteStruct>) {
     super(noteStruct);
-    this.setAttribute('type', 'StemmableNote');
   }
 
   // Get and set the note's `Stem`
@@ -256,9 +255,5 @@ export abstract class StemmableNote extends Note {
 
     this.setStem(new Stem(stemOptions));
     this.stem?.setContext(this.getContext()).draw();
-  }
-
-  getCategory(): string {
-    return StemmableNote.CATEGORY;
   }
 }

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -8,15 +8,18 @@
 import { RuntimeError } from './util';
 import { Modifier } from './modifier';
 import { Renderer } from './renderer';
-import { StaveNote } from './stavenote';
 import { FontInfo } from './types/common';
 import { Note } from './note';
 import { ModifierContextState } from './modifiercontext';
 import { isStaveNote, isStemmableNote } from './typeguard';
+import { Stem } from 'stem';
 
 export class StringNumber extends Modifier {
-  protected radius: number;
+  static get CATEGORY(): string {
+    return 'StringNumber';
+  }
 
+  protected radius: number;
   protected last_note?: Note;
   protected string_number: string;
   protected x_offset: number;
@@ -24,10 +27,6 @@ export class StringNumber extends Modifier {
   protected dashed: boolean;
   protected leg: number;
   protected font: FontInfo;
-
-  static get CATEGORY(): string {
-    return 'stringnumber';
-  }
 
   // ## Static Methods
   // Arrange string numbers inside a `ModifierContext`
@@ -119,7 +118,6 @@ export class StringNumber extends Modifier {
 
   constructor(number: string) {
     super();
-    this.setAttribute('type', 'StringNumber');
 
     this.string_number = number;
     this.setWidth(20); // ???
@@ -136,10 +134,6 @@ export class StringNumber extends Modifier {
       size: 10,
       weight: 'bold',
     };
-  }
-
-  getCategory(): string {
-    return StringNumber.CATEGORY;
   }
 
   setLineEndType(leg: number): this {
@@ -192,7 +186,7 @@ export class StringNumber extends Modifier {
         let top = stem_ext.topY;
         let bottom = stem_ext.baseY + 2;
 
-        if (note.getStemDirection() === StaveNote.STEM_DOWN) {
+        if (note.getStemDirection() === Stem.DOWN) {
           top = stem_ext.baseY;
           bottom = stem_ext.topY - 2;
         }

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -14,6 +14,20 @@ import { ModifierContextState } from './modifiercontext';
 import { isNote, isStaveNote, isTabNote } from './typeguard';
 
 export class Stroke extends Modifier {
+  static get CATEGORY(): string {
+    return 'Stroke';
+  }
+
+  static readonly Type = {
+    BRUSH_DOWN: 1,
+    BRUSH_UP: 2,
+    ROLL_DOWN: 3, // Arpeggiated chord
+    ROLL_UP: 4, // Arpeggiated chord
+    RASQUEDO_DOWN: 5,
+    RASQUEDO_UP: 6,
+    ARPEGGIO_DIRECTIONLESS: 7, // Arpeggiated chord without upwards or downwards arrow
+  };
+
   protected options: {
     all_voices: boolean;
   };
@@ -27,20 +41,6 @@ export class Stroke extends Modifier {
     stroke_spacing: number;
   };
   protected font: FontInfo;
-
-  static get CATEGORY(): string {
-    return 'strokes';
-  }
-
-  static readonly Type = {
-    BRUSH_DOWN: 1,
-    BRUSH_UP: 2,
-    ROLL_DOWN: 3, // Arpeggiated chord
-    ROLL_UP: 4, // Arpeggiated chord
-    RASQUEDO_DOWN: 5,
-    RASQUEDO_UP: 6,
-    ARPEGGIO_DIRECTIONLESS: 7, // Arpeggiated chord without upwards or downwards arrow
-  };
 
   // Arrange strokes inside `ModifierContext`
   static format(strokes: Stroke[], state: ModifierContextState): boolean {
@@ -81,7 +81,6 @@ export class Stroke extends Modifier {
 
   constructor(type: number, options?: { all_voices: boolean }) {
     super();
-    this.setAttribute('type', 'Stroke');
 
     this.options = { all_voices: true, ...options };
 
@@ -106,10 +105,6 @@ export class Stroke extends Modifier {
 
     this.setXShift(0);
     this.setWidth(10);
-  }
-
-  getCategory(): string {
-    return Stroke.CATEGORY;
   }
 
   getPosition(): number {
@@ -139,7 +134,6 @@ export class Stroke extends Modifier {
       if (isNote(note)) {
         // Only Note objects have getYs().
         // note is an instance of either StaveNote or TabNote.
-        // note.getCategory() returns 'stavenotes' or 'tabnotes'
         ys = note.getYs();
         for (let n = 0; n < ys.length; n++) {
           if (this.note === notes[i] || this.all_voices) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -71,6 +71,7 @@ export class System extends Element {
   protected parts: SystemParams[];
   protected connector?: StaveConnector;
   protected debugNoteMetricsYs?: { y: number; voice: Voice }[];
+
   constructor(params: Partial<SystemOptions> = {}) {
     super();
     this.setOptions(params);

--- a/src/system.ts
+++ b/src/system.ts
@@ -59,6 +59,10 @@ export interface SystemOptions {
  * the system are formatted together.
  */
 export class System extends Element {
+  static get CATEGORY(): string {
+    return 'System';
+  }
+
   protected options!: SystemOptions;
   protected factory!: Factory;
   protected formatter?: Formatter;
@@ -69,7 +73,6 @@ export class System extends Element {
   protected debugNoteMetricsYs?: { y: number; voice: Voice }[];
   constructor(params: Partial<SystemOptions> = {}) {
     super();
-    this.setAttribute('type', 'System');
     this.setOptions(params);
     this.parts = [];
   }

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -7,6 +7,7 @@
 //
 // See `tests/tabnote_tests.ts` for usage examples.
 
+import { isDot } from 'typeguard';
 import { Dot } from './dot';
 import { Flow } from './flow';
 import { Glyph, GlyphProps } from './glyph';
@@ -122,19 +123,18 @@ function getPartialStemLines(stem_y: number, unused_strings: number[][], stave: 
 }
 
 export class TabNote extends StemmableNote {
+  static get CATEGORY(): string {
+    return 'TabNote';
+  }
+
   protected ghost: boolean;
   protected glyphs: GlyphProps[] = [];
   protected positions: TabNotePosition[];
-
-  static get CATEGORY(): string {
-    return 'tabnotes';
-  }
 
   // Initialize the TabNote with a `tab_struct` full of properties
   // and whether to `draw_stem` when rendering the note
   constructor(tab_struct: TabNoteStruct, draw_stem?: boolean) {
     super(tab_struct);
-    this.setAttribute('type', 'TabNote');
 
     this.ghost = false; // Renders parenthesis around notes
 
@@ -182,11 +182,6 @@ export class TabNote extends StemmableNote {
   reset(): this {
     if (this.stave) this.setStave(this.stave);
     return this;
-  }
-
-  // The ModifierContext category
-  getCategory(): string {
-    return TabNote.CATEGORY;
   }
 
   // Set as ghost `TabNote`, surrounds the fret positions with parenthesis.
@@ -376,12 +371,13 @@ export class TabNote extends StemmableNote {
     }
   }
 
-  // Render the modifiers onto the context
+  // Render the modifiers onto the context.
   drawModifiers(): void {
-    // Draw the modifiers
     this.modifiers.forEach((modifier) => {
-      // Only draw the dots if enabled
-      if (modifier.getCategory() === Dot.CATEGORY && !this.render_options.draw_dots) return;
+      // Only draw the dots if enabled.
+      if (isDot(modifier) && !this.render_options.draw_dots) {
+        return;
+      }
 
       modifier.setContext(this.getContext());
       modifier.drawWithStyle();
@@ -446,7 +442,7 @@ export class TabNote extends StemmableNote {
     }
   }
 
-  // The main rendering function for the entire note
+  // The main rendering function for the entire note.
   draw(): void {
     const ctx = this.checkContext();
 

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -10,6 +10,10 @@ import { TieNotes } from './types/common';
 import { RuntimeError } from './util';
 
 export class TabSlide extends TabTie {
+  static get CATEGORY(): string {
+    return 'TabSlide';
+  }
+
   static get SLIDE_UP(): number {
     return 1;
   }
@@ -43,7 +47,6 @@ export class TabSlide extends TabTie {
    */
   constructor(notes: TieNotes, direction?: number) {
     super(notes, 'sl.');
-    this.setAttribute('type', 'TabSlide');
 
     // Determine the direction automatically if it is not provided.
     if (!direction) {

--- a/src/tabstave.ts
+++ b/src/tabstave.ts
@@ -3,6 +3,10 @@
 import { Stave, StaveOptions } from './stave';
 
 export class TabStave extends Stave {
+  static get CATEGORY(): string {
+    return 'TabStave';
+  }
+
   constructor(x: number, y: number, width: number, options?: Partial<StaveOptions>) {
     const tab_options = {
       ...{
@@ -14,7 +18,6 @@ export class TabStave extends Stave {
     };
 
     super(x, y, width, tab_options);
-    this.setAttribute('type', 'TabStave');
   }
 
   getYForGlyphs(): number {

--- a/src/tabtie.ts
+++ b/src/tabtie.ts
@@ -8,6 +8,10 @@ import { StaveTie } from './stavetie';
 import { TieNotes } from './types/common';
 
 export class TabTie extends StaveTie {
+  static get CATEGORY(): string {
+    return 'TabTie';
+  }
+
   static createHammeron(notes: TieNotes): TabTie {
     return new TabTie(notes, 'H');
   }
@@ -29,7 +33,6 @@ export class TabTie extends StaveTie {
    */
   constructor(notes: TieNotes, text?: string) {
     super(notes, text);
-    this.setAttribute('type', 'TabTie');
 
     this.render_options.cp1 = 9;
     this.render_options.cp2 = 11;

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -23,9 +23,8 @@ export interface TextBracketParams {
 }
 
 // To enable logging for this class. Set `Vex.Flow.TextBracket.DEBUG` to `true`.
-function L(
-  // eslint-disable-next-line
-  ...args: any[]) {
+// eslint-disable-next-line
+function L(...args: any[]) {
   if (TextBracket.DEBUG) log('Vex.Flow.TextBracket', args);
 }
 
@@ -36,6 +35,10 @@ export enum TextBracketPosition {
 
 export class TextBracket extends Element {
   static DEBUG: boolean;
+
+  static get CATEGORY(): string {
+    return 'TextBracket';
+  }
 
   render_options: {
     dashed: boolean;
@@ -56,30 +59,35 @@ export class TextBracket extends Element {
   protected stop: Note;
   protected font: FontInfo;
 
+  /**
+   * @deprecated
+   */
   static get Positions(): typeof TextBracketPosition {
-    L('Positions is deprecated, use Position instead.');
-    return TextBracket.Position;
+    L('Positions is deprecated, use TextBracketPosition instead.');
+    return TextBracketPosition;
   }
 
   static get Position(): typeof TextBracketPosition {
     return TextBracketPosition;
   }
 
+  /**
+   * @deprecated Use `TextBracket.PositionString` instead.
+   */
   static get PositionsString(): Record<string, number> {
     L('PositionsString is deprecated, use PositionString instead.');
-    return TextBracket.PositionsString;
+    return TextBracket.PositionString;
   }
 
   static get PositionString(): Record<string, number> {
     return {
-      top: TextBracket.Position.TOP,
-      bottom: TextBracket.Position.BOTTOM,
+      top: TextBracketPosition.TOP,
+      bottom: TextBracketPosition.BOTTOM,
     };
   }
 
-  constructor({ start, stop, text = '', superscript = '', position = TextBracket.Position.TOP }: TextBracketParams) {
+  constructor({ start, stop, text = '', superscript = '', position = TextBracketPosition.TOP }: TextBracketParams) {
     super();
-    this.setAttribute('type', 'TextBracket');
 
     this.start = start;
     this.stop = stop;
@@ -149,10 +157,10 @@ export class TextBracket extends Element {
 
     let y = 0;
     switch (this.position) {
-      case TextBracket.Position.TOP:
+      case TextBracketPosition.TOP:
         y = this.start.checkStave().getYForTopText(this.line);
         break;
-      case TextBracket.Position.BOTTOM:
+      case TextBracketPosition.BOTTOM:
         y = this.start.checkStave().getYForBottomText(this.line + Flow.TEXT_HEIGHT_OFFSET_HACK);
         break;
       default:
@@ -196,10 +204,10 @@ export class TextBracket extends Element {
     const end_x = stop.x + this.stop.getGlyph().getWidth();
 
     // Adjust x and y coordinates based on position
-    if (this.position === TextBracket.Position.TOP) {
+    if (this.position === TextBracketPosition.TOP) {
       start_x += main_width + super_width + 5;
       line_y -= super_height / 2.7;
-    } else if (this.position === TextBracket.Position.BOTTOM) {
+    } else if (this.position === TextBracketPosition.BOTTOM) {
       line_y += super_height / 2.7;
       start_x += main_width + 2;
 

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -22,6 +22,10 @@ export class TextDynamics extends Note {
   /** To enable logging for this class. Set `Vex.Flow.TextDynamics.DEBUG` to `true`. */
   static DEBUG: boolean;
 
+  static get CATEGORY(): string {
+    return 'TextDynamics';
+  }
+
   protected sequence: string;
 
   protected line: number;
@@ -58,25 +62,24 @@ export class TextDynamics extends Note {
   }
 
   /**
+   * Create the dynamics marking.
+   *
    * A `TextDynamics` object inherits from `Note` so that it can be formatted
    * within a `Voice`.
-   * Create the dynamics marking. `text_struct` is an object
-   * that contains a `duration` property and a `sequence` of
-   * letters that represents the letters to render
+   *
+   * @param noteStruct an object that contains a `duration` property and a
+   * `sequence` of letters that represents the letters to render.
    */
-  constructor(text_struct: TextNoteStruct) {
-    super(text_struct);
-    this.setAttribute('type', 'TextDynamics');
+  constructor(noteStruct: TextNoteStruct) {
+    super(noteStruct);
 
-    this.sequence = text_struct.text.toLowerCase();
-    this.line = text_struct.line || 0;
+    this.sequence = noteStruct.text.toLowerCase();
+    this.line = noteStruct.line || 0;
     this.glyphs = [];
 
     this.render_options = {
       ...this.render_options,
-      ...{
-        glyph_font_size: 40,
-      },
+      glyph_font_size: 40,
     };
 
     L('New Dynamics Text: ', this.sequence);

--- a/src/textfont.ts
+++ b/src/textfont.ts
@@ -38,14 +38,17 @@ export interface TextFontRegistry {
 }
 
 // To enable logging for this class. Set `Vex.Flow.TextFont.DEBUG` to `true`.
-function L(
-  // eslint-disable-next-line
-  ...args: any[]) {
+// eslint-disable-next-line
+function L(...args: any[]) {
   if (TextFont.DEBUG) log('Vex.Flow.TextFont', args);
 }
 
 export class TextFont {
-  protected static debug: boolean;
+  static DEBUG: boolean;
+  static get CATEGORY(): string {
+    return 'TextFont';
+  }
+
   resolution: number = 1000;
   protected name?: string;
   protected glyphs: Record<string, TextFontMetrics> = {};
@@ -67,18 +70,6 @@ export class TextFont {
 
   protected size: number;
   protected attrs: { type: string };
-
-  static get CATEGORY(): string {
-    return 'textFont';
-  }
-
-  static get DEBUG(): boolean {
-    return TextFont.debug;
-  }
-
-  static set DEBUG(val: boolean) {
-    TextFont.debug = val;
-  }
 
   // ### fontRegistry
   // Getter of an array of available fonts.  Applications may register their
@@ -254,7 +245,7 @@ export class TextFont {
     this.maxSizeGlyph = 'H';
     this.weight = '';
     this.style = '';
-    this.attrs = { type: 'TextFont' };
+    this.attrs = { type: TextFont.CATEGORY };
     if (!params.name) {
       throw new RuntimeError('BadArgument', 'Font constructor must specify a name');
     }

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -28,6 +28,10 @@ export interface TextNoteStruct extends NoteStruct {
  * Examples of this would be such as dynamics, lyrics, chord changes, etc.
  */
 export class TextNote extends Note {
+  static get CATEGORY(): string {
+    return 'TextNote';
+  }
+
   protected text: string;
   protected superscript?: string;
   protected subscript?: string;
@@ -104,36 +108,35 @@ export class TextNote extends Note {
     };
   }
 
-  constructor(options: TextNoteStruct) {
-    super(options);
-    this.setAttribute('type', 'TextNote');
+  constructor(noteStruct: TextNoteStruct) {
+    super(noteStruct);
 
     // Note properties
-    this.text = options.text;
-    this.superscript = options.superscript;
-    this.subscript = options.subscript;
+    this.text = noteStruct.text;
+    this.superscript = noteStruct.superscript;
+    this.subscript = noteStruct.subscript;
     this.glyph = undefined;
     this.font = {
       family: 'Arial',
       size: 12,
       weight: '',
-      ...options.font,
+      ...noteStruct.font,
     };
 
     // Determine and set initial note width. Note that the text width is
     // an approximation and isn't very accurate. The only way to accurately
     // measure the length of text is with `canvasmeasureText()`
-    if (options.glyph) {
-      const struct = TextNote.GLYPHS[options.glyph];
-      if (!struct) throw new RuntimeError('Invalid glyph type: ' + options.glyph);
+    if (noteStruct.glyph) {
+      const struct = TextNote.GLYPHS[noteStruct.glyph];
+      if (!struct) throw new RuntimeError('Invalid glyph type: ' + noteStruct.glyph);
 
       this.glyph = new Glyph(struct.code, 40, { category: 'textNote' });
       this.setWidth(this.glyph.getMetrics().width);
     }
 
-    this.line = options.line || 0;
-    this.smooth = options.smooth || false;
-    this.ignore_ticks = options.ignore_ticks || false;
+    this.line = noteStruct.line || 0;
+    this.smooth = noteStruct.smooth || false;
+    this.ignore_ticks = noteStruct.ignore_ticks || false;
     this.justification = TextNote.Justification.LEFT;
   }
 

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -57,7 +57,6 @@ export abstract class Tickable extends Element {
   /** Constructor */
   constructor() {
     super();
-    this.setAttribute('type', 'Tickable');
 
     // These properties represent the duration of
     // this tickable element.
@@ -102,10 +101,6 @@ export abstract class Tickable extends Element {
         deviation: 0,
       },
     };
-  }
-
-  getCategory(): string {
-    return Tickable.CATEGORY;
   }
 
   /** Reset the Tickable, this function will be overloaded. */

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -54,7 +54,6 @@ export abstract class Tickable extends Element {
   protected intrinsicTicks: number;
   protected align_center: boolean;
 
-  /** Constructor */
   constructor() {
     super();
 

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -34,16 +34,16 @@ const assertIsValidFraction = (timeSpec: string) => {
 };
 
 export class TimeSignature extends StaveModifier {
+  static get CATEGORY(): string {
+    return 'TimeSignature';
+  }
+
   point: number;
   bottomLine: number;
   topLine: number;
 
   protected info: TimeSignatureInfo;
   protected validate_args: boolean;
-
-  static get CATEGORY(): string {
-    return 'timesignatures';
-  }
 
   static get glyphs(): Record<string, { code: string; point: number; line: number }> {
     return {
@@ -62,7 +62,6 @@ export class TimeSignature extends StaveModifier {
 
   constructor(timeSpec: string = '4/4', customPadding = 15, validate_args = true) {
     super();
-    this.setAttribute('type', 'TimeSignature');
     this.validate_args = validate_args;
 
     const padding = customPadding;
@@ -75,10 +74,6 @@ export class TimeSignature extends StaveModifier {
     this.info = this.parseTimeSpec(timeSpec);
     this.setWidth(defined(this.info.glyph.getMetrics().width));
     this.setPadding(padding);
-  }
-
-  getCategory(): string {
-    return TimeSignature.CATEGORY;
   }
 
   parseTimeSpec(timeSpec: string): TimeSignatureInfo {

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -7,7 +7,7 @@
 
 import { RuntimeError, defined } from './util';
 import { Glyph } from './glyph';
-import { StaveModifier } from './stavemodifier';
+import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { TimeSignatureGlyph } from './timesigglyph';
 
 export interface TimeSignatureInfo {
@@ -70,7 +70,7 @@ export class TimeSignature extends StaveModifier {
     const fontLineShift = this.musicFont.lookupMetric('digits.shiftLine', 0);
     this.topLine = 2 + fontLineShift;
     this.bottomLine = 4 + fontLineShift;
-    this.setPosition(StaveModifier.Position.BEGIN);
+    this.setPosition(StaveModifierPosition.BEGIN);
     this.info = this.parseTimeSpec(timeSpec);
     this.setWidth(defined(this.info.glyph.getMetrics().width));
     this.setPadding(padding);

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -38,13 +38,6 @@ export class TimeSignature extends StaveModifier {
     return 'TimeSignature';
   }
 
-  point: number;
-  bottomLine: number;
-  topLine: number;
-
-  protected info: TimeSignatureInfo;
-  protected validate_args: boolean;
-
   static get glyphs(): Record<string, { code: string; point: number; line: number }> {
     return {
       C: {
@@ -59,6 +52,13 @@ export class TimeSignature extends StaveModifier {
       },
     };
   }
+
+  point: number;
+  bottomLine: number;
+  topLine: number;
+
+  protected info: TimeSignatureInfo;
+  protected validate_args: boolean;
 
   constructor(timeSpec: string = '4/4', customPadding = 15, validate_args = true) {
     super();

--- a/src/timesignote.ts
+++ b/src/timesignote.ts
@@ -6,11 +6,14 @@ import { Note } from './note';
 import { TimeSignature, TimeSignatureInfo } from './timesignature';
 
 export class TimeSigNote extends Note {
+  static get CATEGORY(): string {
+    return 'TimeSigNote';
+  }
+
   protected timeSigInfo: TimeSignatureInfo;
 
   constructor(timeSpec: string, customPadding?: number) {
     super({ duration: 'b' });
-    this.setAttribute('type', 'TimeSigNote');
 
     const timeSignature = new TimeSignature(timeSpec, customPadding);
     this.timeSigInfo = timeSignature.getInfo();

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -6,6 +6,7 @@ import { Modifier } from './modifier';
 import { Glyph } from './glyph';
 import { GraceNote } from './gracenote';
 import { Stem } from './stem';
+import { isGraceNote } from 'typeguard';
 
 /** Tremolo implements tremolo notation. */
 export class Tremolo extends Modifier {
@@ -14,25 +15,18 @@ export class Tremolo extends Modifier {
 
   /** Tremolos category string. */
   static get CATEGORY(): string {
-    return 'tremolo';
+    return 'Tremolo';
   }
 
   /**
-   * Constructor.
    * @param num number of bars
    */
   constructor(num: number) {
     super();
-    this.setAttribute('type', 'Tremolo');
 
     this.num = num;
     this.position = Modifier.Position.CENTER;
     this.code = 'tremolo1';
-  }
-
-  /** Get element CATEGORY string. */
-  getCategory(): string {
-    return Tremolo.CATEGORY;
   }
 
   /** Draw the tremolo on the rendering context. */
@@ -45,9 +39,10 @@ export class Tremolo extends Modifier {
 
     const start = note.getModifierStartXY(this.position, this.index);
     let x = start.x;
-    const isGraceNote = note.getCategory() === GraceNote.CATEGORY;
-    const scale = isGraceNote ? GraceNote.SCALE : 1;
-    const category = `tremolo.${isGraceNote ? 'grace' : 'default'}`;
+
+    const gn = isGraceNote(note);
+    const scale = gn ? GraceNote.SCALE : 1;
+    const category = `tremolo.${gn ? 'grace' : 'default'}`;
 
     const y_spacing = this.musicFont.lookupMetric(`${category}.spacing`) * stemDirection;
     const height = this.num * y_spacing;

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -10,13 +10,12 @@ import { isGraceNote } from 'typeguard';
 
 /** Tremolo implements tremolo notation. */
 export class Tremolo extends Modifier {
-  protected readonly code: string;
-  protected readonly num: number;
-
-  /** Tremolos category string. */
   static get CATEGORY(): string {
     return 'Tremolo';
   }
+
+  protected readonly code: string;
+  protected readonly num: number;
 
   /**
    * @param num number of bars

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -63,6 +63,10 @@ export interface TupletOptions {
 }
 
 export class Tuplet extends Element {
+  static get CATEGORY(): string {
+    return 'Tuplet';
+  }
+
   notes: Note[];
 
   protected options: TupletOptions;
@@ -94,7 +98,6 @@ export class Tuplet extends Element {
 
   constructor(notes: Note[], options?: TupletOptions) {
     super();
-    this.setAttribute('type', 'Tuplet');
     if (!notes || !notes.length) {
       throw new RuntimeError('BadArguments', 'No notes provided for tuplet.');
     }

--- a/src/typeguard.ts
+++ b/src/typeguard.ts
@@ -2,16 +2,24 @@
 // Author: Ron B. Yeh
 // MIT License
 
+import { Dot } from 'dot';
+import { GraceNote } from 'gracenote';
+import { GraceNoteGroup } from 'gracenotegroup';
+import { Barline } from 'stavebarline';
 import { Note } from './note';
 import { StaveNote } from './stavenote';
 import { StemmableNote } from './stemmablenote';
 import { TabNote } from './tabnote';
 
-// Helper functions for checking an object's type, via `instanceof` and `obj.getCategory()`.
+// Helper functions for checking an object's type, via `instanceof` and `obj.constructor.CATEGORY`.
 export const isNote = (obj: unknown): obj is Note => isCategory(obj, Note);
 export const isStemmableNote = (obj: unknown): obj is StemmableNote => isCategory(obj, StemmableNote);
 export const isStaveNote = (obj: unknown): obj is StaveNote => isCategory(obj, StaveNote);
 export const isTabNote = (obj: unknown): obj is TabNote => isCategory(obj, TabNote);
+export const isGraceNote = (obj: unknown): obj is GraceNote => isCategory(obj, GraceNote);
+export const isGraceNoteGroup = (obj: unknown): obj is GraceNoteGroup => isCategory(obj, GraceNoteGroup);
+export const isDot = (obj: unknown): obj is Dot => isCategory(obj, Dot);
+export const isBarline = (obj: unknown): obj is Barline => isCategory(obj, Barline);
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
@@ -22,9 +30,9 @@ export const isTabNote = (obj: unknown): obj is TabNote => isCategory(obj, TabNo
  * @param obj check if this object is an instance of the provided `cls`.
  * @param cls a JavaScript class, such as `StaveNote`. `cls` is a constructor function, and it has a `prototype` property, and
  *            optionally a `CATEGORY` property (used in VexFlow for flexible type checking).
- * @param checkAncestors defaults to `true`, so we walk up the prototype chain to look for a matching `.getCategory()`.
+ * @param checkAncestors defaults to `true`, so we walk up the prototype chain to look for a matching `CATEGORY` / `.getCategory()`.
  *        If `false`, we do not check the superclass or other ancestors.
- * @returns true if `obj` is an instance of `ClassName`, or has a `.getCategory()` that matches `ClassName.CATEGORY`.
+ * @returns true if `obj` is an instance of `ClassName`, or has a static `CATEGORY` property that matches `ClassName.CATEGORY`.
  */
 export function isCategory<T>(
   obj: any,
@@ -42,23 +50,25 @@ export function isCategory<T>(
     return true;
   }
 
-  // If instanceof fails, fall back to checking if the object's .getCategory() matches the class's .CATEGORY property.
+  // If instanceof fails, fall back to checking if the object's static .CATEGORY matches the class's .CATEGORY property.
   const categoryToMatch = cls.CATEGORY;
   if (categoryToMatch === undefined) {
     return false;
   }
 
   if (checkAncestors) {
-    // Walk up the prototype chain to look for a matching .getCategory().
+    // Walk up the prototype chain to look for a matching obj.constructor.CATEGORY.
     while (obj !== null) {
-      if ('getCategory' in obj && obj.getCategory() === categoryToMatch) {
+      const constructorFcn = obj.constructor;
+      if ('CATEGORY' in constructorFcn && constructorFcn.CATEGORY === categoryToMatch) {
         return true;
       }
       obj = Object.getPrototypeOf(obj);
     }
     return false;
   } else {
-    // Do not walk up the prototype chain. Just check this particular object's .getCategory().
-    return 'getCategory' in obj && obj.getCategory() === categoryToMatch;
+    // Do not walk up the prototype chain. Just check this particular object's static .CATEGORY string.
+    const constructorFcn = obj.constructor;
+    return 'CATEGORY' in constructorFcn && constructorFcn.CATEGORY === categoryToMatch;
   }
 }

--- a/src/typeguard.ts
+++ b/src/typeguard.ts
@@ -30,7 +30,7 @@ export const isBarline = (obj: unknown): obj is Barline => isCategory(obj, Barli
  * @param obj check if this object is an instance of the provided `cls`.
  * @param cls a JavaScript class, such as `StaveNote`. `cls` is a constructor function, and it has a `prototype` property, and
  *            optionally a `CATEGORY` property (used in VexFlow for flexible type checking).
- * @param checkAncestors defaults to `true`, so we walk up the prototype chain to look for a matching `CATEGORY` / `.getCategory()`.
+ * @param checkAncestors defaults to `true`, so we walk up the prototype chain to look for a matching `CATEGORY`.
  *        If `false`, we do not check the superclass or other ancestors.
  * @returns true if `obj` is an instance of `ClassName`, or has a static `CATEGORY` property that matches `ClassName.CATEGORY`.
  */
@@ -46,7 +46,8 @@ export function isCategory<T>(
 
   // `obj.constructor` is a reference to the constructor function that created the `obj` instance.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor
-  if (obj instanceof cls || obj.constructor === cls) {
+  let constructorFcn = obj.constructor;
+  if (obj instanceof cls || constructorFcn === cls) {
     return true;
   }
 
@@ -59,7 +60,7 @@ export function isCategory<T>(
   if (checkAncestors) {
     // Walk up the prototype chain to look for a matching obj.constructor.CATEGORY.
     while (obj !== null) {
-      const constructorFcn = obj.constructor;
+      constructorFcn = obj.constructor;
       if ('CATEGORY' in constructorFcn && constructorFcn.CATEGORY === categoryToMatch) {
         return true;
       }
@@ -68,7 +69,6 @@ export function isCategory<T>(
     return false;
   } else {
     // Do not walk up the prototype chain. Just check this particular object's static .CATEGORY string.
-    const constructorFcn = obj.constructor;
     return 'CATEGORY' in constructorFcn && constructorFcn.CATEGORY === categoryToMatch;
   }
 }

--- a/src/vibrato.ts
+++ b/src/vibrato.ts
@@ -16,7 +16,6 @@ export interface VibratoRenderOptions {
 
 /** `Vibrato` implements diverse vibratos. */
 export class Vibrato extends Modifier {
-  /** Get element CATEGORY string. */
   static get CATEGORY(): string {
     return 'Vibrato';
   }

--- a/src/vibrato.ts
+++ b/src/vibrato.ts
@@ -16,12 +16,12 @@ export interface VibratoRenderOptions {
 
 /** `Vibrato` implements diverse vibratos. */
 export class Vibrato extends Modifier {
-  protected render_options: VibratoRenderOptions;
-
   /** Get element CATEGORY string. */
   static get CATEGORY(): string {
-    return 'vibratos';
+    return 'Vibrato';
   }
+
+  protected render_options: VibratoRenderOptions;
 
   /** Arrange vibratos inside a `ModifierContext`. */
   static format(vibratos: Vibrato[], state: ModifierContextState, context: ModifierContext): boolean {
@@ -33,7 +33,7 @@ export class Vibrato extends Modifier {
     let shift = state.right_shift - 7;
 
     // If there's a bend, drop the text line
-    const bends = context.getMembers(Bend.CATEGORY) as Modifier[];
+    const bends = context.getMembers(Bend.CATEGORY) as Bend[];
     if (bends && bends.length > 0) {
       text_line--;
     }
@@ -54,7 +54,6 @@ export class Vibrato extends Modifier {
 
   constructor() {
     super();
-    this.setAttribute('type', 'Vibrato');
 
     this.position = Modifier.Position.RIGHT;
     this.render_options = {
@@ -66,11 +65,6 @@ export class Vibrato extends Modifier {
     };
 
     this.setVibratoWidth(this.render_options.vibrato_width);
-  }
-
-  /** Get element category string. */
-  getCategory(): string {
-    return Vibrato.CATEGORY;
   }
 
   /** Set harsh vibrato. */

--- a/src/vibratobracket.ts
+++ b/src/vibratobracket.ts
@@ -7,9 +7,8 @@ import { Element } from './element';
 import { Vibrato } from './vibrato';
 import { Note } from './note';
 
-function L(
-  // eslint-disable-next-line
-  ...args: any []) {
+// eslint-disable-next-line
+function L(...args: any[]) {
   if (VibratoBracket.DEBUG) log('Vex.Flow.VibratoBracket', args);
 }
 
@@ -17,6 +16,10 @@ function L(
 export class VibratoBracket extends Element {
   /** To enable logging for this class. Set `Vex.Flow.VibratoBracket.DEBUG` to `true`. */
   static DEBUG: boolean;
+
+  static get CATEGORY(): string {
+    return 'VibratoBracket';
+  }
 
   protected line: number;
 
@@ -37,7 +40,6 @@ export class VibratoBracket extends Element {
    */
   constructor(bracket_data: { stop?: Note; start?: Note }) {
     super();
-    this.setAttribute('type', 'VibratoBracket');
 
     this.start = bracket_data.start;
     this.stop = bracket_data.stop;

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -26,6 +26,21 @@ export enum VoiceMode {
  * `Voice` is mainly a container object to group `Tickables` for formatting.
  */
 export class Voice extends Element {
+  /** Voice category string. */
+  static get CATEGORY(): string {
+    return 'Voice';
+  }
+
+  /**
+   * Modes allow the addition of ticks in three different ways:
+   * - STRICT: This is the default. Ticks must fill the voice.
+   * - SOFT: Ticks can be added without restrictions.
+   * - FULL: Ticks do not need to fill the voice, but can't exceed the maximum tick length.
+   */
+  static get Mode(): typeof VoiceMode {
+    return VoiceMode;
+  }
+
   protected resolutionMultiplier: number;
   protected smallestTickCount: Fraction;
   protected stave?: Stave;
@@ -40,19 +55,8 @@ export class Voice extends Element {
   protected readonly tickables: Tickable[];
   protected readonly time: VoiceTime;
 
-  /**
-   * Modes allow the addition of ticks in three different ways:
-   * - STRICT: This is the default. Ticks must fill the voice.
-   * - SOFT: Ticks can be added without restrictions.
-   * - FULL: Ticks do not need to fill the voice, but can't exceed the maximum tick length.
-   */
-  static get Mode(): typeof VoiceMode {
-    return VoiceMode;
-  }
-
   constructor(time?: Partial<VoiceTime> | string, options?: { softmaxFactor: number }) {
     super();
-    this.setAttribute('type', 'Voice');
 
     this.options = {
       softmaxFactor: 100,

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -26,7 +26,6 @@ export enum VoiceMode {
  * `Voice` is mainly a container object to group `Tickables` for formatting.
  */
 export class Voice extends Element {
-  /** Voice category string. */
   static get CATEGORY(): string {
     return 'Voice';
   }

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -299,7 +299,7 @@ function cautionary(options: TestOptions): void {
   voice.getTickables().forEach((tickable) => {
     tickable
       .getModifiers()
-      .filter((modifier) => modifier.getAttribute('type') === 'Accidental')
+      .filter((modifier) => modifier.getAttribute('type') === Accidental.CATEGORY)
       .forEach((accid) => (accid as Accidental).setAsCautionary());
   });
 

--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -9,8 +9,8 @@ import { EasyScore } from 'easyscore';
 import { FretHandFinger } from 'frethandfinger';
 import { Modifier } from 'modifier';
 import { StaveConnector } from 'staveconnector';
-import { StaveNote } from 'stavenote';
 import { Tuplet } from 'tuplet';
+import { Stem } from 'stem';
 
 const EasyScoreTests = {
   Start(): void {
@@ -322,17 +322,17 @@ function drawOptionsTest(options: TestOptions): void {
   equal(note0.getAttribute('id'), 'foobar');
   ok(note0.hasClass('red'));
   ok(note0.hasClass('bold'));
-  equal(note0_modifier0.getCategory(), 'articulations');
+  equal(note0_modifier0.getCategory(), Articulation.CATEGORY);
   equal(note0_modifier0.type, 'a.');
   equal(note0_modifier0.getPosition(), Modifier.Position.BELOW);
-  equal(note0_modifier1.getCategory(), 'articulations');
+  equal(note0_modifier1.getCategory(), Articulation.CATEGORY);
   equal(note0_modifier1.type, 'a-');
   equal(note0_modifier1.getPosition(), Modifier.Position.ABOVE);
-  equal(note0.getStemDirection(), StaveNote.STEM_UP);
-  equal(note1_modifier0.getCategory(), 'articulations');
+  equal(note0.getStemDirection(), Stem.UP);
+  equal(note1_modifier0.getCategory(), Articulation.CATEGORY);
   equal(note1_modifier0.type, 'a>');
   equal(note1_modifier0.getPosition(), Modifier.Position.ABOVE);
-  equal(notes[2].getStemDirection(), StaveNote.STEM_DOWN);
+  equal(notes[2].getStemDirection(), Stem.DOWN);
 }
 
 function drawFingeringsTest(options: TestOptions): void {

--- a/tests/registry_tests.ts
+++ b/tests/registry_tests.ts
@@ -7,6 +7,7 @@ import { EasyScore } from 'easyscore';
 import { Element } from 'element';
 import { Factory } from 'factory';
 import { Registry } from 'registry';
+import { StaveNote } from 'stavenote';
 
 const RegistryTests = {
   Start(): void {
@@ -29,11 +30,10 @@ function registerAndClear(): void {
 
   registry.clear();
   notOk(registry.getElementById('foobar'));
-  throws(() => {
-    // eslint-disable-next-line
-    // @ts-ignore: intentional type mismatch to trigger an error.
-    registry.register(score.notes('C4'));
-  });
+
+  // eslint-disable-next-line
+  // @ts-ignore: intentional type mismatch to trigger an error.
+  throws(() => registry.register(score.notes('C4')));
 
   registry.clear();
   ok(registry.register(score.notes('C4[id="boobar"]')[0]).getElementById('boobar'));
@@ -53,10 +53,10 @@ function defaultRegistry(): void {
   notOk(registry.getElementById('foobar'));
 
   registry.clear();
-  equal(registry.getElementsByType('StaveNote').length, 0);
+  equal(registry.getElementsByType(StaveNote.CATEGORY).length, 0);
 
   score.notes('C5');
-  const elements = registry.getElementsByType('StaveNote');
+  const elements = registry.getElementsByType(StaveNote.CATEGORY);
   equal(elements.length, 1);
 }
 

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -581,7 +581,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
 
   // bar 5: d.s. shift (similar potential x-shift concern)
   const mm5 = new Stave(mm4.getX() + mm4.getWidth(), mm4.getY(), 175);
-  // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifier.Position.RIGHT);
+  // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
   mm5.setEndBarType(BarlineType.DOUBLE);
   mm5.setRepetitionTypeRight(Repetition.type.DS, 25);
   mm5.addClef('treble');
@@ -594,7 +594,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
 
   // bar 6: d.s. without modifiers
   const mm6 = new Stave(mm5.getX() + mm5.getWidth(), mm5.getY(), 175);
-  // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifier.Position.RIGHT);
+  // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
   mm6.setRepetitionTypeRight(Repetition.type.DS, 25);
   mm6.setMeasure(6);
   mm6.setSection('E', 0);

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -30,7 +30,7 @@ import { Stave } from 'stave';
 import { Barline, BarlineType } from 'stavebarline';
 import { StaveNote } from 'stavenote';
 import { Repetition } from 'staverepetition';
-import { Volta, VoltaType } from 'stavevolta';
+import { VoltaType } from 'stavevolta';
 import { Justification } from 'textnote';
 import { TimeSignature } from 'timesignature';
 import { StaveModifier } from 'stavemodifier';
@@ -72,8 +72,11 @@ function sortByCategory(): void {
   const bar0 = new Barline(BarlineType.SINGLE);
   const bar1 = new Barline(BarlineType.DOUBLE);
   const bar2 = new Barline(BarlineType.NONE);
-  const order0 = { barlines: 0, clefs: 1, keysignatures: 2, timesignatures: 3 };
-  const order1 = { timesignatures: 0, keysignatures: 1, barlines: 2, clefs: 3 };
+
+  // const order0 = { barlines: 0, clefs: 1, keysignatures: 2, timesignatures: 3 };
+  // const order1 = { timesignatures: 0, keysignatures: 1, barlines: 2, clefs: 3 };
+  const order0 = { Barline: 0, Clef: 1, KeySignature: 2, TimeSignature: 3 };
+  const order1 = { TimeSignature: 0, KeySignature: 1, Barline: 2, Clef: 3 };
 
   const sortAndCompare = (title: string, a: StaveModifier[], b: StaveModifier[], order: Record<string, number>) => {
     stave.sortByCategory(a, order);
@@ -544,7 +547,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   const mm2 = new Stave(mm1.getX() + mm1.getWidth(), mm1.getY(), 175);
   mm2.setBegBarType(BarlineType.REPEAT_BEGIN);
   mm2.setRepetitionTypeRight(Repetition.type.DS, 25);
-  mm2.setVoltaType(Volta.type.BEGIN_MID, '2.', -5);
+  mm2.setVoltaType(VoltaType.BEGIN_MID, '2.', -5);
   mm2.addClef('treble');
   mm2.addKeySignature('A');
   mm2.setMeasure(2);

--- a/tests/stavemodifier_tests.ts
+++ b/tests/stavemodifier_tests.ts
@@ -3,16 +3,11 @@
 //
 // StaveModifier Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Make second argument to setEndTimeSignature(...) optional.
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { Stave } from 'stave';
-import { Barline } from 'stavebarline';
-import { StaveModifier } from 'stavemodifier';
+import { BarlineType } from 'stavebarline';
 import { ContextBuilder } from 'renderer';
+import { StaveModifierPosition } from 'stavemodifier';
 
 const StaveModifierTests = {
   Start(): void {
@@ -61,24 +56,24 @@ function drawBeginAndEnd(options: TestOptions, contextBuilder: ContextBuilder): 
   stave.setTimeSignature('C|');
   stave.setKeySignature('Db');
   stave.setClef('treble');
-  stave.setBegBarType(Barline.type.REPEAT_BEGIN);
+  stave.setBegBarType(BarlineType.REPEAT_BEGIN);
   stave.setEndClef('alto');
   stave.setEndTimeSignature('9/8');
   stave.setEndKeySignature('G', 'C#');
-  stave.setEndBarType(Barline.type.DOUBLE);
+  stave.setEndBarType(BarlineType.DOUBLE);
   stave.draw();
 
   // change
-  const END = StaveModifier.Position.END;
+  const END = StaveModifierPosition.END;
   stave.setY(100);
   stave.setTimeSignature('3/4');
   stave.setKeySignature('G', 'C#');
   stave.setClef('bass');
-  stave.setBegBarType(Barline.type.SINGLE);
+  stave.setBegBarType(BarlineType.SINGLE);
   stave.setClef('treble', undefined, undefined, END);
   stave.setTimeSignature('C', undefined, END);
   stave.setKeySignature('F', undefined, END);
-  stave.setEndBarType(Barline.type.SINGLE);
+  stave.setEndBarType(BarlineType.SINGLE);
   stave.draw();
 
   ok(true, 'all pass');

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -220,16 +220,16 @@ function ticksNewAPI(): void {
 
 function stem(): void {
   const note = new StaveNote({ keys: ['c/4', 'e/4', 'g/4'], duration: 'w' });
-  equal(note.getStemDirection(), StaveNote.STEM_UP, 'Default note has UP stem');
+  equal(note.getStemDirection(), Stem.UP, 'Default note has UP stem');
 }
 
 function autoStem(): void {
   const testData: [/* keys */ string[], /* expectedStemDirection */ number][] = [
-    [['c/5', 'e/5', 'g/5'], StaveNote.STEM_DOWN],
-    [['e/4', 'g/4', 'c/5'], StaveNote.STEM_UP],
-    [['c/5'], StaveNote.STEM_DOWN],
-    [['a/4', 'e/5', 'g/5'], StaveNote.STEM_DOWN],
-    [['b/4'], StaveNote.STEM_DOWN],
+    [['c/5', 'e/5', 'g/5'], Stem.DOWN],
+    [['e/4', 'g/4', 'c/5'], Stem.UP],
+    [['c/5'], Stem.DOWN],
+    [['a/4', 'e/5', 'g/5'], Stem.DOWN],
+    [['b/4'], Stem.DOWN],
   ];
   testData.forEach((td) => {
     const keys = td[0];
@@ -238,7 +238,7 @@ function autoStem(): void {
     equal(
       note.getStemDirection(),
       expectedStemDirection,
-      'Stem must be ' + (expectedStemDirection === StaveNote.STEM_UP ? 'up' : 'down')
+      'Stem must be ' + (expectedStemDirection === Stem.UP ? 'up' : 'down')
     );
   });
 }

--- a/tests/strokes_tests.ts
+++ b/tests/strokes_tests.ts
@@ -220,6 +220,7 @@ function multiNotationAndTab(options: TestOptions): void {
   ok(true, 'Strokes Test Notation & Tab Multi Voice');
 }
 
+/*
 function drawTabStrokes(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 600, 200);
   const stave1 = f.TabStave({ width: 250 }).setEndBarType(Barline.type.DOUBLE);
@@ -307,6 +308,7 @@ function drawTabStrokes(options: TestOptions): void {
 
   ok(true, 'Strokes Tab test');
 }
+*/
 
 function notesWithTab(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 500, 300);

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -19,7 +19,7 @@ import { KeySignature } from 'keysignature';
 import { NoteSubGroup } from 'notesubgroup';
 import { Ornament } from 'ornament';
 import { ContextBuilder } from 'renderer';
-import { StaveModifier } from 'stavemodifier';
+import { StaveModifierPosition } from 'stavemodifier';
 import { StaveNote } from 'stavenote';
 import { Stroke } from 'strokes';
 import { TabNote, TabNoteStruct } from 'tabnote';
@@ -59,7 +59,7 @@ function stave(options: TestOptions): void {
   keySig.addToStave(stave);
   keySig.setStyle(FS('blue'));
   stave.addTimeSignature('4/4');
-  const timeSig = stave.getModifiers(StaveModifier.Position.BEGIN, TimeSignature.CATEGORY);
+  const timeSig = stave.getModifiers(StaveModifierPosition.BEGIN, TimeSignature.CATEGORY);
   timeSig[0].setStyle(FS('brown'));
 
   const notes = [

--- a/tests/typeguard_tests.ts
+++ b/tests/typeguard_tests.ts
@@ -4,6 +4,9 @@
 //
 // TypeGuard Tests
 
+// eslint-disable-next-line
+// @ts-nocheck to support ES5 style class declaration in the fake() test case.
+
 import { isCategory, isNote, isStaveNote, isStemmableNote, isTabNote } from 'typeguard';
 import { StaveNote } from 'stavenote';
 import { TabNote } from 'tabnote';
@@ -13,7 +16,8 @@ const TypeGuardTests = {
   Start(): void {
     QUnit.module('TypeGuard');
     test('Real VexFlow Types', real);
-    test('Fake VexFlow Types', fake);
+    test('Fake VexFlow Types in ES5', fakeES5);
+    test('Fake VexFlow Types in ES6', fakeES6);
     test('instanceof', fallbackToInstanceOf);
     test('Edge Case ES5/ES6', edgeCaseES5vsES6);
   },
@@ -34,20 +38,56 @@ function real(): void {
   ok(isNote(t), 'TabNote extends StemmableNote which extends Note, so t is a Note');
 }
 
-function fake(): void {
-  const fakeStaveNote = {
-    getCategory: () => 'stavenotes',
-  };
-  ok(isStaveNote(fakeStaveNote), 'Fake StaveNote is a StaveNote.');
-  notOk(isNote(fakeStaveNote), 'Fake StaveNote is not a Note. Categories do not match.');
+/**
+ * Helper function to test the fake VexFlow objects we create in fakeES5() and fakeES6().
+ */
+function checkFakeObjects(fakeStemmableNote, fakeStaveNote): void {
+  ok(isStemmableNote(fakeStemmableNote), 'Fake StemmableNote is a StemmableNote.');
+  notOk(isNote(fakeStemmableNote), 'Fake StemmableNote is not a Note (no ancestors with the correct CATEGORY).');
 
-  const fakeStemmableNote = {
-    getCategory() {
-      return StemmableNote.CATEGORY;
-    },
-  };
-  ok(isStemmableNote(fakeStemmableNote), 'Returns the correct category string.');
-  notOk(isNote(fakeStemmableNote), 'The fake stemmable note does not have any ancestors with the correct category.');
+  ok(isCategory(fakeStaveNote, StaveNote), 'Fake StaveNote is a StaveNote.');
+  ok(isStaveNote(fakeStaveNote), 'Fake StaveNote is a StaveNote (via helper function).');
+  ok(isCategory(fakeStaveNote, StemmableNote), 'Fake StaveNote is also a StemmableNote (via inheritance).');
+  notOk(isNote(fakeStaveNote), 'Fake StaveNote is not a Note. CATEGORY does not match.');
+}
+
+/**
+ * Demonstrate that an object (ES5-style) can pass the isCategory(...) test if it
+ * has the correct static .CATEGORY property.
+ */
+function fakeES5(): void {
+  function FakeStemmableNote() {
+    this.isFake = true;
+  }
+  FakeStemmableNote.CATEGORY = StemmableNote.CATEGORY;
+
+  function FakeStaveNote() {
+    FakeStemmableNote.call(this);
+  }
+  FakeStaveNote.CATEGORY = StaveNote.CATEGORY;
+  FakeStaveNote.prototype = Object.create(FakeStemmableNote.prototype);
+  FakeStaveNote.prototype.constructor = FakeStaveNote;
+
+  const fakeStemmableNote = new FakeStemmableNote();
+  const fakeStaveNote = new FakeStaveNote();
+  checkFakeObjects(fakeStemmableNote, fakeStaveNote);
+}
+
+/**
+ * Demonstrate that an object (ES6-style) can pass the isCategory(...) test if it
+ * or its ancestor has the correct static .CATEGORY property.
+ */
+function fakeES6(): void {
+  class FakeStemmableNote {
+    static CATEGORY = StemmableNote.CATEGORY;
+  }
+  class FakeStaveNote extends FakeStemmableNote {
+    static CATEGORY = StaveNote.CATEGORY;
+  }
+
+  const fakeStemmableNote = new FakeStemmableNote();
+  const fakeStaveNote = new FakeStaveNote();
+  checkFakeObjects(fakeStemmableNote, fakeStaveNote);
 }
 
 /**

--- a/tests/typeguard_tests.ts
+++ b/tests/typeguard_tests.ts
@@ -5,7 +5,7 @@
 // TypeGuard Tests
 
 // eslint-disable-next-line
-// @ts-nocheck to support ES5 style class declaration in the fake() test case.
+// @ts-nocheck to support ES5 style class declaration in the fakeES5() test case.
 
 import { isCategory, isNote, isStaveNote, isStemmableNote, isTabNote } from 'typeguard';
 import { StaveNote } from 'stavenote';
@@ -41,7 +41,7 @@ function real(): void {
 /**
  * Helper function to test the fake VexFlow objects we create in fakeES5() and fakeES6().
  */
-function checkFakeObjects(fakeStemmableNote, fakeStaveNote): void {
+function checkFakeObjects(fakeStemmableNote: unknown, fakeStaveNote: unknown): void {
   ok(isStemmableNote(fakeStemmableNote), 'Fake StemmableNote is a StemmableNote.');
   notOk(isNote(fakeStemmableNote), 'Fake StemmableNote is not a Note (no ancestors with the correct CATEGORY).');
 


### PR DESCRIPTION
Standardize `CATEGORY` / `getCategory()` / `this.setAttribute('type', ...)`.
The string is now always UpperCamelCaseSingular.
Improve the typeguard functions to check for the `CATEGORY` property directly.
Element's `this.attrs.type` is set to `this.getCategory()` in the `Element` constructor.

Fixes https://github.com/0xfe/vexflow/issues/1107