### PR TITLE
A few ledger line tweaks

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -116,7 +116,7 @@ export class Stave extends Element {
     };
     this.bounds = { x: this.x, y: this.y, w: this.width, h: 0 };
     this.options = { ...this.options, ...options };
-    this.defaultLedgerLineStyle = {};
+    this.defaultLedgerLineStyle = { strokeStyle: '#444', lineWidth: 1.4 };
 
     this.resetLines();
 

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -367,8 +367,7 @@ export class StaveNote extends StemmableNote {
     super(noteStruct);
     this.setAttribute('type', 'StaveNote');
 
-    // Set default width of ledger lines to 2.0.
-    this.ledgerLineStyle = { lineWidth: 2.0 };
+    this.ledgerLineStyle = {};
 
     this.clef = noteStruct.clef ?? 'treble';
     this.octave_shift = noteStruct.octave_shift ?? 0;
@@ -1052,6 +1051,9 @@ export class StaveNote extends StemmableNote {
       displaced_x,
       non_displaced_x,
     } = this.getNoteHeadBounds();
+
+    // Early out if there are no ledger lines to draw.
+    if (highest_line < 6 && lowest_line > 0) return;
 
     const min_x = Math.min(displaced_x ?? 0, non_displaced_x ?? 0);
 


### PR DESCRIPTION
 - Move the default ledger line style from `StaveNote` to `Stave`. Prior to this change, a user could only change the default ledger line width by explicitly setting it on every single `StaveNote`. Now, they only have to change the default ledger line style on each `Stave`.
 - Following on from the recent discussion on #1052, change the ledger lines to be thinner but darker. In the end, I chose a line width of 1.4 so that the anti-aliasing on the darker line was close to the old ledger line shade.
 - Early out of `StaveNote.drawLedgerLines` if there are no ledger lines to be drawn.

I reviewed every one of the 576 image diffs that result from this PR and they were all caused by the change in ledger line thickness and stroke style, i.e. moving the default style from `StaveNote` to `Stave` had no effect on the tests.

Before:
![old ledger lines](https://user-images.githubusercontent.com/7587269/133873896-811b5f46-cfc4-4ad1-aeb5-7a0ecd092e66.png)

After:
![old ledger lines](https://user-images.githubusercontent.com/7587269/133873899-6e288716-30c0-41f7-af32-4b941adb420b.png)
