### PR TITLE
Fix a couple of defects in SVGContext.arc

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -78,3 +78,14 @@ export function drawDot(ctx: RenderContext, x: number, y: number, color = '#55')
 export function prefix(text: string): string {
   return `vf-${text}`;
 }
+
+/**
+ * Convert an arbitrary angle in radians to the equivalent one in the range [0, pi).
+ */
+export function normalizeAngle(a: number): number {
+  a = a % (2 * Math.PI);
+  if (a < 0) {
+    a += 2 * Math.PI;
+  }
+  return a;
+}


### PR DESCRIPTION
This PR updates the `SVGContext.arc` behaviour to match that of `CanvasRenderingContext2D`:
 - The pen position should end up at the end of the arc: the code that was moving the pen back at the end of `arcHelper` was incorrect.
 - If the length of the arc specified by `angleStart`, `angleEnd` and `radius` is longer than the circle's circumference, a completely closed circle should be drawn.

None of this really matters because this change doesn't cause any image diffs, but it's nice to have consistency across the contexts.

While I was here, I simplified the implementation a bit.