### PR TITLE
Don't stroke rectangles drawn with fillRect

### DIFF
--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -458,12 +458,8 @@ export class SVGContext implements RenderContext {
   }
 
   fillRect(x: number, y: number, width: number, height: number): this {
-    if (height < 0) {
-      y += height;
-      height *= -1;
-    }
-
-    this.rect(x, y, width, height, this.attributes);
+    const attributes = { fill: this.attributes.fill };
+    this.rect(x, y, width, height, attributes);
     return this;
   }
 


### PR DESCRIPTION
This PR fixes a bug in `SVGContext.fillRect`.

Prior to this fix the `SVGContext` was incorrectly applying the current stroke style to the rectangle; the rectangle should be drawn without a stroke to match the behaviour of the `CanvasContext`. The most noticeable effect of this bug was that the barlines & stave connectors were drawn incorrectly.

All visual diffs caused by this change are, rather surprisingly, under the threshold.

SVG before this PR:
![svg old](https://user-images.githubusercontent.com/7587269/133916179-f917ba83-1542-41da-a315-f26229b3dbba.png)

SVG after this PR:
![svg new](https://user-images.githubusercontent.com/7587269/133916186-e45a7ddb-d8d9-48cb-8f21-dd302cb1845f.png)

Canvas:
![canvas](https://user-images.githubusercontent.com/7587269/133916169-36eaefb4-3c88-49b4-ae7b-f9ce9889bffa.png)