### PR TITLE
Fix shadow/glow rendering

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -115,7 +115,13 @@ export class CanvasContext implements RenderContext {
   }
 
   setShadowBlur(blur: number): this {
-    this.vexFlowCanvasContext.shadowBlur = blur;
+    // CanvasRenderingContext2D does not scale the shadow blur by the current
+    // transform, so we have to do it manually. We assume uniform scaling
+    // (though allow for rotation) because the blur can only be scaled
+    // uniformly anyway.
+    const t = this.vexFlowCanvasContext.getTransform();
+    const scale = Math.sqrt(t.a * t.a + t.b * t.b + t.c * t.c + t.d * t.d);
+    this.vexFlowCanvasContext.shadowBlur = scale * blur;
     return this;
   }
 
@@ -198,12 +204,6 @@ export class CanvasContext implements RenderContext {
   // This is an attempt (hack) to simulate the HTML5 canvas arc method.
   arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, antiClockwise: boolean): this {
     this.vexFlowCanvasContext.arc(x, y, radius, startAngle, endAngle, antiClockwise);
-    return this;
-  }
-
-  // CanvasRenderingContext2D does not have a glow function.
-  glow(): this {
-    // DO NOTHING.
     return this;
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -183,9 +183,16 @@ export class Renderer {
   resize(width: number, height: number): this {
     if (this.backend === Renderer.Backends.CANVAS) {
       const canvasElement = this.element as HTMLCanvasElement;
-      [width, height] = CanvasContext.SanitizeCanvasDims(width, height);
-
       const devicePixelRatio = window.devicePixelRatio || 1;
+
+      // Scale the canvas size by the device pixel ratio clamping to the maximum
+      // supported size.
+      [width, height] = CanvasContext.SanitizeCanvasDims(width * devicePixelRatio,
+                                                         height * devicePixelRatio);
+
+      // Divide back down by the pixel ratio and convert to integers.
+      width = (width / devicePixelRatio) | 0;
+      height = (height / devicePixelRatio) | 0;
 
       canvasElement.width = width * devicePixelRatio;
       canvasElement.height = height * devicePixelRatio;

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -73,7 +73,6 @@ export interface RenderContext {
   bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): this;
   quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): this;
   arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, antiClockwise: boolean): this;
-  glow(): this;
   fill(attributes?: any): this;
   stroke(): this;
   closePath(): this;

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -670,7 +670,7 @@ function drawKeyStyles(options: TestOptions, contextBuilder: ContextBuilder): vo
   const note = new StaveNote({ keys: ['g/4', 'bb/4', 'd/5'], duration: 'q' })
     .setStave(stave)
     .addAccidental(1, new Accidental('b'))
-    .setKeyStyle(1, { shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue' });
+    .setKeyStyle(1, { shadowBlur: 2, shadowColor: 'blue', fillStyle: 'blue' });
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
@@ -690,7 +690,7 @@ function drawNoteStyles(options: TestOptions, contextBuilder: ContextBuilder): v
     .setStave(stave)
     .addAccidental(1, new Accidental('b'));
 
-  note.setStyle({ shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
+  note.setStyle({ shadowBlur: 2, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
@@ -710,7 +710,7 @@ function drawNoteStemStyles(options: TestOptions, contextBuilder: ContextBuilder
     .setStave(stave)
     .addAccidental(1, new Accidental('b'));
 
-  note.setStemStyle({ shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
+  note.setStemStyle({ shadowBlur: 2, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
@@ -783,7 +783,7 @@ function drawNoteStylesWithFlag(options: TestOptions, contextBuilder: ContextBui
     .setStave(stave)
     .addAccidental(1, new Accidental('b'));
 
-  note.setFlagStyle({ shadowBlur: 15, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
+  note.setFlagStyle({ shadowBlur: 2, shadowColor: 'blue', fillStyle: 'blue', strokeStyle: 'blue' });
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
@@ -845,7 +845,7 @@ function drawBeamStyles(options: TestOptions, contextBuilder: ContextBuilder): v
   staveNotes[1].setKeyStyle(0, { fillStyle: 'darkturquoise' });
 
   staveNotes[5].setStyle({ fillStyle: 'tomato', strokeStyle: 'tomato' });
-  beam3.setStyle({ shadowBlur: 20, shadowColor: 'blue' });
+  beam3.setStyle({ shadowBlur: 4, shadowColor: 'blue' });
 
   staveNotes[9].setLedgerLineStyle({ fillStyle: 'lawngreen', strokeStyle: 'lawngreen', lineWidth: 1 });
   staveNotes[9].setFlagStyle({ fillStyle: 'orange', strokeStyle: 'orange' });


### PR DESCRIPTION
This PR makes the shadow/glow appearance consistent across the SVG context and canvas contexts at different device pixel ratios. The old SVG glow code is deleted and replaced with a `drop-shadow` CSS filter, a feature that now has more than [95% browser support](https://caniuse.com/?search=drop-shadow).

It also fixes a bug with the canvas shadow where the shadow blur radius wasn't being scaled by the canvas transform. It turns out that `CanvasRenderingContext2D` ignores scaling when applying a shadow. This meant that glow/shadow had a different appearance when depending on whether or not the user had a high density display.

I had to update the shadow blur sizes in the `StaveNote` tests to account for the fact that the blur radius now uses the correct units.

All visual diffs from this PR are caused by differences in the glow rendering.

I also fixed a bug the canvas size sanitisation: the pixel ratio scaling should be applied before sanitisation.

## Appearance before this PR

Low resolution canvas (simulated by forcing `devicePixelRatio` to 1):
![LR canvas](https://user-images.githubusercontent.com/7587269/132801292-b1d82039-6df3-47c0-a0e0-84ca4e4e3734.png)

High resolution canvas (note the glow is much tighter):
![HR canvas](https://user-images.githubusercontent.com/7587269/132801136-5986b8e4-1997-46fa-8827-434d93212ee7.png)

SVG (the glow has a different look):
![svg](https://user-images.githubusercontent.com/7587269/132801149-81736d39-c999-4e77-8232-c2bc2de9efd0.png)

## Appearance after this PR

Low resolution canvas
![LR canvas](https://user-images.githubusercontent.com/7587269/132801200-d70208d2-d04c-4d45-9523-483cf7e3617d.png)

High resolution canvas
![HR canvas](https://user-images.githubusercontent.com/7587269/132801222-a739e650-5ac0-46a6-8378-cd453fab6fb0.png)

SVG
![svg](https://user-images.githubusercontent.com/7587269/132801231-04b5472c-59d4-499b-8128-55b0f53e7fcd.png)
