### PR TITLE
Fix Tests, Remove Partial<...>, Prefer Optional Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please help test this beta release and [report issues on GitHub](https://github.
   - Examples:
     - `Accidental.CATEGORY` is now `'Accidental'` instead of `'accidentals'`.
     - `Modifier.CATEGORY` is now `'Modifier'` instead of `'none'`.
+- `ChordSymbol.NO_TEXT_FORMAT` was previously named `ChordSymbol.NOTEXTFORMAT`.
 
 # 3.0.9 / 2020-04-21
 

--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -102,7 +102,7 @@ export class Accidental extends Modifier {
         prevNote = note;
       }
       if (stave) {
-        const lineSpace = stave.getOptions().spacing_between_lines_px;
+        const lineSpace = stave.getSpacingBetweenLines();
         const y = stave.getYForLine(props.line);
         const accLine = Math.round((y / lineSpace) * 2) / 2;
         accList.push({ y, line: accLine, shift: shiftL, acc, lineSpace });

--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -30,7 +30,7 @@ export class BarNote extends Note {
   // Initialized by the constructor via this.setType(type)
   protected type!: BarlineType;
 
-  constructor(type = BarlineType.SINGLE) {
+  constructor(type: string | BarlineType = BarlineType.SINGLE) {
     super({ duration: 'b' });
 
     this.metrics = {

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -492,9 +492,10 @@ export class ChordSymbol extends Modifier {
   // eslint-disable-next-line
   getSymbolBlock(parameters?: any): any {
     parameters = parameters ?? {};
-    const symbolType = parameters.symbolType ? parameters.symbolType : ChordSymbol.symbolTypes.TEXT;
-    const text = parameters.text ? parameters.text : '';
-    const symbolModifier = parameters.symbolModifier ? parameters.symbolModifier : ChordSymbol.symbolModifiers.NONE;
+    const symbolType = parameters.symbolType ?? ChordSymbol.symbolTypes.TEXT;
+    const text = parameters.text ?? '';
+    const symbolModifier = parameters.symbolModifier ?? ChordSymbol.symbolModifiers.NONE;
+
     const xShift = 0;
     const yShift = 0;
     const vAlign = 0;

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -572,14 +572,14 @@ export class ChordSymbol extends Modifier {
 
   // ### addGlyphSuperscript
   // add a glyph block with superscript modifier
-  addGlyphSuperscript(glyph: Glyph): this {
+  addGlyphSuperscript(glyph: string): this {
     const symbolType = ChordSymbol.symbolTypes.GLYPH;
     const symbolModifier = ChordSymbol.symbolModifiers.SUPERSCRIPT;
     return this.addSymbolBlock({ glyph, symbolType, symbolModifier });
   }
 
   // eslint-disable-next-line
-  addGlyph(glyph: string, parameters: any): this {
+  addGlyph(glyph: string, parameters?: any): this {
     parameters = parameters == null ? {} : parameters;
     parameters.glyph = glyph;
     parameters.symbolType = ChordSymbol.symbolTypes.GLYPH;
@@ -592,7 +592,7 @@ export class ChordSymbol extends Modifier {
   // `addGlyphOrText("(+5#11)")`
   // will use text for the '5' and '11', and glyphs for everything else.
   // eslint-disable-next-line
-  addGlyphOrText(text: string, parameters: any): this {
+  addGlyphOrText(text: string, parameters?: any): this {
     parameters = parameters == null ? {} : parameters;
     let str = '';
     for (let i = 0; i < text.length; ++i) {
@@ -615,7 +615,7 @@ export class ChordSymbol extends Modifier {
   // ### Add a line of the given width, used as a continuation of the previous
   // symbol in analysis, or lyrics, etc.
   // eslint-disable-next-line
-  addLine(width: number, parameters: any): this {
+  addLine(width: number, parameters?: any): this {
     parameters = parameters == null ? {} : parameters;
     parameters.symbolType = ChordSymbol.symbolTypes.LINE;
     parameters.width = width;

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -574,8 +574,8 @@ export class ChordSymbol extends Modifier {
     return this.addSymbolBlock({ glyph, symbolType, symbolModifier });
   }
 
-  // eslint-disable-next-line
   /** Add a glyph block. */
+  // eslint-disable-next-line
   addGlyph(glyph: string, params: any = {}): this {
     const symbolType = SymbolTypes.GLYPH;
     return this.addSymbolBlock({ ...params, glyph, symbolType });

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -490,8 +490,8 @@ export class ChordSymbol extends Modifier {
   // ChordSymbol allows multiple blocks so we can mix glyphs and font text.
   // Each block can have its own vertical orientation
   // eslint-disable-next-line
-  getSymbolBlock(parameters: any): any {
-    parameters = parameters == undefined ? {} : parameters;
+  getSymbolBlock(parameters?: any): any {
+    parameters = parameters ?? {};
     const symbolType = parameters.symbolType ? parameters.symbolType : ChordSymbol.symbolTypes.TEXT;
     const text = parameters.text ? parameters.text : '';
     const symbolModifier = parameters.symbolModifier ? parameters.symbolModifier : ChordSymbol.symbolModifiers.NONE;
@@ -548,7 +548,7 @@ export class ChordSymbol extends Modifier {
   // Add a text block
   // eslint-disable-next-line
   addText(text: string, parameters?: any): this {
-    parameters = parameters == null || parameters == undefined ? {} : parameters;
+    parameters = parameters ?? {};
     parameters.text = text;
     parameters.symbolType = ChordSymbol.symbolTypes.TEXT;
     return this.addSymbolBlock(parameters);
@@ -580,7 +580,7 @@ export class ChordSymbol extends Modifier {
 
   // eslint-disable-next-line
   addGlyph(glyph: string, parameters?: any): this {
-    parameters = parameters == null ? {} : parameters;
+    parameters = parameters ?? {};
     parameters.glyph = glyph;
     parameters.symbolType = ChordSymbol.symbolTypes.GLYPH;
     return this.addSymbolBlock(parameters);
@@ -593,7 +593,7 @@ export class ChordSymbol extends Modifier {
   // will use text for the '5' and '11', and glyphs for everything else.
   // eslint-disable-next-line
   addGlyphOrText(text: string, parameters?: any): this {
-    parameters = parameters == null ? {} : parameters;
+    parameters = parameters ?? {};
     let str = '';
     for (let i = 0; i < text.length; ++i) {
       if (ChordSymbol.glyphs[text[i]]) {
@@ -616,7 +616,7 @@ export class ChordSymbol extends Modifier {
   // symbol in analysis, or lyrics, etc.
   // eslint-disable-next-line
   addLine(width: number, parameters?: any): this {
-    parameters = parameters == null ? {} : parameters;
+    parameters = parameters ?? {};
     parameters.symbolType = ChordSymbol.symbolTypes.LINE;
     parameters.width = width;
     return this.addSymbolBlock(parameters);

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -174,7 +174,7 @@ export class Clef extends StaveModifier {
     if (this.type === 'tab') {
       const glyph = defined(this.glyph, 'ClefError', "Can't set stave without glyph.");
 
-      const numLines = this.stave.getOptions().num_lines;
+      const numLines = this.stave.getNumLines();
       const point = this.musicFont.lookupMetric(`clef.lineCount.${numLines}.point`);
       const shiftY = this.musicFont.lookupMetric(`clef.lineCount.${numLines}.shiftY`);
       glyph.setPoint(point);

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -8,13 +8,14 @@ import { Element } from './element';
 import { Note } from './note';
 
 export interface CurveOptions {
-  thickness: number;
-  x_shift: number;
-  y_shift: number;
-  position: string | number;
-  position_end: string | number;
-  invert: boolean;
-  cps: { x: number; y: number }[];
+  /** Two control points for the bezier curves. */
+  cps?: { x: number; y: number }[];
+  thickness?: number;
+  x_shift?: number;
+  y_shift?: number;
+  position?: string | number;
+  position_end?: string | number;
+  invert?: boolean;
 }
 
 export enum CurvePosition {
@@ -88,16 +89,17 @@ export class Curve extends Element {
 
   renderCurve(params: { last_y: number; last_x: number; first_y: number; first_x: number; direction: number }): void {
     const ctx = this.checkContext();
-    const cps = this.render_options.cps;
+    // eslint-disable-next-line
+    const cps = this.render_options.cps!;
 
-    const x_shift = this.render_options.x_shift;
-    const y_shift = this.render_options.y_shift * params.direction;
+    const x_shift = this.render_options.x_shift as number;
+    const y_shift = (this.render_options.y_shift as number) * params.direction;
 
     const first_x = params.first_x + x_shift;
     const first_y = params.first_y + y_shift;
     const last_x = params.last_x - x_shift;
     const last_y = params.last_y + y_shift;
-    const thickness = this.render_options.thickness;
+    const thickness = this.render_options.thickness as number;
 
     const cp_spacing = (last_x - first_x) / (cps.length + 2);
 
@@ -139,7 +141,7 @@ export class Curve extends Element {
     let metric = 'baseY';
     let end_metric = 'baseY';
 
-    function getPosition(position: string | number) {
+    function getPosition(position?: string | number) {
       return typeof position === 'string' ? Curve.PositionString[position] : position;
     }
     const position = getPosition(this.render_options.position);

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -135,7 +135,7 @@ export class Dot extends Modifier {
     this.setRendered();
 
     const stave = note.checkStave();
-    const lineSpace = stave.getOptions().spacing_between_lines_px;
+    const lineSpace = stave.getSpacingBetweenLines();
 
     const start = note.getModifierStartXY(this.position, this.index, { forceFlagRight: true });
 

--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -231,11 +231,11 @@ interface BuilderElements {
   accidentals: (Accidental | undefined)[][];
 }
 
-export interface BuilderOptions {
+// Extending Record<string, any> allows arbitrary properties via Builder.reset() & EasyScore.parse().
+// eslint-disable-next-line
+export interface BuilderOptions extends Record<string, any> {
   stem?: string;
   clef?: string;
-  // eslint-disable-next-line
-  [x: string]: any; // allow arbitrary properties via Builder.reset() & EasyScore.parse().
 }
 
 export class Builder {
@@ -254,7 +254,7 @@ export class Builder {
     this.reset();
   }
 
-  reset(options: BuilderOptions = {}): void {
+  reset(options?: BuilderOptions): void {
     this.options = {
       stem: 'auto',
       clef: 'treble',
@@ -387,18 +387,18 @@ export class Builder {
 }
 
 export interface EasyScoreOptions {
-  factory: Factory;
-  builder: Builder;
-  commitHooks: CommitHook[];
-  throwOnError: boolean;
+  factory?: Factory;
+  builder?: Builder;
+  commitHooks?: CommitHook[];
+  throwOnError?: boolean;
 }
 
-export interface EasyScoreDefaults {
-  clef: string;
-  time: string;
-  stem: string;
-  // eslint-disable-next-line
-  [x: string]: any; // allow arbitrary properties via set(defaults)
+// Extending Record<string, any> allows arbitrary properties via set(defaults).
+// eslint-disable-next-line
+export interface EasyScoreDefaults extends Record<string, any> {
+  clef?: string;
+  time?: string;
+  stem?: string;
 }
 
 /**
@@ -440,7 +440,7 @@ export class EasyScore {
   grammar!: EasyScoreGrammar;
   parser!: Parser;
 
-  constructor(options: Partial<EasyScoreOptions> = {}) {
+  constructor(options: EasyScoreOptions = {}) {
     this.setOptions(options);
   }
 
@@ -452,7 +452,7 @@ export class EasyScore {
    * @param defaults.stem default stem arrangement (auto | up | down)
    * @returns this
    */
-  set(defaults: Partial<EasyScoreDefaults>): this {
+  set(defaults: EasyScoreDefaults): this {
     this.defaults = { ...this.defaults, ...defaults };
     return this;
   }
@@ -461,7 +461,7 @@ export class EasyScore {
    * @param options.factory is required.
    * @returns this
    */
-  setOptions(options: Partial<EasyScoreOptions>): this {
+  setOptions(options: EasyScoreOptions): this {
     // eslint-disable-next-line
     const factory = options.factory!; // ! operator, because options.factory was set in Factory.EasyScore().
     const builder = options.builder ?? new Builder(factory);
@@ -478,7 +478,7 @@ export class EasyScore {
     this.builder = builder;
     this.grammar = new EasyScoreGrammar(this.builder);
     this.parser = new Parser(this.grammar);
-    this.options.commitHooks.forEach((commitHook) => this.addCommitHook(commitHook));
+    this.options.commitHooks?.forEach((commitHook) => this.addCommitHook(commitHook));
     return this;
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -143,13 +143,8 @@ export class Factory {
     this.stave = undefined; // current stave
   }
 
-  getOptions(): Required<FactoryOptions> {
-    return this.options;
-  }
-
   setOptions(options?: FactoryOptions): void {
     this.options = { ...this.options, ...options };
-
     this.initRenderer();
     this.reset();
   }
@@ -192,20 +187,14 @@ export class Factory {
   }
 
   /** Return pixels from current stave spacing. */
-  space(spacing: number): number {
-    if (!this.options.stave) throw new RuntimeError('NoStave');
-    return this.options.stave.space * spacing;
-  }
 
   Stave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): Stave {
-    if (!this.options.stave) throw new RuntimeError('NoStave');
+    const staveSpace = this.options.stave.space;
     const p = {
       x: 0,
       y: 0,
-      width: this.options.renderer.width - this.space(1),
-      options: {
-        spacing_between_lines_px: this.options.stave.space,
-      },
+      width: this.options.renderer.width - staveSpace * 1.0,
+      options: { spacing_between_lines_px: staveSpace * 1.0 },
       ...params,
     };
 
@@ -217,13 +206,12 @@ export class Factory {
   }
 
   TabStave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): TabStave {
-    if (!this.options.stave) throw new RuntimeError('NoStave');
-
+    const staveSpace = this.options.stave.space;
     const p = {
       x: 0,
       y: 0,
-      width: this.options.renderer.width - this.space(1),
-      options: { spacing_between_lines_px: this.options.stave.space * 1.3 },
+      width: this.options.renderer.width - staveSpace * 1.0,
+      options: { spacing_between_lines_px: staveSpace * 1.3 },
       ...params,
     };
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -24,7 +24,7 @@ import { StaveConnector } from './staveconnector';
 import { System, SystemOptions } from './system';
 import { TickContext } from './tickcontext';
 import { Tuplet, TupletOptions } from './tuplet';
-import { Voice } from './voice';
+import { Voice, VoiceTime } from './voice';
 import { Beam } from './beam';
 import { Curve, CurveOptions } from './curve';
 import { GraceNote, GraceNoteStruct } from './gracenote';
@@ -284,7 +284,7 @@ export class Factory {
     return textNote;
   }
 
-  BarNote(params: { type?: BarlineType } = {}): BarNote {
+  BarNote(params: { type?: BarlineType | string } = {}): BarNote {
     const barNote = new BarNote(params.type);
     if (this.stave) barNote.setStave(this.stave);
     barNote.setContext(this.context);
@@ -326,7 +326,7 @@ export class Factory {
     return timeSigNote;
   }
 
-  KeySigNote(params: { key: string; cancelKey: string; alterKey: string }): KeySigNote {
+  KeySigNote(params: { key: string; cancelKey?: string; alterKey?: string[] }): KeySigNote {
     const keySigNote = new KeySigNote(params.key, params.cancelKey, params.alterKey);
     if (this.stave) keySigNote.setStave(this.stave);
     keySigNote.setContext(this.context);
@@ -508,7 +508,7 @@ export class Factory {
     return multimeasurerest;
   }
 
-  Voice(paramsP: { time?: string; options?: { softmaxFactor: number } } = {}): Voice {
+  Voice(paramsP: { time?: Partial<VoiceTime> | string; options?: { softmaxFactor: number } } = {}): Voice {
     const params = {
       ...{
         time: '4/4',

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -96,7 +96,7 @@ export class Factory {
     return new Factory({ renderer: { elementId, width, height, backend: Renderer.Backends.SVG } });
   }
 
-  protected options: FactoryOptions;
+  protected options: Required<FactoryOptions>;
 
   protected stave?: Stave;
   protected context!: RenderContext;
@@ -144,34 +144,27 @@ export class Factory {
   }
 
   getOptions(): Required<FactoryOptions> {
-    // Assume we did not unset `this.options.stave`, `this.options.renderer`, or `this.options.font`.
-    return this.options as Required<FactoryOptions>;
+    return this.options;
   }
 
   setOptions(options?: FactoryOptions): void {
     this.options = { ...this.options, ...options };
 
-    if (this.options.renderer?.elementId !== null) {
-      this.initRenderer();
-    }
+    this.initRenderer();
     this.reset();
   }
 
   initRenderer(): void {
-    if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     const { elementId, backend, width, height, background } = this.options.renderer;
-    if (elementId === '') {
-      L(this);
-      throw new RuntimeError('HTML DOM element not set in Factory');
+    if (elementId === null) {
+      return;
     }
 
-    this.context = Renderer.buildContext(
-      elementId as string,
-      backend ?? Renderer.Backends.SVG,
-      width,
-      height,
-      background
-    );
+    if (elementId === '' || typeof elementId !== 'string') {
+      L(this);
+      throw new RuntimeError('renderer.elementId not set in FactoryOptions');
+    }
+    this.context = Renderer.buildContext(elementId, backend ?? Renderer.Backends.SVG, width, height, background);
   }
 
   getContext(): RenderContext {
@@ -198,7 +191,6 @@ export class Factory {
   }
 
   Stave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): Stave {
-    if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     if (!this.options.stave) throw new RuntimeError('NoStave');
     const p = {
       x: 0,
@@ -218,7 +210,6 @@ export class Factory {
   }
 
   TabStave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): TabStave {
-    if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     if (!this.options.stave) throw new RuntimeError('NoStave');
 
     const p = {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -244,7 +244,7 @@ export class Factory {
     return stave;
   }
 
-  StaveNote(noteStruct: StaveNoteStruct): StaveNote {
+  StaveNote(noteStruct: Partial<StaveNoteStruct>): StaveNote {
     const note = new StaveNote(noteStruct);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -268,7 +268,7 @@ export class Factory {
     return note;
   }
 
-  GhostNote(noteStruct: string | NoteStruct): GhostNote {
+  GhostNote(noteStruct: string | Partial<NoteStruct>): GhostNote {
     const ghostNote = new GhostNote(noteStruct);
     if (this.stave) ghostNote.setStave(this.stave);
     ghostNote.setContext(this.context);
@@ -276,8 +276,8 @@ export class Factory {
     return ghostNote;
   }
 
-  TextNote(textNoteStruct: TextNoteStruct): TextNote {
-    const textNote = new TextNote(textNoteStruct);
+  TextNote(noteStruct: Partial<TextNoteStruct>): TextNote {
+    const textNote = new TextNote(noteStruct);
     if (this.stave) textNote.setStave(this.stave);
     textNote.setContext(this.context);
     this.renderQ.push(textNote);
@@ -334,7 +334,7 @@ export class Factory {
     return keySigNote;
   }
 
-  TabNote(noteStruct: TabNoteStruct): TabNote {
+  TabNote(noteStruct: Partial<TabNoteStruct>): TabNote {
     const note = new TabNote(noteStruct);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -160,11 +160,18 @@ export class Factory {
       return;
     }
 
-    if (elementId === '' || typeof elementId !== 'string') {
+    if (elementId === '') {
       L(this);
       throw new RuntimeError('renderer.elementId not set in FactoryOptions');
     }
-    this.context = Renderer.buildContext(elementId, backend ?? Renderer.Backends.SVG, width, height, background);
+
+    this.context = Renderer.buildContext(
+      elementId as string,
+      backend ?? Renderer.Backends.SVG,
+      width,
+      height,
+      background
+    );
   }
 
   getContext(): RenderContext {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -2,7 +2,7 @@
 // @author Mohit Cheppudira
 // MIT License
 
-import { RuntimeError, log } from './util';
+import { RuntimeError, log, defined } from './util';
 import { Accidental } from './accidental';
 import { Articulation } from './articulation';
 import { Annotation } from './annotation';
@@ -51,17 +51,17 @@ import { StemmableNote } from './stemmablenote';
 import { Element } from './element';
 
 export interface FactoryOptions {
-  stave: {
+  stave?: {
     space: number;
   };
-  renderer: {
+  renderer?: {
     elementId: string | null;
     backend?: number;
     width: number;
     height: number;
     background?: string;
   };
-  font: {
+  font?: {
     family: string;
     size: number;
     weight: string;
@@ -83,6 +83,19 @@ export class Factory {
   /** To enable logging for this class. Set `Vex.Flow.Factory.DEBUG` to `true`. */
   static DEBUG: boolean;
 
+  /**
+   * Static simplified function to access constructor without providing FactoryOptions
+   *
+   * Example:
+   *
+   * Create an SVG renderer and attach it to the DIV element named "boo" to render using <page-width> 1200 and <page-height> 600
+   *
+   * `const vf: Factory = Vex.Flow.Factory.newFromElementId('boo', 1200, 600 );`
+   */
+  static newFromElementId(elementId: string | null, width = 500, height = 200): Factory {
+    return new Factory({ renderer: { elementId, width, height, backend: Renderer.Backends.SVG } });
+  }
+
   protected options: FactoryOptions;
 
   protected stave?: Stave;
@@ -93,17 +106,15 @@ export class Factory {
   protected systems!: System[];
 
   /**
-   * Constructor.
-   *
    * Example:
    *
    * Create an SVG renderer and attach it to the DIV element named "boo" to render using <page-width> 1200 and <page-height> 600
    *
    * `const vf: Factory = new Vex.Flow.Factory({renderer: { elementId: 'boo', width: 1200, height: 600 }});`
    */
-  constructor(options: Partial<FactoryOptions> = {}) {
+  constructor(options: FactoryOptions = {}) {
     L('New factory: ', options);
-    const defaults: FactoryOptions = {
+    this.options = {
       stave: {
         space: 10,
       },
@@ -121,21 +132,7 @@ export class Factory {
       },
     };
 
-    this.options = defaults;
     this.setOptions(options);
-  }
-
-  /**
-   * Static simplified function to access constructor without providing FactoryOptions
-   *
-   * Example:
-   *
-   * Create an SVG renderer and attach it to the DIV element named "boo" to render using <page-width> 1200 and <page-height> 600
-   *
-   * `const vf: Factory = Vex.Flow.Factory.newFromElementId('boo', 1200, 600 );`
-   */
-  static newFromElementId(elementId: string | null, width = 500, height = 200): Factory {
-    return new Factory({ renderer: { elementId, width, height, backend: Renderer.Backends.SVG } });
   }
 
   reset(): void {
@@ -146,15 +143,15 @@ export class Factory {
     this.stave = undefined; // current stave
   }
 
-  getOptions(): FactoryOptions {
-    return this.options;
+  getOptions(): Required<FactoryOptions> {
+    // Assume we did not unset `this.options.stave`, `this.options.renderer`, or `this.options.font`.
+    return this.options as Required<FactoryOptions>;
   }
 
-  setOptions(options: Partial<FactoryOptions> = {}): void {
-    if (options.stave) this.options.stave = options.stave;
-    if (options.renderer) this.options.renderer = options.renderer;
-    if (options.font) this.options.font = options.font;
-    if (this.options.renderer.elementId !== null) {
+  setOptions(options?: FactoryOptions): void {
+    this.options = { ...this.options, ...options };
+
+    if (this.options.renderer?.elementId !== null) {
       this.initRenderer();
     }
     this.reset();
@@ -200,51 +197,46 @@ export class Factory {
     return this.options.stave.space * spacing;
   }
 
-  Stave(paramsP: { x?: number; y?: number; width?: number; options?: Partial<StaveOptions> } = {}): Stave {
+  Stave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): Stave {
     if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     if (!this.options.stave) throw new RuntimeError('NoStave');
-    const params = {
-      ...{
-        x: 0,
-        y: 0,
-        width: this.options.renderer.width - this.space(1),
-        options: {
-          spacing_between_lines_px: this.options.stave.space,
-        },
+    const p = {
+      x: 0,
+      y: 0,
+      width: this.options.renderer.width - this.space(1),
+      options: {
+        spacing_between_lines_px: this.options.stave.space,
       },
-      ...paramsP,
+      ...params,
     };
 
-    const stave: Stave = new Stave(params.x, params.y, params.width, params.options);
+    const stave: Stave = new Stave(p.x, p.y, p.width, p.options);
     this.staves.push(stave);
     stave.setContext(this.context);
     this.stave = stave;
     return stave;
   }
 
-  TabStave(paramsP: { x?: number; y?: number; width?: number; options?: Partial<StaveOptions> } = {}): TabStave {
+  TabStave(params?: { x?: number; y?: number; width?: number; options?: StaveOptions }): TabStave {
     if (!this.options.renderer) throw new RuntimeError('NoRenderer');
     if (!this.options.stave) throw new RuntimeError('NoStave');
-    const params = {
-      ...{
-        x: 0,
-        y: 0,
-        width: this.options.renderer.width - this.space(1),
-        options: {
-          spacing_between_lines_px: this.options.stave.space * 1.3,
-        },
-      },
-      ...paramsP,
+
+    const p = {
+      x: 0,
+      y: 0,
+      width: this.options.renderer.width - this.space(1),
+      options: { spacing_between_lines_px: this.options.stave.space * 1.3 },
+      ...params,
     };
 
-    const stave = new TabStave(params.x, params.y, params.width, params.options);
+    const stave = new TabStave(p.x, p.y, p.width, p.options);
     this.staves.push(stave);
     stave.setContext(this.context);
     this.stave = stave;
     return stave;
   }
 
-  StaveNote(noteStruct: Partial<StaveNoteStruct>): StaveNote {
+  StaveNote(noteStruct: StaveNoteStruct): StaveNote {
     const note = new StaveNote(noteStruct);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -252,7 +244,7 @@ export class Factory {
     return note;
   }
 
-  GlyphNote(glyph: Glyph, noteStruct: Partial<NoteStruct>, options?: GlyphNoteOptions): GlyphNote {
+  GlyphNote(glyph: Glyph, noteStruct: NoteStruct, options?: GlyphNoteOptions): GlyphNote {
     const note = new GlyphNote(glyph, noteStruct, options);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -260,7 +252,7 @@ export class Factory {
     return note;
   }
 
-  RepeatNote(type: string, noteStruct?: Partial<NoteStruct>, options?: GlyphNoteOptions): RepeatNote {
+  RepeatNote(type: string, noteStruct?: NoteStruct, options?: GlyphNoteOptions): RepeatNote {
     const note = new RepeatNote(type, noteStruct, options);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -268,7 +260,7 @@ export class Factory {
     return note;
   }
 
-  GhostNote(noteStruct: string | Partial<NoteStruct>): GhostNote {
+  GhostNote(noteStruct: string | NoteStruct): GhostNote {
     const ghostNote = new GhostNote(noteStruct);
     if (this.stave) ghostNote.setStave(this.stave);
     ghostNote.setContext(this.context);
@@ -276,7 +268,7 @@ export class Factory {
     return ghostNote;
   }
 
-  TextNote(noteStruct: Partial<TextNoteStruct>): TextNote {
+  TextNote(noteStruct: TextNoteStruct): TextNote {
     const textNote = new TextNote(noteStruct);
     if (this.stave) textNote.setStave(this.stave);
     textNote.setContext(this.context);
@@ -292,34 +284,30 @@ export class Factory {
     return barNote;
   }
 
-  ClefNote(paramsP: { type?: string; options?: { size?: string; annotation?: string } } = {}): ClefNote {
-    const params = {
-      ...{
-        type: 'treble',
-        options: {
-          size: 'default',
-          annotation: undefined,
-        },
+  ClefNote(params?: { type?: string; options?: { size?: string; annotation?: string } }): ClefNote {
+    const p = {
+      type: 'treble',
+      options: {
+        size: 'default',
+        annotation: undefined,
       },
-      ...paramsP,
+      ...params,
     };
 
-    const clefNote = new ClefNote(params.type, params.options.size, params.options.annotation);
+    const clefNote = new ClefNote(p.type, p.options.size, p.options.annotation);
     if (this.stave) clefNote.setStave(this.stave);
     clefNote.setContext(this.context);
     this.renderQ.push(clefNote);
     return clefNote;
   }
 
-  TimeSigNote(paramsP: { time?: string } = {}): TimeSigNote {
-    const params = {
-      ...{
-        time: '4/4',
-      },
-      ...paramsP,
+  TimeSigNote(params?: { time?: string }): TimeSigNote {
+    const p = {
+      time: '4/4',
+      ...params,
     };
 
-    const timeSigNote = new TimeSigNote(params.time);
+    const timeSigNote = new TimeSigNote(p.time);
     if (this.stave) timeSigNote.setStave(this.stave);
     timeSigNote.setContext(this.context);
     this.renderQ.push(timeSigNote);
@@ -334,7 +322,7 @@ export class Factory {
     return keySigNote;
   }
 
-  TabNote(noteStruct: Partial<TabNoteStruct>): TabNote {
+  TabNote(noteStruct: TabNoteStruct): TabNote {
     const note = new TabNote(noteStruct);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -342,7 +330,7 @@ export class Factory {
     return note;
   }
 
-  GraceNote(noteStruct: Partial<GraceNoteStruct>): GraceNote {
+  GraceNote(noteStruct: GraceNoteStruct): GraceNote {
     const note = new GraceNote(noteStruct);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);
@@ -361,107 +349,94 @@ export class Factory {
     return accid;
   }
 
-  Annotation(
-    paramsP: {
-      text?: string;
-      vJustify?: string;
-      hJustify?: string;
-      fontFamily?: string;
-      fontSize?: number;
-      fontWeight?: string;
-    } = {}
-  ): Annotation {
-    const params = {
-      ...{
-        text: 'p',
-        vJustify: 'below',
-        hJustify: 'center',
-        fontFamily: 'Times',
-        fontSize: 14,
-        fontWeight: 'bold italic',
-        options: {},
-      },
-      ...paramsP,
+  Annotation(params?: {
+    text?: string;
+    vJustify?: string;
+    hJustify?: string;
+    fontFamily?: string;
+    fontSize?: number;
+    fontWeight?: string;
+  }): Annotation {
+    const p = {
+      text: 'p',
+      vJustify: 'below',
+      hJustify: 'center',
+      fontFamily: 'Times',
+      fontSize: 14,
+      fontWeight: 'bold italic',
+      options: {},
+      ...params,
     };
 
-    const annotation = new Annotation(params.text);
-    annotation.setJustification(params.hJustify);
-    annotation.setVerticalJustification(params.vJustify);
-    annotation.setFont(params.fontFamily, params.fontSize, params.fontWeight);
+    const annotation = new Annotation(p.text);
+    annotation.setJustification(p.hJustify);
+    annotation.setVerticalJustification(p.vJustify);
+    annotation.setFont(p.fontFamily, p.fontSize, p.fontWeight);
     annotation.setContext(this.context);
     return annotation;
   }
 
-  ChordSymbol(
-    paramsP: {
-      vJustify?: string;
-      hJustify?: string;
-      kerning?: boolean;
-      reportWidth?: boolean;
-      fontFamily?: string;
-      fontSize?: number;
-      fontWeight?: string;
-    } = {}
-  ): ChordSymbol {
-    const params = {
-      ...{
-        vJustify: 'top',
-        hJustify: 'center',
-        kerning: true,
-        reportWidth: true,
-      },
-      ...paramsP,
+  ChordSymbol(params?: {
+    vJustify?: string;
+    hJustify?: string;
+    kerning?: boolean;
+    reportWidth?: boolean;
+    fontFamily?: string;
+    fontSize?: number;
+    fontWeight?: string;
+  }): ChordSymbol {
+    const p = {
+      vJustify: 'top',
+      hJustify: 'center',
+      kerning: true,
+      reportWidth: true,
+      ...params,
     };
 
     const chordSymbol = new ChordSymbol();
-    chordSymbol.setHorizontal(params.hJustify);
-    chordSymbol.setVertical(params.vJustify);
-    chordSymbol.setEnableKerning(params.kerning);
-    chordSymbol.setReportWidth(params.reportWidth);
+    chordSymbol.setHorizontal(p.hJustify);
+    chordSymbol.setVertical(p.vJustify);
+    chordSymbol.setEnableKerning(p.kerning);
+    chordSymbol.setReportWidth(p.reportWidth);
     // There is a default font based on the engraving font.  Only set then
     // font if it is specific, else use the default
-    if (typeof params.fontFamily === 'string' && typeof params.fontSize === 'number') {
-      if (typeof params.fontWeight === 'string')
-        chordSymbol.setFont(params.fontFamily, params.fontSize, params.fontWeight);
-      else chordSymbol.setFont(params.fontFamily, params.fontSize, '');
-    } else if (typeof params.fontSize === 'number') {
-      chordSymbol.setFontSize(params.fontSize);
+    if (typeof p.fontFamily === 'string' && typeof p.fontSize === 'number') {
+      if (typeof p.fontWeight === 'string') chordSymbol.setFont(p.fontFamily, p.fontSize, p.fontWeight);
+      else chordSymbol.setFont(p.fontFamily, p.fontSize, '');
+    } else if (typeof p.fontSize === 'number') {
+      chordSymbol.setFontSize(p.fontSize);
     }
     chordSymbol.setContext(this.context);
     return chordSymbol;
   }
 
-  Articulation(paramsP: { type?: string; position?: string | number } = {}): Articulation {
-    const params = {
-      ...{
-        type: 'a.',
-        position: 'above',
-      },
-      ...paramsP,
+  Articulation(params?: { type?: string; position?: string | number }): Articulation {
+    const p = {
+      type: 'a.',
+      position: 'above',
+      ...params,
     };
 
-    const articulation = new Articulation(params.type);
-    articulation.setPosition(params.position);
+    const articulation = new Articulation(p.type);
+    articulation.setPosition(p.position);
     articulation.setContext(this.context);
     return articulation;
   }
 
-  TextDynamics(paramsP: { text?: string; duration?: string; dots?: number; line?: number } = {}): TextDynamics {
-    const params = {
-      ...{
-        text: 'p',
-        duration: 'q',
-        dots: 0,
-        line: 0,
-      },
-      ...paramsP,
+  TextDynamics(params?: { text?: string; duration?: string; dots?: number; line?: number }): TextDynamics {
+    const p = {
+      text: 'p',
+      duration: 'q',
+      dots: 0,
+      line: 0,
+      ...params,
     };
 
     const text = new TextDynamics({
-      text: params.text,
-      line: params.line,
-      duration: params.duration,
-      dots: params.dots,
+      text: p.text,
+      line: p.line,
+      duration: p.duration,
+      dots: p.dots,
     });
 
     if (this.stave) text.setStave(this.stave);
@@ -470,17 +445,15 @@ export class Factory {
     return text;
   }
 
-  Fingering(paramsP: { number: string; position?: string }): FretHandFinger {
-    const params = {
-      ...{
-        number: '0',
-        position: 'left',
-      },
-      ...paramsP,
+  Fingering(params: { number?: string; position?: string }): FretHandFinger {
+    const p = {
+      number: '0',
+      position: 'left',
+      ...params,
     };
 
-    const fingering = new FretHandFinger(params.number);
-    fingering.setPosition(params.position);
+    const fingering = new FretHandFinger(p.number);
+    fingering.setPosition(p.position);
     fingering.setContext(this.context);
     return fingering;
   }
@@ -500,22 +473,20 @@ export class Factory {
     return new ModifierContext();
   }
 
-  MultiMeasureRest(params: Partial<MultimeasureRestRenderOptions>): MultiMeasureRest {
-    if (params.number_of_measures === undefined) throw new RuntimeError('NoNumberOfMeasures');
-    const multimeasurerest = new MultiMeasureRest(params.number_of_measures, params);
-    multimeasurerest.setContext(this.context);
-    this.renderQ.push(multimeasurerest);
-    return multimeasurerest;
+  MultiMeasureRest(params: MultimeasureRestRenderOptions): MultiMeasureRest {
+    const numMeasures = defined(params.number_of_measures, 'NoNumberOfMeasures');
+    const multiMeasureRest = new MultiMeasureRest(numMeasures, params);
+    multiMeasureRest.setContext(this.context);
+    this.renderQ.push(multiMeasureRest);
+    return multiMeasureRest;
   }
 
-  Voice(paramsP: { time?: Partial<VoiceTime> | string; options?: { softmaxFactor: number } } = {}): Voice {
-    const params = {
-      ...{
-        time: '4/4',
-      },
-      ...paramsP,
+  Voice(params?: { time?: VoiceTime | string; options?: { softmaxFactor: number } }): Voice {
+    const p = {
+      time: '4/4',
+      ...params,
     };
-    const voice = new Voice(params.time, params.options);
+    const voice = new Voice(p.time, p.options);
     this.voices.push(voice);
     return voice;
   }
@@ -527,20 +498,18 @@ export class Factory {
     return connector;
   }
 
-  Formatter(options: Partial<FormatterOptions> = {}): Formatter {
+  Formatter(options?: FormatterOptions): Formatter {
     return new Formatter(options);
   }
 
-  Tuplet(paramsP: { notes?: Note[]; options?: TupletOptions } = {}): Tuplet {
-    const params = {
-      ...{
-        notes: [],
-        options: {},
-      },
-      ...paramsP,
+  Tuplet(params?: { notes?: Note[]; options?: TupletOptions }): Tuplet {
+    const p = {
+      notes: [],
+      options: {},
+      ...params,
     };
 
-    const tuplet = new Tuplet(params.notes, params.options).setContext(this.context);
+    const tuplet = new Tuplet(p.notes, p.options).setContext(this.context);
     this.renderQ.push(tuplet);
     return tuplet;
   }
@@ -552,7 +521,7 @@ export class Factory {
     return beam;
   }
 
-  Curve(params: { from: Note; to: Note; options: Partial<CurveOptions> }): Curve {
+  Curve(params: { from: Note; to: Note; options: CurveOptions }): Curve {
     const curve = new Curve(params.from, params.to, params.options).setContext(this.context);
     this.renderQ.push(curve);
     return curve;
@@ -634,7 +603,7 @@ export class Factory {
       superscript: string;
       position: string;
       line?: number;
-      font?: Partial<FontInfo>;
+      font?: FontInfo;
     };
   }): TextBracket {
     const textBracket = new TextBracket({
@@ -653,7 +622,10 @@ export class Factory {
     return textBracket;
   }
 
-  System(params: Partial<SystemOptions> = {}): System {
+  // TODO: SystemOptions make all properties optional.
+  // eslint-disable-next-line
+  // @ts-ignore
+  System(params: SystemOptions = {}): System {
     params.factory = this;
     const system = new System(params).setContext(this.context);
     this.systems.push(system);
@@ -661,69 +633,66 @@ export class Factory {
   }
 
   /**
-   * Creates EasyScore. Normally the first step after constructing a Factory.
-   *
-   * Example:
-   *
-   * `const vf: Factory = new Vex.Flow.Factory({renderer: { elementId: 'boo', width: 1200, height: 600 }});`
-   *
-   * `const score: EasyScore = vf.EasyScore();`
+   * Creates EasyScore. Normally the first step after constructing a Factory. For example:
+   * ```
+   * const vf: Factory = new Vex.Flow.Factory({renderer: { elementId: 'boo', width: 1200, height: 600 }});
+   * const score: EasyScore = vf.EasyScore();
+   * ```
    * @param options.factory optional instance of Factory
    * @param options.builder instance of Builder
    * @param options.commitHooks function to call after a note element is created
    * @param options.throwOnError throw error in case of parsing error
    */
-  EasyScore(options: Partial<EasyScoreOptions> = {}): EasyScore {
+  // TODO: EasyScoreOptions make all properties optional.
+  // eslint-disable-next-line
+  // @ts-ignore
+  EasyScore(options: EasyScoreOptions = {}): EasyScore {
     options.factory = this;
     return new EasyScore(options);
   }
 
-  PedalMarking(paramsP: { notes?: StaveNote[]; options?: { style: string } } = {}): PedalMarking {
-    const params = {
-      ...{
-        notes: [],
-        options: {
-          style: 'mixed',
-        },
+  PedalMarking(params?: { notes?: StaveNote[]; options?: { style: string } }): PedalMarking {
+    const p = {
+      notes: [],
+      options: {
+        style: 'mixed',
       },
-      ...paramsP,
+      ...params,
     };
 
-    const pedal = new PedalMarking(params.notes);
-    pedal.setType(PedalMarking.typeString[params.options.style]);
+    const pedal = new PedalMarking(p.notes);
+    pedal.setType(PedalMarking.typeString[p.options.style]);
     pedal.setContext(this.context);
     this.renderQ.push(pedal);
     return pedal;
   }
 
-  NoteSubGroup(paramsP: { notes?: Note[] } = {}): NoteSubGroup {
-    const params = {
-      ...{
-        notes: [],
-      },
-      ...paramsP,
+  NoteSubGroup(params?: { notes?: Note[] }): NoteSubGroup {
+    const p = {
+      notes: [],
+      ...params,
     };
 
-    const group = new NoteSubGroup(params.notes);
+    const group = new NoteSubGroup(p.notes);
     group.setContext(this.context);
     return group;
   }
 
   TextFont(params: TextFontRegistry): TextFont {
     params.factory = this;
-    const textFont = new TextFont(params);
-    return textFont;
+    return new TextFont(params);
   }
 
   /** Render the score. */
   draw(): void {
-    this.systems.forEach((i) => i.setContext(this.context).format());
-    this.staves.forEach((i) => i.setContext(this.context).draw());
-    this.voices.forEach((i) => i.setContext(this.context).draw());
-    this.renderQ.forEach((i) => {
-      if (!i.isRendered()) i.setContext(this.context).draw();
+    const ctx = this.context;
+    this.systems.forEach((s) => s.setContext(ctx).format());
+    this.staves.forEach((s) => s.setContext(ctx).draw());
+    this.voices.forEach((v) => v.setContext(ctx).draw());
+    this.renderQ.forEach((e) => {
+      if (!e.isRendered()) e.setContext(ctx).draw();
     });
-    this.systems.forEach((i) => i.setContext(this.context).draw());
+    this.systems.forEach((s) => s.setContext(ctx).draw());
     this.reset();
   }
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -634,9 +634,6 @@ export class Factory {
    * @param options.commitHooks function to call after a note element is created
    * @param options.throwOnError throw error in case of parsing error
    */
-  // TODO: EasyScoreOptions make all properties optional.
-  // eslint-disable-next-line
-  // @ts-ignore
   EasyScore(options: EasyScoreOptions = {}): EasyScore {
     options.factory = this;
     return new EasyScore(options);

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -15,7 +15,7 @@ export class GhostNote extends StemmableNote {
     return 'GhostNote';
   }
 
-  constructor(parameter: string | Partial<NoteStruct>) {
+  constructor(parameter: string | NoteStruct) {
     if (!parameter) {
       throw new RuntimeError('BadArguments', ERROR_MSG);
     }

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -15,7 +15,7 @@ export class GhostNote extends StemmableNote {
     return 'GhostNote';
   }
 
-  constructor(parameter: string | NoteStruct) {
+  constructor(parameter: string | Partial<NoteStruct>) {
     if (!parameter) {
       throw new RuntimeError('BadArguments', ERROR_MSG);
     }

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -14,7 +14,7 @@ export class GlyphNote extends Note {
     return 'GlyphNote';
   }
 
-  protected options: GlyphNoteOptions;
+  protected options: Required<GlyphNoteOptions>;
 
   constructor(glyph: Glyph | undefined, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
     super(noteStruct);
@@ -25,7 +25,7 @@ export class GlyphNote extends Note {
     };
 
     // Note properties
-    this.ignore_ticks = this.options.ignoreTicks as boolean;
+    this.ignore_ticks = this.options.ignoreTicks;
     if (glyph) {
       this.setGlyph(glyph);
     }
@@ -67,15 +67,16 @@ export class GlyphNote extends Note {
     ctx.openGroup('glyphNote', this.getAttribute('id'));
 
     // Context is set when setStave is called on Note
-    if (!this.glyph.getContext()) {
-      this.glyph.setContext(ctx);
+    const glyph = this.glyph;
+    if (!glyph.getContext()) {
+      glyph.setContext(ctx);
     }
 
-    this.glyph.setStave(stave);
-    this.glyph.setYShift(stave.getYForLine(this.options.line as number) - stave.getYForGlyphs());
+    glyph.setStave(stave);
+    glyph.setYShift(stave.getYForLine(this.options.line) - stave.getYForGlyphs());
 
     const x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
-    this.glyph.renderToStave(x);
+    glyph.renderToStave(x);
     this.drawModifiers();
     ctx.closeGroup();
   }

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -16,7 +16,7 @@ export class GlyphNote extends Note {
 
   protected options: GlyphNoteOptions;
 
-  constructor(glyph: Glyph | undefined, noteStruct: Partial<NoteStruct>, options?: GlyphNoteOptions) {
+  constructor(glyph: Glyph | undefined, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
     super(noteStruct);
     this.options = {
       ignoreTicks: false,

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -6,7 +6,7 @@ import { Stem } from './stem';
 import { Flow } from './flow';
 
 export interface GraceNoteStruct extends StaveNoteStruct {
-  slash: boolean;
+  slash?: boolean;
 }
 
 export class GraceNote extends StaveNote {

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -25,7 +25,7 @@ export class GraceNote extends StaveNote {
   protected slash: boolean;
   protected slur: boolean;
 
-  constructor(noteStruct: Partial<GraceNoteStruct>) {
+  constructor(noteStruct: GraceNoteStruct) {
     super({
       glyph_font_scale: Flow.DEFAULT_NOTATION_FONT_SCALE * GraceNote.SCALE,
       stroke_px: GraceNote.LEDGER_LINE_OFFSET,

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -27,10 +27,8 @@ export class GraceNote extends StaveNote {
 
   constructor(noteStruct: Partial<GraceNoteStruct>) {
     super({
-      ...{
-        glyph_font_scale: Flow.DEFAULT_NOTATION_FONT_SCALE * GraceNote.SCALE,
-        stroke_px: GraceNote.LEDGER_LINE_OFFSET,
-      },
+      glyph_font_scale: Flow.DEFAULT_NOTATION_FONT_SCALE * GraceNote.SCALE,
+      stroke_px: GraceNote.LEDGER_LINE_OFFSET,
       ...noteStruct,
     });
 

--- a/src/gracetabnote.ts
+++ b/src/gracetabnote.ts
@@ -15,26 +15,19 @@ export class GraceTabNote extends TabNote {
     return 'GraceTabNote';
   }
 
-  constructor(noteStruct: Partial<TabNoteStruct>) {
+  constructor(noteStruct: TabNoteStruct) {
     super(noteStruct, false);
 
     this.render_options = {
       ...this.render_options,
-      ...{
-        // vertical shift from stave line
-        y_shift: 0.3,
-        // grace glyph scale
-        scale: 0.6,
-        // grace tablature font
-        font: '7.5pt Arial',
-      },
+      // vertical shift from stave line
+      y_shift: 0.3,
+      // grace glyph scale
+      scale: 0.6,
+      // grace tablature font
+      font: '7.5pt Arial',
     };
 
     this.updateWidth();
-  }
-
-  draw(): void {
-    super.draw();
-    this.setRendered();
   }
 }

--- a/src/gracetabnote.ts
+++ b/src/gracetabnote.ts
@@ -15,7 +15,7 @@ export class GraceTabNote extends TabNote {
     return 'GraceTabNote';
   }
 
-  constructor(noteStruct: TabNoteStruct) {
+  constructor(noteStruct: Partial<TabNoteStruct>) {
     super(noteStruct, false);
 
     this.render_options = {

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -25,7 +25,7 @@ export class KeySignature extends StaveModifier {
   protected cancelKeySpec?: string;
   protected accList: { type: string; line: number }[] = [];
   protected keySpec?: string;
-  protected alterKeySpec?: string;
+  protected alterKeySpec?: string[];
 
   // Space between natural and following accidental depending
   // on vertical position
@@ -89,7 +89,7 @@ export class KeySignature extends StaveModifier {
   };
 
   // Create a new Key Signature based on a `key_spec`
-  constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string) {
+  constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]) {
     super();
 
     this.setKeySig(keySpec, cancelKeySpec, alterKeySpec);
@@ -242,7 +242,7 @@ export class KeySignature extends StaveModifier {
     return this.width;
   }
 
-  setKeySig(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string): this {
+  setKeySig(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]): this {
     this.formatted = false;
     this.keySpec = keySpec;
     this.cancelKeySpec = cancelKeySpec;
@@ -254,14 +254,14 @@ export class KeySignature extends StaveModifier {
   // Alter the accidentals of a key spec one by one.
   // Each alteration is a new accidental that replaces the
   // original accidental (or the canceled one).
-  alterKey(alterKeySpec: string): this {
+  alterKey(alterKeySpec: string[]): this {
     this.formatted = false;
     this.alterKeySpec = alterKeySpec;
 
     return this;
   }
 
-  convertToAlterAccList(alterKeySpec: string): void {
+  convertToAlterAccList(alterKeySpec: string[]): void {
     const max = Math.min(alterKeySpec.length, this.accList.length);
     for (let i = 0; i < max; ++i) {
       if (alterKeySpec[i]) {

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -12,7 +12,7 @@ export class KeySigNote extends Note {
 
   protected keySignature: KeySignature;
 
-  constructor(keySpec: string, cancelKeySpec: string, alterKeySpec: string) {
+  constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]) {
     super({ duration: 'b' });
 
     this.keySignature = new KeySignature(keySpec, cancelKeySpec, alterKeySpec);

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -101,7 +101,6 @@ export class MultiMeasureRest extends Element {
     this.hasLineThickness = typeof options.line_thickness === 'number';
     this.hasSymbolSpacing = typeof options.symbol_spacing === 'number';
 
-    // Any numeric fields in `this.render_options` can be safely be cast "as number" when needed.
     this.render_options = {
       use_symbols: false,
       show_number: true,

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -15,18 +15,18 @@ import { RenderContext } from './types/common';
 import { isBarline } from 'typeguard';
 
 export interface MultimeasureRestRenderOptions {
-  number_of_measures?: number;
+  number_of_measures: number;
   padding_left?: number;
-  line: number;
-  number_glyph_point: number;
-  show_number: boolean;
+  line?: number;
+  number_glyph_point?: number;
+  show_number?: boolean;
   line_thickness?: number;
   symbol_spacing?: number;
-  serif_thickness: number;
-  use_symbols: boolean;
-  number_line: number;
-  spacing_between_lines_px: number;
-  semibreve_rest_glyph_scale: number;
+  serif_thickness?: number;
+  use_symbols?: boolean;
+  number_line?: number;
+  spacing_between_lines_px?: number;
+  semibreve_rest_glyph_scale?: number;
   padding_right?: number;
 }
 
@@ -74,30 +74,23 @@ export class MultiMeasureRest extends Element {
   //   * `use_symbols` - Use rest symbols or not.
   //   * `symbol_spacing` - Spacing between each rest symbol glyphs.
   //   * `semibreve_rest_glyph_scale` - Size of the semibreve(1-bar) rest symbol.
-  constructor(number_of_measures: number, options: Partial<MultimeasureRestRenderOptions>) {
+  constructor(number_of_measures: number, options: MultimeasureRestRenderOptions) {
     super();
 
-    const point = this.musicFont.lookupMetric('digits.point');
-    const fontLineShift = this.musicFont.lookupMetric('digits.shiftLine', 0);
-
+    // Any numeric fields in `this.render_options` can be safely be cast "as number" when needed.
     this.render_options = {
+      use_symbols: false,
       show_number: true,
       number_line: -0.5,
-      number_glyph_point: point, // same as TimeSignature.
-
+      number_glyph_point: this.musicFont.lookupMetric('digits.point'), // same as TimeSignature.
       line: 2,
-
       spacing_between_lines_px: 10, // same as Stave.
-
       serif_thickness: 2,
-
-      use_symbols: false,
-
-      /* same as NoteHead. */
-      semibreve_rest_glyph_scale: Flow.DEFAULT_NOTATION_FONT_SCALE,
+      semibreve_rest_glyph_scale: Flow.DEFAULT_NOTATION_FONT_SCALE, // same as NoteHead.
+      ...options,
     };
-    this.render_options = { ...this.render_options, ...options };
 
+    const fontLineShift = this.musicFont.lookupMetric('digits.shiftLine', 0);
     this.render_options.number_line += fontLineShift;
 
     this.number_of_measures = number_of_measures;
@@ -125,14 +118,14 @@ export class MultiMeasureRest extends Element {
   }
 
   drawLine(ctx: RenderContext, left: number, right: number, sbl: number): void {
-    const y = this.checkStave().getYForLine(this.render_options.line);
+    const y = this.checkStave().getYForLine(this.render_options.line as number);
     const padding = (right - left) * 0.1;
 
     left += padding;
     right -= padding;
 
     const serif = {
-      thickness: this.render_options.serif_thickness,
+      thickness: this.render_options.serif_thickness as number,
       height: sbl,
     };
     let lineThicknessHalf = sbl * 0.25;
@@ -185,9 +178,11 @@ export class MultiMeasureRest extends Element {
 
     const width = n4 * glyphs[2].width + n2 * glyphs[2].width + n1 * glyphs[1].width + (n4 + n2 + n1 - 1) * spacing;
     let x = left + (right - left) * 0.5 - width * 0.5;
-    const yTop = stave.getYForLine(this.render_options.line - 1);
-    const yMiddle = stave.getYForLine(this.render_options.line);
-    const yBottom = stave.getYForLine(this.render_options.line + 1);
+
+    const line = this.render_options.line as number;
+    const yTop = stave.getYForLine(line - 1);
+    const yMiddle = stave.getYForLine(line);
+    const yBottom = stave.getYForLine(line + 1);
 
     ctx.save();
     ctx.setStrokeStyle('none');
@@ -215,7 +210,7 @@ export class MultiMeasureRest extends Element {
     this.setRendered();
 
     const stave = this.checkStave();
-    const sbl = this.render_options.spacing_between_lines_px;
+    const sbl = this.render_options.spacing_between_lines_px as number;
 
     let left = stave.getNoteStartX();
     let right = stave.getNoteEndX();
@@ -248,11 +243,11 @@ export class MultiMeasureRest extends Element {
     if (this.render_options.show_number) {
       const timeSpec = '/' + this.number_of_measures;
       const timeSig = new TimeSignature(timeSpec, 0, false);
-      timeSig.point = this.render_options.number_glyph_point;
+      timeSig.point = this.render_options.number_glyph_point as number;
       timeSig.setTimeSig(timeSpec);
       timeSig.setStave(stave);
       timeSig.setX(left + (right - left) * 0.5 - timeSig.getInfo().glyph.getMetrics().width * 0.5);
-      timeSig.bottomLine = this.render_options.number_line;
+      timeSig.bottomLine = this.render_options.number_line as number;
       timeSig.setContext(ctx).draw();
     }
   }

--- a/src/note.ts
+++ b/src/note.ts
@@ -61,16 +61,17 @@ export interface ParsedNote {
 }
 
 export interface NoteStruct {
+  /** Array of pitches, e.g: `['c/4', 'e/4', 'g/4']` */
+  keys?: string[];
   /** The time length (e.g., `q` for quarter, `h` for half, `8` for eighth etc.). */
-  duration: string;
-  line: number;
+  duration?: string;
+  line?: number;
   /** The number of dots, which affects the duration. */
-  dots: number;
-  keys: string[];
+  dots?: number;
   /** The note type (e.g., `r` for rest, `s` for slash notes, etc.). */
-  type: string;
-  align_center: boolean;
-  duration_override: Fraction;
+  type?: string;
+  align_center?: boolean;
+  duration_override?: Fraction;
 }
 
 /**
@@ -168,12 +169,9 @@ export abstract class Note extends Tickable {
     return { duration, dots, type };
   }
 
-  protected static parseNoteStruct(noteStruct: Partial<NoteStruct>): ParsedNote | undefined {
-    const durationString = noteStruct.duration;
-    const customTypes: string[] = [];
-
+  protected static parseNoteStruct(noteStruct: NoteStruct): ParsedNote | undefined {
     // Preserve backwards-compatibility
-    const durationProps = Note.parseDuration(durationString);
+    const durationProps = Note.parseDuration(noteStruct.duration);
     if (!durationProps) {
       return undefined;
     }
@@ -185,6 +183,7 @@ export abstract class Note extends Tickable {
     }
 
     // If no type specified, check duration or custom types
+    const customTypes: string[] = [];
     if (!type) {
       type = durationProps.type || 'n';
 
@@ -234,7 +233,7 @@ export abstract class Note extends Tickable {
    *
    * @param noteStruct To create a new note you need to provide a `noteStruct`.
    */
-  constructor(noteStruct: Partial<NoteStruct>) {
+  constructor(noteStruct: NoteStruct) {
     super();
 
     if (!noteStruct) {
@@ -242,8 +241,8 @@ export abstract class Note extends Tickable {
     }
 
     /** Parses `noteStruct` and get note properties. */
-    const initStruct = Note.parseNoteStruct(noteStruct);
-    if (!initStruct) {
+    const parsedNoteStruct = Note.parseNoteStruct(noteStruct);
+    if (!parsedNoteStruct) {
       throw new RuntimeError('BadArguments', `Invalid note initialization object: ${JSON.stringify(noteStruct)}`);
     }
 
@@ -252,17 +251,17 @@ export abstract class Note extends Tickable {
     // per-pitch properties
     this.keyProps = [];
 
-    this.duration = initStruct.duration;
-    this.dots = initStruct.dots;
-    this.noteType = initStruct.type;
-    this.customTypes = initStruct.customTypes;
+    this.duration = parsedNoteStruct.duration;
+    this.dots = parsedNoteStruct.dots;
+    this.noteType = parsedNoteStruct.type;
+    this.customTypes = parsedNoteStruct.customTypes;
 
     if (noteStruct.duration_override) {
       // Custom duration
       this.setDuration(noteStruct.duration_override);
     } else {
       // Default duration
-      this.setIntrinsicTicks(initStruct.ticks);
+      this.setIntrinsicTicks(parsedNoteStruct.ticks);
     }
 
     this.modifiers = [];

--- a/src/note.ts
+++ b/src/note.ts
@@ -63,14 +63,14 @@ export interface ParsedNote {
 export interface NoteStruct {
   /** The time length (e.g., `q` for quarter, `h` for half, `8` for eighth etc.). */
   duration: string;
-  line?: number;
+  line: number;
   /** The number of dots, which affects the duration. */
-  dots?: number;
-  keys?: string[];
+  dots: number;
+  keys: string[];
   /** The note type (e.g., `r` for rest, `s` for slash notes, etc.). */
-  type?: string;
-  align_center?: boolean;
-  duration_override?: Fraction;
+  type: string;
+  align_center: boolean;
+  duration_override: Fraction;
 }
 
 /**

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -17,21 +17,20 @@ function L(...args: any[]) {
 }
 
 export interface NoteHeadStruct extends NoteStruct {
-  glyph_font_scale?: number;
-  slashed?: boolean;
-  style?: ElementStyle;
-  stem_down_x_offset?: number;
-  stem_up_x_offset?: number;
-  custom_glyph_code?: string;
-  x_shift?: number;
-  line?: number;
-  stem_direction?: number;
-  displaced?: boolean;
-  //  duration: string;
+  glyph_font_scale: number;
+  slashed: boolean;
+  style: ElementStyle;
+  stem_down_x_offset: number;
+  stem_up_x_offset: number;
+  custom_glyph_code: string;
+  x_shift: number;
+  line: number;
+  stem_direction: number;
+  displaced: boolean;
   note_type: string;
-  y?: number;
-  x?: number;
-  index?: number;
+  y: number;
+  x: number;
+  index: number;
 }
 
 /**
@@ -108,7 +107,7 @@ export class NoteHead extends Note {
   protected custom_glyph: boolean = false;
   protected stem_up_x_offset: number = 0;
   protected stem_down_x_offset: number = 0;
-  protected note_type: string;
+  protected note_type?: string;
   protected displaced: boolean;
   protected stem_direction: number;
 
@@ -118,17 +117,16 @@ export class NoteHead extends Note {
   protected index?: number;
   protected slashed: boolean;
 
-  constructor(head_options: NoteHeadStruct) {
-    super(head_options);
+  constructor(noteStruct: Partial<NoteHeadStruct>) {
+    super(noteStruct);
 
-    this.index = head_options.index;
-    this.x = head_options.x || 0;
-    this.y = head_options.y || 0;
-    this.note_type = head_options.note_type;
-    this.duration = head_options.duration;
-    this.displaced = head_options.displaced || false;
-    this.stem_direction = head_options.stem_direction || Stem.UP;
-    this.line = head_options.line || 0;
+    this.index = noteStruct.index;
+    this.x = noteStruct.x || 0;
+    this.y = noteStruct.y || 0;
+    this.note_type = noteStruct.note_type;
+    this.displaced = noteStruct.displaced || false;
+    this.stem_direction = noteStruct.stem_direction || Stem.UP;
+    this.line = noteStruct.line || 0;
 
     // Get glyph code based on duration and note type. This could be
     // regular notes, rests, or other custom codes.
@@ -136,22 +134,22 @@ export class NoteHead extends Note {
     defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.note_type}'`);
 
     this.glyph_code = this.glyph.code_head;
-    this.x_shift = head_options.x_shift || 0;
-    if (head_options.custom_glyph_code) {
+    this.x_shift = noteStruct.x_shift || 0;
+    if (noteStruct.custom_glyph_code) {
       this.custom_glyph = true;
-      this.glyph_code = head_options.custom_glyph_code;
-      this.stem_up_x_offset = head_options.stem_up_x_offset || 0;
-      this.stem_down_x_offset = head_options.stem_down_x_offset || 0;
+      this.glyph_code = noteStruct.custom_glyph_code;
+      this.stem_up_x_offset = noteStruct.stem_up_x_offset || 0;
+      this.stem_down_x_offset = noteStruct.stem_down_x_offset || 0;
     }
 
-    this.style = head_options.style;
-    this.slashed = head_options.slashed || false;
+    this.style = noteStruct.style;
+    this.slashed = noteStruct.slashed || false;
 
     this.render_options = {
       ...this.render_options,
       ...{
         // font size for note heads
-        glyph_font_scale: head_options.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
+        glyph_font_scale: noteStruct.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
         // number of stroke px to the left and right of head
         stroke_px: 3,
       },

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -107,7 +107,6 @@ export class NoteHead extends Note {
   protected custom_glyph: boolean = false;
   protected stem_up_x_offset: number = 0;
   protected stem_down_x_offset: number = 0;
-  protected note_type?: string;
   protected displaced: boolean;
   protected stem_direction: number;
 
@@ -123,15 +122,15 @@ export class NoteHead extends Note {
     this.index = noteStruct.index;
     this.x = noteStruct.x || 0;
     this.y = noteStruct.y || 0;
-    this.note_type = noteStruct.note_type;
+    if (noteStruct.note_type) this.noteType = noteStruct.note_type;
     this.displaced = noteStruct.displaced || false;
     this.stem_direction = noteStruct.stem_direction || Stem.UP;
     this.line = noteStruct.line || 0;
 
     // Get glyph code based on duration and note type. This could be
     // regular notes, rests, or other custom codes.
-    this.glyph = Flow.getGlyphProps(this.duration, this.note_type);
-    defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.note_type}'`);
+    this.glyph = Flow.getGlyphProps(this.duration, this.noteType);
+    defined(this.glyph, 'BadArguments', `No glyph found for duration '${this.duration}' and type '${this.noteType}'`);
 
     this.glyph_code = this.glyph.code_head;
     this.x_shift = noteStruct.x_shift || 0;
@@ -269,7 +268,7 @@ export class NoteHead extends Note {
 
     const y = this.y;
 
-    L("Drawing note head '", this.note_type, this.duration, "' at", head_x, y);
+    L("Drawing note head '", this.noteType, this.duration, "' at", head_x, y);
 
     // Begin and end positions for head.
     const stem_direction = this.stem_direction;
@@ -280,7 +279,7 @@ export class NoteHead extends Note {
     }
 
     const categorySuffix = `${this.glyph_code}Stem${stem_direction === Stem.UP ? 'Up' : 'Down'}`;
-    if (this.note_type === 's') {
+    if (this.noteType === 's') {
       const staveSpace = this.checkStave().getSpacingBetweenLines();
       drawSlashNoteHead(ctx, this.duration, head_x, y, stem_direction, staveSpace);
     } else {

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -17,20 +17,20 @@ function L(...args: any[]) {
 }
 
 export interface NoteHeadStruct extends NoteStruct {
-  glyph_font_scale: number;
-  slashed: boolean;
-  style: ElementStyle;
-  stem_down_x_offset: number;
-  stem_up_x_offset: number;
-  custom_glyph_code: string;
-  x_shift: number;
-  line: number;
-  stem_direction: number;
-  displaced: boolean;
-  note_type: string;
-  y: number;
-  x: number;
-  index: number;
+  line?: number;
+  glyph_font_scale?: number;
+  slashed?: boolean;
+  style?: ElementStyle;
+  stem_down_x_offset?: number;
+  stem_up_x_offset?: number;
+  custom_glyph_code?: string;
+  x_shift?: number;
+  stem_direction?: number;
+  displaced?: boolean;
+  note_type?: string;
+  x?: number;
+  y?: number;
+  index?: number;
 }
 
 /**
@@ -116,7 +116,7 @@ export class NoteHead extends Note {
   protected index?: number;
   protected slashed: boolean;
 
-  constructor(noteStruct: Partial<NoteHeadStruct>) {
+  constructor(noteStruct: NoteHeadStruct) {
     super(noteStruct);
 
     this.index = noteStruct.index;
@@ -146,12 +146,10 @@ export class NoteHead extends Note {
 
     this.render_options = {
       ...this.render_options,
-      ...{
-        // font size for note heads
-        glyph_font_scale: noteStruct.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
-        // number of stroke px to the left and right of head
-        stroke_px: 3,
-      },
+      // font size for note heads
+      glyph_font_scale: noteStruct.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
+      // number of stroke px to the left and right of head
+      stroke_px: 3,
     };
 
     this.setWidth(this.glyph.getWidth(this.render_options.glyph_font_scale));

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -36,18 +36,17 @@ export class Renderer {
   static lastContext?: RenderContext = undefined;
 
   static buildContext(
-    elementId: string,
+    elementId: string | HTMLCanvasElement | HTMLDivElement,
     backend: number,
     width: number,
     height: number,
-    background?: string
+    background: string = '#FFF'
   ): RenderContext {
     const renderer = new Renderer(elementId, backend);
     if (width && height) {
       renderer.resize(width, height);
     }
 
-    if (!background) background = '#FFF';
     const ctx = renderer.getContext();
     ctx.setBackgroundFillStyle(background);
     Renderer.lastContext = ctx;
@@ -113,7 +112,7 @@ export class Renderer {
       throw new RuntimeError('BadArgument', 'Invalid id for renderer.');
     } else if (typeof canvasId === 'string') {
       this.elementId = canvasId;
-      this.element = document.getElementById(canvasId as string) as HTMLCanvasElement | HTMLDivElement;
+      this.element = document.getElementById(canvasId) as HTMLCanvasElement | HTMLDivElement;
     } else if ('getContext' in canvasId /* HTMLCanvasElement */) {
       this.element = canvasId as HTMLCanvasElement;
     } else {

--- a/src/repeatnote.ts
+++ b/src/repeatnote.ts
@@ -18,7 +18,7 @@ export class RepeatNote extends GlyphNote {
     return 'RepeatNote';
   }
 
-  constructor(type: string, noteStruct?: Partial<NoteStruct>, options?: GlyphNoteOptions) {
+  constructor(type: string, noteStruct?: NoteStruct, options?: GlyphNoteOptions) {
     super(undefined, { duration: 'q', align_center: type !== 'slash', ...noteStruct }, options);
 
     const glyphCode = CODES[type] || 'repeat1Bar';

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -338,7 +338,7 @@ export class Stave extends Element {
   setText(
     text: string,
     position: number,
-    options: {
+    options?: {
       shift_x: number;
       shift_y: number;
       justification: number;

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -19,30 +19,27 @@ import { Bounds, FontInfo } from './types/common';
 import { RuntimeError } from './util';
 
 export interface StaveLineConfig {
-  visible: boolean;
+  visible?: boolean;
 }
 
 export interface StaveOptions {
-  // [name: string]: any;
-  spacing: number;
-  thickness: number;
-  x_shift: number;
-  y_shift: number;
-  position_end?: number;
-  invert?: boolean;
+  spacing?: number;
+  thickness?: number;
+  x_shift?: number;
+  y_shift?: number;
   cps?: { x: number; y: number }[];
-  bottom_text_position: number;
-  line_config: Partial<StaveLineConfig>[];
-  space_below_staff_ln: number;
-  glyph_spacing_px: number;
-  space_above_staff_ln: number;
-  vertical_bar_width: number;
-  fill_style: string;
-  left_bar: boolean;
-  right_bar: boolean;
-  spacing_between_lines_px: number;
-  top_text_position: number;
-  num_lines: number;
+  bottom_text_position?: number;
+  line_config?: StaveLineConfig[];
+  space_below_staff_ln?: number;
+  glyph_spacing_px?: number;
+  space_above_staff_ln?: number;
+  vertical_bar_width?: number;
+  fill_style?: string;
+  left_bar?: boolean;
+  right_bar?: boolean;
+  spacing_between_lines_px?: number;
+  top_text_position?: number;
+  num_lines?: number;
 }
 
 // Used by Stave.format() to sort the modifiers at the beginning and end of a stave.
@@ -69,7 +66,7 @@ export class Stave extends Element {
 
   protected start_x: number;
   protected clef: string;
-  protected options: StaveOptions;
+  protected options: Required<StaveOptions>;
   protected endClef?: string;
 
   protected x: number;
@@ -99,7 +96,7 @@ export class Stave extends Element {
     return musicFont.lookupMetric('stave.endPaddingMax');
   }
 
-  constructor(x: number, y: number, width: number, options?: Partial<StaveOptions>) {
+  constructor(x: number, y: number, width: number, options?: StaveOptions) {
     super();
 
     this.x = x;
@@ -134,9 +131,10 @@ export class Stave extends Element {
       top_text_position: 1, // in staff lines
       bottom_text_position: 4, // in staff lines
       line_config: [],
+      cps: [],
+      ...options,
     };
     this.bounds = { x: this.x, y: this.y, w: this.width, h: 0 };
-    this.options = { ...this.options, ...options };
     this.defaultLedgerLineStyle = { strokeStyle: '#444', lineWidth: 1.4 };
 
     this.resetLines();
@@ -156,6 +154,7 @@ export class Stave extends Element {
   getDefaultLedgerLineStyle(): ElementStyle {
     return { ...this.getStyle(), ...this.defaultLedgerLineStyle };
   }
+
   space(spacing: number): number {
     return this.options.spacing_between_lines_px * spacing;
   }
@@ -169,7 +168,7 @@ export class Stave extends Element {
     this.options.bottom_text_position = this.options.num_lines;
   }
 
-  getOptions(): StaveOptions {
+  getOptions(): Required<StaveOptions> {
     return this.options;
   }
 
@@ -329,7 +328,7 @@ export class Stave extends Element {
   }
 
   // Tempo functions
-  setTempo(tempo: Partial<StaveTempoOptions>, y: number): this {
+  setTempo(tempo: StaveTempoOptions, y: number): this {
     this.modifiers.push(new StaveTempo(tempo, this.x, y));
     return this;
   }
@@ -338,11 +337,11 @@ export class Stave extends Element {
   setText(
     text: string,
     position: number,
-    options: Partial<{
-      shift_x: number;
-      shift_y: number;
-      justification: number;
-    }> = {}
+    options: {
+      shift_x?: number;
+      shift_y?: number;
+      justification?: number;
+    } = {}
   ): this {
     this.modifiers.push(new StaveText(text, position, options));
     return this;
@@ -815,7 +814,7 @@ export class Stave extends Element {
    * Get the current configuration for the Stave.
    * @return {Array} An array of configuration objects.
    */
-  getConfigForLines(): Partial<StaveLineConfig>[] {
+  getConfigForLines(): StaveLineConfig[] {
     return this.options.line_config;
   }
 
@@ -859,7 +858,7 @@ export class Stave extends Element {
    *   exactly the same number of elements as the num_lines configuration object set in
    *   the constructor.
    */
-  setConfigForLines(lines_configuration: Partial<StaveLineConfig>[]): this {
+  setConfigForLines(lines_configuration: StaveLineConfig[]): this {
     if (lines_configuration.length !== this.options.num_lines) {
       throw new RuntimeError(
         'StaveConfigError',

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -168,10 +168,6 @@ export class Stave extends Element {
     this.options.bottom_text_position = this.options.num_lines;
   }
 
-  getOptions(): Required<StaveOptions> {
-    return this.options;
-  }
-
   setNoteStartX(x: number): this {
     if (!this.formatted) this.format();
 
@@ -404,9 +400,7 @@ export class Stave extends Element {
     const options = this.options;
     const spacing = options.spacing_between_lines_px;
     const headroom = options.space_above_staff_ln;
-    const y = this.y + headroom * spacing + 5 * spacing - line * spacing;
-
-    return y;
+    return this.y + headroom * spacing + 5 * spacing - line * spacing;
   }
 
   getYForGlyphs(): number {
@@ -757,11 +751,12 @@ export class Stave extends Element {
 
     // Draw the modifiers (bar lines, coda, segno, repeat brackets, etc.)
     for (let i = 0; i < this.modifiers.length; i++) {
+      const modifier = this.modifiers[i];
       // Only draw modifier if it has a draw function
-      if (typeof this.modifiers[i].draw === 'function') {
-        this.modifiers[i].applyStyle(ctx);
-        this.modifiers[i].draw(this, this.getModifierXShift(i));
-        this.modifiers[i].restoreStyle(ctx);
+      if (typeof modifier.draw === 'function') {
+        modifier.applyStyle(ctx);
+        modifier.draw(this, this.getModifierXShift(i));
+        modifier.restoreStyle(ctx);
       }
     }
 
@@ -808,6 +803,10 @@ export class Stave extends Element {
       ctx.fillRect(x - 3, top_line, 1, bottom_line - top_line + 1);
     }
     ctx.fillRect(x, top_line, 1, bottom_line - top_line + 1);
+  }
+
+  getVerticalBarWidth(): number {
+    return this.options.vertical_bar_width;
   }
 
   /**

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -264,7 +264,7 @@ export class Stave extends Element {
       fillStyle: this.options.fill_style,
       strokeStyle: this.options.fill_style, // yes, this is correct for legacy compatibility
       lineWidth: Flow.STAVE_LINE_THICKNESS,
-      ...(this.style || {}),
+      ...this.style,
     };
   }
 
@@ -279,7 +279,7 @@ export class Stave extends Element {
    * @param  {Number} index The index from which to determine the shift
    * @return {Number}       The amount of pixels shifted
    */
-  getModifierXShift(index = 0): number {
+  getModifierXShift(index: number = 0): number {
     if (typeof index !== 'number') {
       throw new RuntimeError('InvalidIndex', 'Must be of number type');
     }

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -129,10 +129,10 @@ export class StaveConnector extends Element {
   /** Set optional associated Text. */
   setText(
     text: string,
-    options?: {
+    options: Partial<{
       shift_x: number;
       shift_y: number;
-    }
+    }> = {}
   ): this {
     this.texts.push({
       content: text,

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -127,23 +127,16 @@ export class StaveConnector extends Element {
   }
 
   /** Set optional associated Text. */
-  setText(
-    text: string,
-    options: Partial<{
-      shift_x: number;
-      shift_y: number;
-    }> = {}
-  ): this {
+  setText(text: string, options: { shift_x?: number; shift_y?: number } = {}): this {
     this.texts.push({
       content: text,
-      options: { ...{ shift_x: 0, shift_y: 0 }, ...options },
+      options: {
+        shift_x: 0,
+        shift_y: 0,
+        ...options,
+      },
     });
     return this;
-  }
-
-  /** Set text font. */
-  setFont(font: FontInfo): void {
-    this.font = { ...this.font, ...font };
   }
 
   /** Set connector x shift. */

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -52,14 +52,14 @@ export interface StaveNoteFormatSettings {
 }
 
 export interface StaveNoteStruct extends NoteStruct {
-  stem_down_x_offset?: number;
-  stem_up_x_offset?: number;
-  stroke_px?: number;
-  glyph_font_scale?: number;
-  stem_direction?: number;
-  auto_stem?: boolean;
-  octave_shift?: number;
-  clef?: string;
+  stem_down_x_offset: number;
+  stem_up_x_offset: number;
+  stroke_px: number;
+  glyph_font_scale: number;
+  stem_direction: number;
+  auto_stem: boolean;
+  octave_shift: number;
+  clef: string;
 }
 
 // To enable logging for this class. Set `Vex.Flow.StaveNote.DEBUG` to `true`.

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -52,14 +52,15 @@ export interface StaveNoteFormatSettings {
 }
 
 export interface StaveNoteStruct extends NoteStruct {
-  stem_down_x_offset: number;
-  stem_up_x_offset: number;
-  stroke_px: number;
-  glyph_font_scale: number;
-  stem_direction: number;
-  auto_stem: boolean;
-  octave_shift: number;
-  clef: string;
+  /** `Stem.UP` or `Stem.DOWN`. */
+  stem_direction?: number;
+  auto_stem?: boolean;
+  stem_down_x_offset?: number;
+  stem_up_x_offset?: number;
+  stroke_px?: number;
+  glyph_font_scale?: number;
+  octave_shift?: number;
+  clef?: string;
 }
 
 // To enable logging for this class. Set `Vex.Flow.StaveNote.DEBUG` to `true`.
@@ -373,7 +374,7 @@ export class StaveNote extends StemmableNote {
     return true;
   }
 
-  constructor(noteStruct: Partial<StaveNoteStruct>) {
+  constructor(noteStruct: StaveNoteStruct) {
     super(noteStruct);
 
     this.ledgerLineStyle = {};
@@ -397,12 +398,10 @@ export class StaveNote extends StemmableNote {
 
     this.render_options = {
       ...this.render_options,
-      ...{
-        // font size for note heads and rests
-        glyph_font_scale: noteStruct.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
-        // number of stroke px to the left and right of head
-        stroke_px: noteStruct.stroke_px || StaveNote.DEFAULT_LEDGER_LINE_OFFSET,
-      },
+      // font size for note heads and rests
+      glyph_font_scale: noteStruct.glyph_font_scale || Flow.DEFAULT_NOTATION_FONT_SCALE,
+      // number of stroke px to the left and right of head
+      stroke_px: noteStruct.stroke_px || StaveNote.DEFAULT_LEDGER_LINE_OFFSET,
     };
 
     this.calculateKeyProps();

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -123,7 +123,7 @@ export class Repetition extends StaveModifier {
     let symbol_x = x + this.x_shift;
     if (this.symbol_type === Repetition.type.CODA_LEFT) {
       // Offset Coda text to right of stave beginning
-      text_x = this.x + stave.getOptions().vertical_bar_width;
+      text_x = this.x + stave.getVerticalBarWidth();
       symbol_x = text_x + ctx.measureText(text).width + 12;
     } else if (this.symbol_type === Repetition.type.DS) {
       const modifierWidth = stave.getNoteStartX() - this.x;

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -4,14 +4,14 @@
 import { Flow } from './flow';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Glyph } from './glyph';
-import { FontInfo } from './types/common';
 import { Stave } from './stave';
+import { FontInfo } from 'types/common';
 
 export interface StaveTempoOptions {
-  bpm: number;
-  dots: number;
-  duration: string;
-  name: string;
+  bpm?: number;
+  duration?: string;
+  dots?: number;
+  name?: string;
 }
 
 export class StaveTempo extends StaveModifier {
@@ -20,15 +20,13 @@ export class StaveTempo extends StaveModifier {
   }
 
   protected font: FontInfo;
-  protected render_options: {
-    glyph_font_scale: number;
-  };
-
-  protected tempo: Partial<StaveTempoOptions>;
+  /** Font size for note. */
+  protected render_options = { glyph_font_scale: 30 };
+  protected tempo: StaveTempoOptions;
   protected shift_x: number;
   protected shift_y: number;
 
-  constructor(tempo: Partial<StaveTempoOptions>, x: number, shift_y: number) {
+  constructor(tempo: StaveTempoOptions, x: number, shift_y: number) {
     super();
 
     this.tempo = tempo;
@@ -40,9 +38,6 @@ export class StaveTempo extends StaveModifier {
       family: 'times',
       size: 14,
       weight: 'bold',
-    };
-    this.render_options = {
-      glyph_font_scale: 30, // font size for note
     };
   }
 

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -24,11 +24,11 @@ export class StaveTempo extends StaveModifier {
     glyph_font_scale: number;
   };
 
-  protected tempo: StaveTempoOptions;
+  protected tempo: Partial<StaveTempoOptions>;
   protected shift_x: number;
   protected shift_y: number;
 
-  constructor(tempo: StaveTempoOptions, x: number, shift_y: number) {
+  constructor(tempo: Partial<StaveTempoOptions>, x: number, shift_y: number) {
     super();
 
     this.tempo = tempo;
@@ -71,7 +71,7 @@ export class StaveTempo extends StaveModifier {
     const scale = options.glyph_font_scale / 38;
     const name = this.tempo.name;
     const duration = this.tempo.duration;
-    const dots = this.tempo.dots;
+    const dots = this.tempo.dots || 0;
     const bpm = this.tempo.bpm;
     const font = this.font;
     let x = this.x + this.shift_x + shift_x;

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -4,14 +4,17 @@
 import { RuntimeError } from './util';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Justification, TextNote } from './textnote';
-import { FontInfo } from './types/common';
 import { Stave } from './stave';
+import { FontInfo } from 'types/common';
 
 export class StaveText extends StaveModifier {
   static get CATEGORY(): string {
     return 'StaveText';
   }
 
+  protected text: string;
+  protected shift_x?: number;
+  protected shift_y?: number;
   protected options: {
     shift_x: number;
     shift_y: number;
@@ -19,18 +22,10 @@ export class StaveText extends StaveModifier {
   };
   protected font: FontInfo;
 
-  protected text: string;
-  protected shift_x?: number;
-  protected shift_y?: number;
-
   constructor(
     text: string,
     position: number,
-    options: Partial<{
-      shift_x: number;
-      shift_y: number;
-      justification: number;
-    }> = {}
+    options: { shift_x?: number; shift_y?: number; justification?: number } = {}
   ) {
     super();
 
@@ -41,8 +36,8 @@ export class StaveText extends StaveModifier {
       shift_x: 0,
       shift_y: 0,
       justification: TextNote.Justification.CENTER,
+      ...options,
     };
-    this.options = { ...this.options, ...options };
 
     this.font = {
       family: 'times',

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -26,7 +26,7 @@ export class StaveText extends StaveModifier {
   constructor(
     text: string,
     position: number,
-    options: {
+    options?: {
       shift_x: number;
       shift_y: number;
       justification: number;

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -26,11 +26,11 @@ export class StaveText extends StaveModifier {
   constructor(
     text: string,
     position: number,
-    options?: {
+    options: Partial<{
       shift_x: number;
       shift_y: number;
       justification: number;
-    }
+    }> = {}
   ) {
     super();
 

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -51,8 +51,8 @@ export class Volta extends StaveModifier {
     this.setRendered();
 
     let width = stave.getWidth() - x; // don't include x (offset) for width
-    const top_y = stave.getYForTopText(stave.getOptions().num_lines) + this.y_shift;
-    const vert_height = 1.5 * stave.getOptions().spacing_between_lines_px;
+    const top_y = stave.getYForTopText(stave.getNumLines()) + this.y_shift;
+    const vert_height = 1.5 * stave.getSpacingBetweenLines();
     switch (this.volta) {
       case VoltaType.BEGIN:
         ctx.fillRect(this.x + x, top_y, 1, vert_height);

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -22,7 +22,7 @@ export abstract class StemmableNote extends Note {
   protected flag?: Glyph;
   protected stem_extension_override?: number;
 
-  constructor(noteStruct: Partial<NoteStruct>) {
+  constructor(noteStruct: NoteStruct) {
     super(noteStruct);
   }
 

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -173,7 +173,7 @@ export class StringNumber extends Modifier {
     const note = this.checkAttachedNote();
     this.setRendered();
 
-    const line_space = note.checkStave().getOptions().spacing_between_lines_px;
+    const line_space = note.checkStave().getSpacingBetweenLines();
 
     const start = note.getModifierStartXY(this.position, this.index);
     let dot_x = start.x + this.x_shift + this.x_offset;

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -126,7 +126,7 @@ export class Stroke extends Modifier {
     let topY = start.y;
     let botY = start.y;
     const x = start.x - 5;
-    const line_space = note.checkStave().getOptions().spacing_between_lines_px;
+    const line_space = note.checkStave().getSpacingBetweenLines();
 
     const notes = this.checkModifierContext().getMembers(note.getCategory());
     for (let i = 0; i < notes.length; i++) {

--- a/src/system.ts
+++ b/src/system.ts
@@ -39,18 +39,17 @@ export interface SystemParams {
  */
 export interface SystemOptions {
   factory?: Factory;
-  noPadding: boolean;
-  debugFormatter: boolean;
-  connector?: StaveConnector;
-  spaceBetweenStaves: number;
-  formatIterations: number;
-  autoWidth: boolean;
-  x: number;
-  width: number;
-  y: number;
-  details: SystemFormatterOptions;
-  formatOptions: FormatOptions;
-  noJustification: boolean;
+  noPadding?: boolean;
+  debugFormatter?: boolean;
+  spaceBetweenStaves?: number;
+  formatIterations?: number;
+  autoWidth?: boolean;
+  x?: number;
+  width?: number;
+  y?: number;
+  details?: SystemFormatterOptions;
+  formatOptions?: FormatOptions;
+  noJustification?: boolean;
 }
 
 /**
@@ -63,7 +62,7 @@ export class System extends Element {
     return 'System';
   }
 
-  protected options!: SystemOptions;
+  protected options!: Required<SystemOptions>;
   protected factory!: Factory;
   protected formatter?: Formatter;
   protected startX?: number;
@@ -80,7 +79,9 @@ export class System extends Element {
 
   /** Set formatting options. */
   setOptions(options: Partial<SystemOptions> = {}): void {
+    this.factory = options.factory ?? new Factory({ renderer: { elementId: null, width: 0, height: 0 } });
     this.options = {
+      factory: this.factory,
       x: 10,
       y: 10,
       width: 500,
@@ -99,11 +100,10 @@ export class System extends Element {
         ...options.formatOptions,
       },
     };
+
     if (this.options.noJustification === false && typeof options.width === 'undefined') {
       this.options.autoWidth = true;
     }
-
-    this.factory = this.options.factory || new Factory({ renderer: { elementId: null, width: 0, height: 0 } });
   }
 
   /** Set associated context. */

--- a/src/system.ts
+++ b/src/system.ts
@@ -12,12 +12,9 @@ import { RenderContext } from './types/common';
 import { RuntimeError } from './util';
 import { Voice } from './voice';
 
-interface FormatterTuneOptions {
+export interface SystemFormatterOptions extends FormatterOptions {
   alpha?: number;
 }
-
-// SystemFormatterOptions is a combination of two interfaces, with no additional fields.
-export interface SystemFormatterOptions extends FormatterTuneOptions, FormatterOptions {}
 
 export interface SystemParams {
   voices: Voice[];

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -30,6 +30,7 @@ export interface TabNotePosition {
 export interface TabNoteStruct extends StaveNoteStruct {
   positions: TabNotePosition[];
 }
+
 // Gets the unused strings grouped together if consecutive.
 //
 // Parameters:
@@ -131,9 +132,9 @@ export class TabNote extends StemmableNote {
   protected glyphs: GlyphProps[] = [];
   protected positions: TabNotePosition[];
 
-  // Initialize the TabNote with a `tab_struct` full of properties
+  // Initialize the TabNote with a `noteStruct` full of properties
   // and whether to `draw_stem` when rendering the note
-  constructor(noteStruct: Partial<TabNoteStruct>, draw_stem?: boolean) {
+  constructor(noteStruct: TabNoteStruct, draw_stem: boolean = false) {
     super(noteStruct);
 
     this.ghost = false; // Renders parenthesis around notes
@@ -145,22 +146,20 @@ export class TabNote extends StemmableNote {
     // Render Options
     this.render_options = {
       ...this.render_options,
-      ...{
-        // font size for note heads and rests
-        glyph_font_scale: Flow.DEFAULT_TABLATURE_FONT_SCALE,
-        // Flag to draw a stem
-        draw_stem,
-        // Flag to draw dot modifiers
-        draw_dots: draw_stem,
-        // Flag to extend the main stem through the stave and fret positions
-        draw_stem_through_stave: false,
-        // vertical shift from stave line
-        y_shift: 0,
-        // normal glyph scale
-        scale: 1.0,
-        // default tablature font
-        font: '10pt Arial',
-      },
+      // font size for note heads and rests
+      glyph_font_scale: Flow.DEFAULT_TABLATURE_FONT_SCALE,
+      // Flag to draw a stem
+      draw_stem,
+      // Flag to draw dot modifiers
+      draw_dots: draw_stem,
+      // Flag to extend the main stem through the stave and fret positions
+      draw_stem_through_stave: false,
+      // vertical shift from stave line
+      y_shift: 0,
+      // normal glyph scale
+      scale: 1.0,
+      // default tablature font
+      font: '10pt Arial',
     };
 
     this.glyph = Flow.getGlyphProps(this.duration, this.noteType);
@@ -253,7 +252,7 @@ export class TabNote extends StemmableNote {
         const text = '' + glyph.text;
         if (text.toUpperCase() !== 'X') {
           ctx.save();
-          ctx.setRawFont(this.render_options.font as string);
+          ctx.setRawFont(this.render_options.font);
           glyph.width = ctx.measureText(text).width;
           ctx.restore();
           glyph.getWidth = () => glyph.width;

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -133,14 +133,14 @@ export class TabNote extends StemmableNote {
 
   // Initialize the TabNote with a `tab_struct` full of properties
   // and whether to `draw_stem` when rendering the note
-  constructor(tab_struct: TabNoteStruct, draw_stem?: boolean) {
-    super(tab_struct);
+  constructor(noteStruct: Partial<TabNoteStruct>, draw_stem?: boolean) {
+    super(noteStruct);
 
     this.ghost = false; // Renders parenthesis around notes
 
     // Note properties
     // The fret positions in the note. An array of `{ str: X, fret: X }`
-    this.positions = tab_struct.positions;
+    this.positions = noteStruct.positions || [];
 
     // Render Options
     this.render_options = {
@@ -168,8 +168,8 @@ export class TabNote extends StemmableNote {
 
     this.buildStem();
 
-    if (tab_struct.stem_direction) {
-      this.setStemDirection(tab_struct.stem_direction);
+    if (noteStruct.stem_direction) {
+      this.setStemDirection(noteStruct.stem_direction);
     } else {
       this.setStemDirection(Stem.UP);
     }

--- a/src/tabstave.ts
+++ b/src/tabstave.ts
@@ -7,7 +7,7 @@ export class TabStave extends Stave {
     return 'TabStave';
   }
 
-  constructor(x: number, y: number, width: number, options?: Partial<StaveOptions>) {
+  constructor(x: number, y: number, width: number, options?: StaveOptions) {
     const tab_options = {
       spacing_between_lines_px: 13,
       num_lines: 6,

--- a/src/tabstave.ts
+++ b/src/tabstave.ts
@@ -9,11 +9,9 @@ export class TabStave extends Stave {
 
   constructor(x: number, y: number, width: number, options?: Partial<StaveOptions>) {
     const tab_options = {
-      ...{
-        spacing_between_lines_px: 13,
-        num_lines: 6,
-        top_text_position: 1,
-      },
+      spacing_between_lines_px: 13,
+      num_lines: 6,
+      top_text_position: 1,
       ...options,
     };
 

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -139,7 +139,7 @@ export class TextBracket extends Element {
   }
 
   // Set the font for the text
-  setFont(font: Partial<FontInfo>): this {
+  setFont(font: FontInfo): this {
     // We use Object.assign to support partial updates to the font object
     this.font = { ...this.font, ...font };
     return this;

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -70,10 +70,10 @@ export class TextDynamics extends Note {
    * @param noteStruct an object that contains a `duration` property and a
    * `sequence` of letters that represents the letters to render.
    */
-  constructor(noteStruct: TextNoteStruct) {
+  constructor(noteStruct: Partial<TextNoteStruct>) {
     super(noteStruct);
 
-    this.sequence = noteStruct.text.toLowerCase();
+    this.sequence = (noteStruct.text || '').toLowerCase();
     this.line = noteStruct.line || 0;
     this.glyphs = [];
 

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -70,17 +70,14 @@ export class TextDynamics extends Note {
    * @param noteStruct an object that contains a `duration` property and a
    * `sequence` of letters that represents the letters to render.
    */
-  constructor(noteStruct: Partial<TextNoteStruct>) {
+  constructor(noteStruct: TextNoteStruct) {
     super(noteStruct);
 
     this.sequence = (noteStruct.text || '').toLowerCase();
     this.line = noteStruct.line || 0;
     this.glyphs = [];
 
-    this.render_options = {
-      ...this.render_options,
-      glyph_font_size: 40,
-    };
+    this.render_options = { ...this.render_options, glyph_font_size: 40 };
 
     L('New Dynamics Text: ', this.sequence);
   }

--- a/src/textfont.ts
+++ b/src/textfont.ts
@@ -180,6 +180,9 @@ export class TextFont {
     let selectedFont = undefined;
     const fallback = TextFont.fontRegistry[0];
     let candidates: TextFontRegistry[] = [];
+    if (!fd.family) {
+      fd.family = 'Arial';
+    }
     const families = fd.family.split(',');
     for (i = 0; i < families.length; ++i) {
       const famliy = families[i];

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -13,13 +13,13 @@ export enum Justification {
 }
 
 export interface TextNoteStruct extends NoteStruct {
-  ignore_ticks: boolean;
-  smooth: boolean;
-  glyph: string;
-  font: FontInfo;
-  subscript: string;
-  superscript: string;
-  text: string;
+  text?: string;
+  glyph?: string;
+  ignore_ticks?: boolean;
+  smooth?: boolean;
+  font?: FontInfo;
+  subscript?: string;
+  superscript?: string;
 }
 
 /**
@@ -108,36 +108,35 @@ export class TextNote extends Note {
     };
   }
 
-  constructor(noteStruct: Partial<TextNoteStruct>) {
+  constructor(noteStruct: TextNoteStruct) {
     super(noteStruct);
 
-    // Note properties
     this.text = noteStruct.text || '';
     this.superscript = noteStruct.superscript;
     this.subscript = noteStruct.subscript;
-    this.glyph = undefined;
     this.font = {
       family: 'Arial',
       size: 12,
       weight: '',
       ...noteStruct.font,
     };
+    this.line = noteStruct.line || 0;
+    this.smooth = noteStruct.smooth || false;
+    this.ignore_ticks = noteStruct.ignore_ticks || false;
+    this.justification = Justification.LEFT;
 
     // Determine and set initial note width. Note that the text width is
     // an approximation and isn't very accurate. The only way to accurately
-    // measure the length of text is with `canvasmeasureText()`
+    // measure the length of text is with `CanvasRenderingContext2D.measureText()`.
     if (noteStruct.glyph) {
       const struct = TextNote.GLYPHS[noteStruct.glyph];
       if (!struct) throw new RuntimeError('Invalid glyph type: ' + noteStruct.glyph);
 
       this.glyph = new Glyph(struct.code, 40, { category: 'textNote' });
       this.setWidth(this.glyph.getMetrics().width);
+    } else {
+      this.glyph = undefined;
     }
-
-    this.line = noteStruct.line || 0;
-    this.smooth = noteStruct.smooth || false;
-    this.ignore_ticks = noteStruct.ignore_ticks || false;
-    this.justification = TextNote.Justification.LEFT;
   }
 
   /** Set the horizontal justification of the TextNote. */

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -13,12 +13,12 @@ export enum Justification {
 }
 
 export interface TextNoteStruct extends NoteStruct {
-  ignore_ticks?: boolean;
-  smooth?: boolean;
-  glyph?: string;
-  font?: FontInfo;
-  subscript?: string;
-  superscript?: string;
+  ignore_ticks: boolean;
+  smooth: boolean;
+  glyph: string;
+  font: FontInfo;
+  subscript: string;
+  superscript: string;
   text: string;
 }
 
@@ -108,11 +108,11 @@ export class TextNote extends Note {
     };
   }
 
-  constructor(noteStruct: TextNoteStruct) {
+  constructor(noteStruct: Partial<TextNoteStruct>) {
     super(noteStruct);
 
     // Note properties
-    this.text = noteStruct.text;
+    this.text = noteStruct.text || '';
     this.superscript = noteStruct.superscript;
     this.subscript = noteStruct.subscript;
     this.glyph = undefined;

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -96,13 +96,13 @@ export class Tuplet extends Element {
     return 15;
   }
 
-  constructor(notes: Note[], options?: TupletOptions) {
+  constructor(notes: Note[], options: TupletOptions = {}) {
     super();
     if (!notes || !notes.length) {
       throw new RuntimeError('BadArguments', 'No notes provided for tuplet.');
     }
 
-    this.options = { ...options };
+    this.options = options;
     this.notes = notes;
     this.num_notes = this.options.num_notes != undefined ? this.options.num_notes : notes.length;
 

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -80,14 +80,17 @@ export interface RenderContext {
   bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): this;
   quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): this;
   arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, antiClockwise: boolean): this;
+  // eslint-disable-next-line
   fill(attributes?: any): this;
   stroke(): this;
   closePath(): this;
   fillText(text: string, x: number, y: number): this;
   save(): this;
   restore(): this;
+  // eslint-disable-next-line
   openGroup(cls: string, id?: string, attrs?: { pointerBBox: boolean }): any;
   closeGroup(): void;
+  // eslint-disable-next-line
   add(child: any): void;
 
   measureText(text: string): TextMeasure;

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -1,9 +1,11 @@
 import { Note } from '../note';
 
 export interface FontInfo {
-  size: number;
-  weight: string;
   family: string;
+  size: number;
+  /** `bold` or a numeric string '900' as inspired by CSS font-weight. */
+  weight: string;
+  /** `italic` as inspired by CSS font-style. */
   style?: string;
 }
 

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -57,7 +57,7 @@ export interface TypeProps extends KeyProps {
 
 export interface RenderContext {
   clear(): void;
-  setFont(family: string, size: number, weight: string): this;
+  setFont(family: string, size: number, weight: string = ''): this;
   setRawFont(font: string): this;
   setFillStyle(style: string): this;
   setBackgroundFillStyle(style: string): this;

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -41,21 +41,21 @@ export class Voice extends Element {
     return VoiceMode;
   }
 
-  protected resolutionMultiplier: number;
+  protected resolutionMultiplier: number = 1;
   protected smallestTickCount: Fraction;
   protected stave?: Stave;
-  protected mode: VoiceMode;
+  protected mode: VoiceMode = VoiceMode.STRICT;
   protected expTicksUsed?: number;
   protected preFormatted?: boolean;
   protected options: { softmaxFactor: number };
 
   protected readonly totalTicks: Fraction;
-  protected readonly ticksUsed: Fraction;
-  protected readonly largestTickWidth: number;
-  protected readonly tickables: Tickable[];
-  protected readonly time: VoiceTime;
+  protected readonly ticksUsed: Fraction = new Fraction(0, 1);
+  protected readonly largestTickWidth: number = 0;
+  protected readonly tickables: Tickable[] = [];
+  protected readonly time: Required<VoiceTime>;
 
-  constructor(time?: Partial<VoiceTime> | string, options?: { softmaxFactor: number }) {
+  constructor(time?: VoiceTime | string, options?: { softmaxFactor: number }) {
     super();
 
     this.options = {
@@ -63,40 +63,32 @@ export class Voice extends Element {
       ...options,
     };
 
-    // Time signature shortcut: "4/4", "3/8", etc.
+    // Convert the `time` string into a VoiceTime object if necessary.
+    let voiceTime: VoiceTime | undefined;
     if (typeof time === 'string') {
+      // Time signature shortcut: "4/4", "3/8", etc.
       const match = time.match(/(\d+)\/(\d+)/);
       if (match) {
-        time = {
+        voiceTime = {
           num_beats: parseInt(match[1]),
           beat_value: parseInt(match[2]),
-          resolution: Flow.RESOLUTION,
         };
       }
+    } else {
+      voiceTime = time;
     }
 
-    // Default time sig is 4/4
+    // Default time signature is 4/4.
     this.time = {
-      ...{
-        num_beats: 4,
-        beat_value: 4,
-        resolution: Flow.RESOLUTION,
-      },
-      ...(time as VoiceTime),
+      num_beats: 4,
+      beat_value: 4,
+      resolution: Flow.RESOLUTION,
+      ...voiceTime,
     };
 
     // Recalculate total ticks.
-    this.totalTicks = new Fraction(this.time.num_beats * ((this.time.resolution as number) / this.time.beat_value), 1);
-
-    this.resolutionMultiplier = 1;
-
-    // Set defaults
-    this.tickables = [];
-    this.ticksUsed = new Fraction(0, 1);
+    this.totalTicks = new Fraction(this.time.num_beats * (this.time.resolution / this.time.beat_value), 1);
     this.smallestTickCount = this.totalTicks.clone();
-    this.largestTickWidth = 0;
-    // Do we care about strictly timed notes
-    this.mode = Voice.Mode.STRICT;
   }
 
   /** Get the total ticks in the voice. */
@@ -131,7 +123,7 @@ export class Voice extends Element {
 
   /**
    * Set the voice mode.
-   * @param mode value from `Voice.Mode`
+   * @param mode value from `VoiceMode`
    */
   setMode(mode: number): this {
     this.mode = mode;
@@ -145,7 +137,7 @@ export class Voice extends Element {
 
   /** Get the actual tick resolution for the voice. */
   getActualResolution(): number {
-    return this.resolutionMultiplier * (this.time.resolution as number);
+    return this.resolutionMultiplier * this.time.resolution;
   }
 
   /** Set the voice's stave. */
@@ -180,13 +172,13 @@ export class Voice extends Element {
 
   /** Set the voice mode to strict or soft. */
   setStrict(strict: boolean): this {
-    this.mode = strict ? Voice.Mode.STRICT : Voice.Mode.SOFT;
+    this.mode = strict ? VoiceMode.STRICT : VoiceMode.SOFT;
     return this;
   }
 
   /** Determine if the voice is complete according to the voice mode. */
   isComplete(): boolean {
-    if (this.mode === Voice.Mode.STRICT || this.mode === Voice.Mode.FULL) {
+    if (this.mode === VoiceMode.STRICT || this.mode === VoiceMode.FULL) {
       return this.ticksUsed.equals(this.totalTicks);
     } else {
       return true;
@@ -238,7 +230,7 @@ export class Voice extends Element {
       this.expTicksUsed = 0; // reset
 
       if (
-        (this.mode === Voice.Mode.STRICT || this.mode === Voice.Mode.FULL) &&
+        (this.mode === VoiceMode.STRICT || this.mode === VoiceMode.FULL) &&
         this.ticksUsed.greaterThan(this.totalTicks)
       ) {
         this.ticksUsed.subtract(ticks);

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -13,7 +13,8 @@ import { Tickable } from './tickable';
 export interface VoiceTime {
   num_beats: number;
   beat_value: number;
-  resolution: number;
+  /** Defaults to `Flow.RESOLUTION` if not provided. */
+  resolution?: number;
 }
 
 export enum VoiceMode {
@@ -85,7 +86,7 @@ export class Voice extends Element {
     };
 
     // Recalculate total ticks.
-    this.totalTicks = new Fraction(this.time.num_beats * (this.time.resolution / this.time.beat_value), 1);
+    this.totalTicks = new Fraction(this.time.num_beats * ((this.time.resolution as number) / this.time.beat_value), 1);
 
     this.resolutionMultiplier = 1;
 
@@ -144,7 +145,7 @@ export class Voice extends Element {
 
   /** Get the actual tick resolution for the voice. */
   getActualResolution(): number {
-    return this.resolutionMultiplier * this.time.resolution;
+    return this.resolutionMultiplier * (this.time.resolution as number);
   }
 
   /** Set the voice's stave. */

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -59,7 +59,7 @@ function makeNewAccid(factory: Factory) {
  *
  */
 function autoAccidentalWorking(): void {
-  const createStaveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
+  const createStaveNote = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
 
   let notes = [
     { keys: ['bb/4'], duration: '4' },

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -59,7 +59,7 @@ function makeNewAccid(factory: Factory) {
  *
  */
 function autoAccidentalWorking(): void {
-  const createStaveNote = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
+  const createStaveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
 
   let notes = [
     { keys: ['bb/4'], duration: '4' },

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -43,8 +43,8 @@ const AnnotationTests = {
 const FONT_SIZE = VexFlowTests.Font.size;
 
 // Helper functions to create TabNote and StaveNote objects.
-const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
-const staveNote = (struct: StaveNoteStruct) => new StaveNote(struct);
+const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const staveNote = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
 
 /**
  * Show lyrics using Annotation objects.

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -43,8 +43,8 @@ const AnnotationTests = {
 const FONT_SIZE = VexFlowTests.Font.size;
 
 // Helper functions to create TabNote and StaveNote objects.
-const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
-const staveNote = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
+const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
+const staveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
 
 /**
  * Show lyrics using Annotation objects.

--- a/tests/bach_tests.ts
+++ b/tests/bach_tests.ts
@@ -8,6 +8,7 @@ import { Factory } from 'factory';
 import { Registry } from 'registry';
 import { BarlineType } from 'stavebarline';
 import { StaveNote } from 'stavenote';
+import { EasyScoreOptions } from 'easyscore';
 
 const BachDemoTests = {
   Start(): void {
@@ -24,7 +25,7 @@ function minuet1(options: TestOptions): void {
   const id = (id: string) => registry.getElementById(id) as StaveNote;
 
   const f: Factory = VexFlowTests.makeFactory(options, 1100, 900);
-  const score = f.EasyScore({ throwOnError: true });
+  const score = f.EasyScore({ throwOnError: true } as EasyScoreOptions);
 
   // Bind these three functions so the code looks cleaner.
   // Instead of score.voice(...), just call voice(...).

--- a/tests/bach_tests.ts
+++ b/tests/bach_tests.ts
@@ -8,7 +8,6 @@ import { Factory } from 'factory';
 import { Registry } from 'registry';
 import { BarlineType } from 'stavebarline';
 import { StaveNote } from 'stavenote';
-import { EasyScoreOptions } from 'easyscore';
 
 const BachDemoTests = {
   Start(): void {
@@ -25,7 +24,7 @@ function minuet1(options: TestOptions): void {
   const id = (id: string) => registry.getElementById(id) as StaveNote;
 
   const f: Factory = VexFlowTests.makeFactory(options, 1100, 900);
-  const score = f.EasyScore({ throwOnError: true } as EasyScoreOptions);
+  const score = f.EasyScore({ throwOnError: true });
 
   // Bind these three functions so the code looks cleaner.
   // Instead of score.voice(...), just call voice(...).

--- a/tests/barline_tests.ts
+++ b/tests/barline_tests.ts
@@ -3,11 +3,6 @@
 //
 // Barline Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Factory.BarNote()'s type argument expects BarlineType, but we pass in string. Did the previous API allow string?
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { Barline, BarlineType } from 'stavebarline';
 
@@ -33,7 +28,7 @@ function simple(options: TestOptions): void {
 
   const notes = [
     f.StaveNote({ keys: ['d/4', 'e/4', 'f/4'], stem_direction: -1, duration: '2' }),
-    f.BarNote({ type: 'single' }), // => f.BarNote({ type: BarlineType.SINGLE })
+    f.BarNote({ type: 'single' }),
     f
       .StaveNote({ keys: ['c/4', 'f/4', 'a/4'], stem_direction: -1, duration: '2' })
       .addAccidental(0, f.Accidental({ type: 'n' }))
@@ -53,7 +48,7 @@ function style(options: TestOptions): void {
 
   const notes = [
     f.StaveNote({ keys: ['d/4', 'e/4', 'f/4'], stem_direction: -1, duration: '2' }),
-    f.BarNote({ type: 'single' }), // => f.BarNote({ type: BarlineType.SINGLE })
+    f.BarNote({ type: 'single' }),
     f
       .StaveNote({ keys: ['c/4', 'f/4', 'a/4'], stem_direction: -1, duration: '2' })
       .addAccidental(0, f.Accidental({ type: 'n' }))

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -27,7 +27,7 @@ const BendTests = {
 };
 
 // Helper functions for creating TabNote and Bend objects.
-const note = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const note = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 const bendWithText = (text: string, release = false) => new Bend(text, release);
 const bendWithPhrase = (phrase: BendPhrase[]) => new Bend('', false, phrase);
 

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -3,11 +3,6 @@
 //
 // Bend Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: ctx.setFont()'s 3rd argument "weight" should be optional, and default to ''.
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { ContextBuilder } from 'renderer';
 import { Bend, BendPhrase } from 'bend';
@@ -32,7 +27,7 @@ const BendTests = {
 };
 
 // Helper functions for creating TabNote and Bend objects.
-const note = (struct: TabNoteStruct) => new TabNote(struct);
+const note = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
 const bendWithText = (text: string, release = false) => new Bend(text, release);
 const bendWithPhrase = (phrase: BendPhrase[]) => new Bend('', false, phrase);
 

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -3,11 +3,6 @@
 //
 // ChordSymbol Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// ChordSymbol methods addGlyphOrText(), addLine(), addText()) need their second arguments to be optional.
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { Accidental } from 'accidental';
 import { ChordSymbol } from 'chordsymbol';
@@ -243,7 +238,7 @@ function topJustify(options: TestOptions): void {
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
 
-  function draw(chord1: ChordSymbol, chord2: ChordSymbol, y) {
+  function draw(chord1: ChordSymbol, chord2: ChordSymbol, y: number) {
     const stave = new Stave(10, y, 450).addClef('treble').setContext(ctx).draw();
 
     const notes = [

--- a/tests/factory_tests.ts
+++ b/tests/factory_tests.ts
@@ -28,7 +28,9 @@ function defaults(): void {
     renderer: { elementId: null, width: 700, height: 500 },
   });
 
-  const options = factory.getOptions();
+  // eslint-disable-next-line
+  // @ts-ignore access a protected member for testing purposes.
+  const options = factory.options;
   equal(options.renderer.width, 700);
   equal(options.renderer.height, 500);
   equal(options.renderer.elementId, null);

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -3,11 +3,6 @@
 //
 // Formatter Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: SystemOptions.details might need to be typed as Partial<SystemFormatterOptions>
-
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Annotation } from 'annotation';
 import { Beam } from 'beam';
@@ -456,7 +451,7 @@ function proportional(options: TestOptions): void {
     debugFormatter: debug,
     noJustification: !(options.params.justify === undefined && true),
     formatIterations: options.params.iterations,
-    options: { alpha: options.params.alpha },
+    details: { alpha: options.params.alpha },
   });
 
   const score = f.EasyScore();

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -161,7 +161,7 @@ const createNoteForStemTest = (
   stem_direction: number,
   slash: boolean = false
 ): StaveNote => {
-  const struct: Partial<GraceNoteStruct> | Partial<StaveNoteStruct> = { duration, slash };
+  const struct: GraceNoteStruct | StaveNoteStruct = { duration, slash };
   struct.stem_direction = stem_direction;
   struct.keys = keys;
   return noteBuilder(struct);

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -161,7 +161,7 @@ const createNoteForStemTest = (
   stem_direction: number,
   slash: boolean = false
 ): StaveNote => {
-  const struct: GraceNoteStruct | StaveNoteStruct = { duration, slash };
+  const struct: Partial<GraceNoteStruct> | Partial<StaveNoteStruct> = { duration, slash };
   struct.stem_direction = stem_direction;
   struct.keys = keys;
   return noteBuilder(struct);

--- a/tests/gracetabnote_tests.ts
+++ b/tests/gracetabnote_tests.ts
@@ -26,8 +26,8 @@ const GraceTabNoteTests = {
 };
 
 // Helper functions to create TabNote and GraceTabNote objects.
-const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
-const graceTabNote = (noteStruct: Partial<TabNoteStruct>) => new GraceTabNote(noteStruct);
+const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
+const graceTabNote = (noteStruct: TabNoteStruct) => new GraceTabNote(noteStruct);
 
 /**
  * Helper function to build a RenderContext and TabStave.

--- a/tests/gracetabnote_tests.ts
+++ b/tests/gracetabnote_tests.ts
@@ -26,8 +26,8 @@ const GraceTabNoteTests = {
 };
 
 // Helper functions to create TabNote and GraceTabNote objects.
-const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
-const graceTabNote = (struct: TabNoteStruct) => new GraceTabNote(struct);
+const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const graceTabNote = (noteStruct: Partial<TabNoteStruct>) => new GraceTabNote(noteStruct);
 
 /**
  * Helper function to build a RenderContext and TabStave.

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -4,12 +4,6 @@
 // Key Signature Tests
 //
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: KeySignature.alterKey(alterKeySpec: string) should accept a string[] instead.
-// TODO: Factory.KeySigNote() should take a Partial<T>, or allow cancelKey and alterKey to be optional.
-
 import { VexFlowTests, TestOptions, MAJOR_KEYS, MINOR_KEYS } from './vexflow_test_helpers';
 import { ContextBuilder } from 'renderer';
 import { Flow } from 'flow';

--- a/tests/multimeasurerest_tests.ts
+++ b/tests/multimeasurerest_tests.ts
@@ -25,7 +25,7 @@ function simple(options: TestOptions): void {
   //   item[0] => staveParams to adjust vertical spacing between lines
   //   item[1] => multiMeasureRestParams
   // eslint-disable-next-line
-  const params: [any, Partial<MultimeasureRestRenderOptions>][] = [
+  const params: [any, MultimeasureRestRenderOptions][] = [
     [{}, { number_of_measures: 2, show_number: false }],
     [{}, { number_of_measures: 2 }],
     [{}, { number_of_measures: 2, line_thickness: 8, serif_thickness: 3 }],
@@ -104,7 +104,7 @@ function staveWithModifiers(options: TestOptions): void {
   let y = 0;
 
   // eslint-disable-next-line
-  const params: [any, Partial<MultimeasureRestRenderOptions>][] = [
+  const params: [any, MultimeasureRestRenderOptions][] = [
     [{ clef: 'treble', params: { width: 150 } }, { number_of_measures: 5 }],
     [{ clef: 'treble', keySig: 'G', params: { width: 150 } }, { number_of_measures: 5 }],
     [{ clef: 'treble', timeSig: '4/4', keySig: 'G', params: { width: 150 } }, { number_of_measures: 5 }],

--- a/tests/multimeasurerest_tests.ts
+++ b/tests/multimeasurerest_tests.ts
@@ -3,12 +3,6 @@
 //
 // MultiMeasureRest Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Line 158: Expected 2 arguments, but got 1.
-//       stave.setEndTimeSignature()'s second argument should be optional.
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { Flow } from 'flow';
 import { MultimeasureRestRenderOptions } from 'multimeasurerest';

--- a/tests/multimeasurerest_tests.ts
+++ b/tests/multimeasurerest_tests.ts
@@ -49,7 +49,12 @@ function simple(options: TestOptions): void {
     [line_spacing_15px, { number_of_measures: 12, spacing_between_lines_px: 15, number_glyph_point: 40 * 1.5 }],
     [
       line_spacing_15px,
-      { number_of_measures: 9, spacing_between_lines_px: 15, use_symbols: true, number_glyph_point: 40 * 1.5 },
+      {
+        number_of_measures: 9,
+        spacing_between_lines_px: 15,
+        use_symbols: true,
+        number_glyph_point: 40 * 1.5,
+      },
     ],
     [
       line_spacing_15px,

--- a/tests/notehead_tests.ts
+++ b/tests/notehead_tests.ts
@@ -3,11 +3,6 @@
 //
 // NoteHead Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: NoteHead constructor should take a Partial<NoteHeadStruct>.
-//       In the basicBoundingBoxes() test case, we omit the note_type option.
 // TODO: There is a bug in RenderContext.scale(). The CanvasContext works as expected.
 //       Each time you call scale(sx, sy), it multiplies the sx and sy by the currently stored scale.
 //       The SVGContext operates differently. It just sets the sx and sy as the new scale, instead of multiplying it.
@@ -72,15 +67,15 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 /**
  * Used by the next two test cases to draw a note.
  */
-function showNote(struct: StaveNoteStruct, stave: Stave, ctx: RenderContext, x: number) {
-  const note = new StaveNote(struct).setStave(stave);
+function showNote(noteStruct: Partial<StaveNoteStruct>, stave: Stave, ctx: RenderContext, x: number) {
+  const note = new StaveNote(noteStruct).setStave(stave);
   new TickContext().addTickable(note).preFormat().setX(x);
   note.setContext(ctx).draw();
   return note;
 }
 
 function variousHeads(options: TestOptions, contextBuilder: ContextBuilder): void {
-  const notes: StaveNoteStruct[] = [
+  const notes: Partial<StaveNoteStruct>[] = [
     { keys: ['g/5/d0'], duration: '4' },
     { keys: ['g/5/d1'], duration: '4' },
     { keys: ['g/5/d2'], duration: '4' },
@@ -128,7 +123,7 @@ function variousHeads(options: TestOptions, contextBuilder: ContextBuilder): voi
 }
 
 function drumChordHeads(options: TestOptions, contextBuilder: ContextBuilder): void {
-  const notes: StaveNoteStruct[] = [
+  const notes: Partial<StaveNoteStruct>[] = [
     { keys: ['a/4/d0', 'g/5/x3'], duration: '4' },
     { keys: ['a/4/x3', 'g/5/d0'], duration: '4' },
     { keys: ['a/4/d1', 'g/5/x2'], duration: '4' },

--- a/tests/notehead_tests.ts
+++ b/tests/notehead_tests.ts
@@ -67,7 +67,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 /**
  * Used by the next two test cases to draw a note.
  */
-function showNote(noteStruct: Partial<StaveNoteStruct>, stave: Stave, ctx: RenderContext, x: number) {
+function showNote(noteStruct: StaveNoteStruct, stave: Stave, ctx: RenderContext, x: number) {
   const note = new StaveNote(noteStruct).setStave(stave);
   new TickContext().addTickable(note).preFormat().setX(x);
   note.setContext(ctx).draw();
@@ -75,7 +75,7 @@ function showNote(noteStruct: Partial<StaveNoteStruct>, stave: Stave, ctx: Rende
 }
 
 function variousHeads(options: TestOptions, contextBuilder: ContextBuilder): void {
-  const notes: Partial<StaveNoteStruct>[] = [
+  const notes: StaveNoteStruct[] = [
     { keys: ['g/5/d0'], duration: '4' },
     { keys: ['g/5/d1'], duration: '4' },
     { keys: ['g/5/d2'], duration: '4' },
@@ -123,7 +123,7 @@ function variousHeads(options: TestOptions, contextBuilder: ContextBuilder): voi
 }
 
 function drumChordHeads(options: TestOptions, contextBuilder: ContextBuilder): void {
-  const notes: Partial<StaveNoteStruct>[] = [
+  const notes: StaveNoteStruct[] = [
     { keys: ['a/4/d0', 'g/5/x3'], duration: '4' },
     { keys: ['a/4/x3', 'g/5/d0'], duration: '4' },
     { keys: ['a/4/d1', 'g/5/x2'], duration: '4' },

--- a/tests/notesubgroup_tests.ts
+++ b/tests/notesubgroup_tests.ts
@@ -25,7 +25,7 @@ const NoteSubGroupTests = {
 // Return three helper functions for creating StaveNotes, and adding Accidental & NoteSubGroup to those StaveNotes.
 function createShortcuts(f: Factory) {
   return {
-    createStaveNote: (struct: StaveNoteStruct) => f.StaveNote(struct),
+    createStaveNote: (noteStruct: Partial<StaveNoteStruct>) => f.StaveNote(noteStruct),
     addAccidental: (note: StaveNote, accid: string) => note.addModifier(f.Accidental({ type: accid }), 0),
     addSubGroup: (note: StaveNote, subNotes: Note[]) => note.addModifier(f.NoteSubGroup({ notes: subNotes }), 0),
   };

--- a/tests/notesubgroup_tests.ts
+++ b/tests/notesubgroup_tests.ts
@@ -25,7 +25,7 @@ const NoteSubGroupTests = {
 // Return three helper functions for creating StaveNotes, and adding Accidental & NoteSubGroup to those StaveNotes.
 function createShortcuts(f: Factory) {
   return {
-    createStaveNote: (noteStruct: Partial<StaveNoteStruct>) => f.StaveNote(noteStruct),
+    createStaveNote: (noteStruct: StaveNoteStruct) => f.StaveNote(noteStruct),
     addAccidental: (note: StaveNote, accid: string) => note.addModifier(f.Accidental({ type: accid }), 0),
     addSubGroup: (note: StaveNote, subNotes: Note[]) => note.addModifier(f.NoteSubGroup({ notes: subNotes }), 0),
   };

--- a/tests/rests_tests.ts
+++ b/tests/rests_tests.ts
@@ -82,7 +82,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 }
 
 // Optional: Use a helper function to make your code more concise.
-const note = (s: StaveNoteStruct) => new StaveNote(s);
+const note = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
 
 /**
  * Rests are intermixed within beamed notes (with the stems and beams at the top).
@@ -337,7 +337,7 @@ function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void 
   const ctx = contextBuilder(options.elementId, 600, 200);
   const stave = new Stave(50, 10, 500).addClef('treble').setContext(ctx).addTimeSignature('4/4').draw();
 
-  const noteOnStave = (s: StaveNoteStruct) => new StaveNote(s).setStave(stave);
+  const noteOnStave = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct).setStave(stave);
 
   const notes1 = [
     noteOnStave({ keys: ['c/4', 'e/4', 'g/4'], duration: '4' }),

--- a/tests/rests_tests.ts
+++ b/tests/rests_tests.ts
@@ -82,7 +82,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 }
 
 // Optional: Use a helper function to make your code more concise.
-const note = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct);
+const note = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
 
 /**
  * Rests are intermixed within beamed notes (with the stems and beams at the top).
@@ -337,7 +337,7 @@ function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void 
   const ctx = contextBuilder(options.elementId, 600, 200);
   const stave = new Stave(50, 10, 500).addClef('treble').setContext(ctx).addTimeSignature('4/4').draw();
 
-  const noteOnStave = (noteStruct: Partial<StaveNoteStruct>) => new StaveNote(noteStruct).setStave(stave);
+  const noteOnStave = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct).setStave(stave);
 
   const notes1 = [
     noteOnStave({ keys: ['c/4', 'e/4', 'g/4'], duration: '4' }),

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -3,20 +3,8 @@
 //
 // Basic Stave Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Stave.setText()'s third arg needs to be Partial<T> or have more optional fields.
 // TODO: Like Stave.setTempo(t: StaveTempoOptions, ...), Stave.setText(...) could declare an interface called StaveTextOptions.
 //       This helps developers because they can use the named type in their code for type checking.
-// TODO: Stave.drawVerticalBar() only accepts one arg, but we pass in a second (boolean).
-//       Stave.drawVertical() requires two args, but we only pass in one. The second is a boolean. Did we mix up something?
-// TODO: Stave.setEndTimeSignature()'s second arg should be optional.
-// TODO: VoltaType.BEGIN_MID is used, but doesn't exist. Did it exist in the past?
-// TODO: Stave.setConfigForLines(lines_configuration: StaveLineConfig[])'s comment (and our test case) shows that null is a valid option in the array.
-//       Should we change it to undefined? Or should the type be (StaveLineConfig | null)[] instead?
-// TODO: In the drawTempo test case, Stave.setTempo(...) receives incomplete options, so it should probably take a Partial<StaveTempoOptions>.
-//       Additionally, it receives an unexpected option note: '8'.
 
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { ContextBuilder } from 'renderer';
@@ -547,7 +535,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   const mm2 = new Stave(mm1.getX() + mm1.getWidth(), mm1.getY(), 175);
   mm2.setBegBarType(BarlineType.REPEAT_BEGIN);
   mm2.setRepetitionTypeRight(Repetition.type.DS, 25);
-  mm2.setVoltaType(VoltaType.BEGIN_MID, '2.', -5);
+  mm2.setVoltaType(VoltaType.BEGIN, '2.', -5);
   mm2.addClef('treble');
   mm2.addKeySignature('A');
   mm2.setMeasure(2);
@@ -612,7 +600,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   let y = 50;
 
   // TODO: Change tempo to Partial<StaveTempoOptions> or make .name optional in StaveTempoOptions.
-  function drawTempoStaveBar(width: number, tempo: StaveTempoOptions, tempo_y: number, notes?: StaveNote[]) {
+  function drawTempoStaveBar(width: number, tempo: Partial<StaveTempoOptions>, tempo_y: number, notes?: StaveNote[]) {
     const staveBar = new Stave(padding + x, y, width);
     if (x === 0) staveBar.addClef('treble');
     staveBar.setTempo(tempo, tempo_y);
@@ -633,7 +621,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   drawTempoStaveBar(100, { duration: '8', dots: 2, bpm: 90 }, 0);
   drawTempoStaveBar(100, { duration: '16', dots: 1, bpm: 96 }, 0);
   drawTempoStaveBar(100, { duration: '32', bpm: 70 }, 0);
-  drawTempoStaveBar(250, { name: 'Andante', note: '8', bpm: 120 }, -20, [
+  drawTempoStaveBar(250, { name: 'Andante', bpm: 120 }, -20, [
     new StaveNote({ keys: ['c/4'], duration: '8' }),
     new StaveNote({ keys: ['d/4'], duration: '8' }),
     new StaveNote({ keys: ['g/4'], duration: '8' }),
@@ -688,7 +676,7 @@ function configureAllLines(options: TestOptions, contextBuilder: ContextBuilder)
   const ctx = contextBuilder(options.elementId, 400, 120);
   const stave = new Stave(10, 10, 300);
   stave
-    .setConfigForLines([{ visible: false }, null, { visible: false }, { visible: true }, { visible: false }])
+    .setConfigForLines([{ visible: false }, {}, { visible: false }, { visible: true }, { visible: false }])
     .setContext(ctx)
     .draw();
 

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -599,8 +599,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   let x = 0;
   let y = 50;
 
-  // TODO: Change tempo to Partial<StaveTempoOptions> or make .name optional in StaveTempoOptions.
-  function drawTempoStaveBar(width: number, tempo: Partial<StaveTempoOptions>, tempo_y: number, notes?: StaveNote[]) {
+  function drawTempoStaveBar(width: number, tempo: StaveTempoOptions, tempo_y: number, notes?: StaveNote[]) {
     const staveBar = new Stave(padding + x, y, width);
     if (x === 0) staveBar.addClef('treble');
     staveBar.setTempo(tempo, tempo_y);

--- a/tests/staveconnector_tests.ts
+++ b/tests/staveconnector_tests.ts
@@ -3,11 +3,6 @@
 //
 // StaveConnector Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: StaveConnector.setText() needs an optional shift_x.
-// TODO: Stave.setText()'s third argument needs to be optional.
 // TODO: Should we change StaveConnector.type => StaveConnectorType? We are inconsistent with this.
 
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';

--- a/tests/stavehairpin_tests.ts
+++ b/tests/stavehairpin_tests.ts
@@ -8,7 +8,6 @@
 // @ts-nocheck
 
 // TODO: Incorrect property names in the options object: vo, left_ho, right_ho.
-// TODO: StaveHairpin.setRenderOptions() should take a Partial<StaveHairpinRenderOptions>.
 
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { RenderContext } from 'types/common';
@@ -37,7 +36,7 @@ function drawHairpin(
   ctx: RenderContext,
   type: number,
   position: number,
-  options?: Partial<StaveHairpinRenderOptions>
+  options?: StaveHairpinRenderOptions
 ) {
   const hairpin = new StaveHairpin({ first_note, last_note }, type);
   hairpin.setContext(ctx);

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -3,11 +3,6 @@
 //
 // StringNumber Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Stroke constructor's second argument should be optional.
-
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Renderer } from 'renderer';
 import { BarlineType } from 'stavebarline';

--- a/tests/strokes_tests.ts
+++ b/tests/strokes_tests.ts
@@ -80,7 +80,7 @@ function arpeggioDirectionless(options: TestOptions): void {
 
   const notes1 = score.notes('(g4 b4 d5)/4, (g4 b4 d5 g5), (g4 b4 d5 g5), (g4 b4 d5)', { stem: 'up' });
 
-  const graceNoteStructs: Partial<GraceNoteStruct>[] = [
+  const graceNoteStructs: GraceNoteStruct[] = [
     { keys: ['e/4'], duration: '32' },
     { keys: ['f/4'], duration: '32' },
     { keys: ['g/4'], duration: '32' },

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -116,7 +116,7 @@ function tab(options: TestOptions, contextBuilder: ContextBuilder): void {
   stave.getModifiers()[2].setStyle(FS('blue'));
   stave.setContext(ctx).draw();
 
-  const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+  const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 
   const notes = [
     tabNote({

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -116,7 +116,7 @@ function tab(options: TestOptions, contextBuilder: ContextBuilder): void {
   stave.getModifiers()[2].setStyle(FS('blue'));
   stave.setContext(ctx).draw();
 
-  const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
+  const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
 
   const notes = [
     tabNote({

--- a/tests/tabnote_tests.ts
+++ b/tests/tabnote_tests.ts
@@ -153,7 +153,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   ];
 
   // Helper function
-  function showNote(noteStruct: Partial<TabNoteStruct>, stave: TabStave, ctx: RenderContext, x: number): TabNote {
+  function showNote(noteStruct: TabNoteStruct, stave: TabStave, ctx: RenderContext, x: number): TabNote {
     const tabNote = new TabNote(noteStruct);
     const tickContext = new TickContext();
     tickContext.addTickable(tabNote).preFormat().setX(x);
@@ -178,7 +178,7 @@ function drawStemsUp(options: TestOptions, contextBuilder: ContextBuilder): void
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: Partial<TabNoteStruct>[] = [
+  const specs: TabNoteStruct[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -251,7 +251,7 @@ function drawStemsDown(options: TestOptions, contextBuilder: ContextBuilder): vo
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: Partial<TabNoteStruct>[] = [
+  const specs: TabNoteStruct[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -324,7 +324,7 @@ function drawStemsUpThrough(options: TestOptions, contextBuilder: ContextBuilder
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: Partial<TabNoteStruct>[] = [
+  const specs: TabNoteStruct[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -399,7 +399,7 @@ function drawStemsDownThrough(options: TestOptions, contextBuilder: ContextBuild
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: Partial<TabNoteStruct>[] = [
+  const specs: TabNoteStruct[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -478,7 +478,7 @@ function drawStemsDotted(options: TestOptions, contextBuilder: ContextBuilder): 
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: Partial<TabNoteStruct>[] = [
+  const specs: TabNoteStruct[] = [
     {
       positions: [
         { str: 3, fret: 6 },

--- a/tests/tabnote_tests.ts
+++ b/tests/tabnote_tests.ts
@@ -153,8 +153,8 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   ];
 
   // Helper function
-  function showNote(struct: TabNoteStruct, stave: TabStave, ctx: RenderContext, x: number): TabNote {
-    const tabNote = new TabNote(struct);
+  function showNote(noteStruct: Partial<TabNoteStruct>, stave: TabStave, ctx: RenderContext, x: number): TabNote {
+    const tabNote = new TabNote(noteStruct);
     const tickContext = new TickContext();
     tickContext.addTickable(tabNote).preFormat().setX(x);
     tabNote.setContext(ctx).setStave(stave);
@@ -178,7 +178,7 @@ function drawStemsUp(options: TestOptions, contextBuilder: ContextBuilder): void
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: TabNoteStruct[] = [
+  const specs: Partial<TabNoteStruct>[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -251,7 +251,7 @@ function drawStemsDown(options: TestOptions, contextBuilder: ContextBuilder): vo
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: TabNoteStruct[] = [
+  const specs: Partial<TabNoteStruct>[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -324,7 +324,7 @@ function drawStemsUpThrough(options: TestOptions, contextBuilder: ContextBuilder
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: TabNoteStruct[] = [
+  const specs: Partial<TabNoteStruct>[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -399,7 +399,7 @@ function drawStemsDownThrough(options: TestOptions, contextBuilder: ContextBuild
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: TabNoteStruct[] = [
+  const specs: Partial<TabNoteStruct>[] = [
     {
       positions: [
         { str: 3, fret: 6 },
@@ -478,7 +478,7 @@ function drawStemsDotted(options: TestOptions, contextBuilder: ContextBuilder): 
   stave.setContext(ctx);
   stave.draw();
 
-  const specs: TabNoteStruct[] = [
+  const specs: Partial<TabNoteStruct>[] = [
     {
       positions: [
         { str: 3, fret: 6 },

--- a/tests/tabslide_tests.ts
+++ b/tests/tabslide_tests.ts
@@ -57,7 +57,7 @@ function setupContext(options: TestOptions, width?: number): { context: RenderCo
 }
 
 // Helper function to create TabNote objects.
-const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
+const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
 
 /**
  * Test Case

--- a/tests/tabslide_tests.ts
+++ b/tests/tabslide_tests.ts
@@ -57,7 +57,7 @@ function setupContext(options: TestOptions, width?: number): { context: RenderCo
 }
 
 // Helper function to create TabNote objects.
-const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 
 /**
  * Test Case

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -33,7 +33,7 @@ const TabTieTests = {
 /**
  * Helper function to create TabNote objects.
  */
-const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
+const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
 
 /**
  * Helper function to create a RenderContext and TabStave.

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -33,7 +33,7 @@ const TabTieTests = {
 /**
  * Helper function to create TabNote objects.
  */
-const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 
 /**
  * Helper function to create a RenderContext and TabStave.

--- a/tests/textbracket_tests.ts
+++ b/tests/textbracket_tests.ts
@@ -4,6 +4,7 @@
 // TextBracket Tests
 
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
+import { FontInfo } from '../src/types/common';
 
 const TextBracketTests = {
   Start(): void {
@@ -89,7 +90,7 @@ function simple1(options: TestOptions): void {
         superscript: 'vb',
         position: 'bottom',
         line: 3,
-        font: { size: 30 },
+        font: { size: 30 } as FontInfo,
       },
     }),
     f.TextBracket({

--- a/tests/textnote_tests.ts
+++ b/tests/textnote_tests.ts
@@ -7,14 +7,12 @@
 // @ts-nocheck
 
 // TODO: TextNote needs a setFont() accessor.
-// TODO: Line 177 => Property 'text' is missing but required in type 'TextNoteStruct'.
-//       Maybe Factory.TextNote() should accept a Partial<TextNoteStruct>?
 
 import { Crescendo } from 'crescendo';
 import { Flow } from 'flow';
 import { Note } from 'note';
 import { TextNote } from 'textnote';
-import { Stave} from 'stave';
+import { Stave } from 'stave';
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
@@ -269,9 +267,9 @@ function textDynamics(options: TestOptions): void {
     { time: '7/4' }
   );
 
-  // This is refactored to use preCalculateMinWidth... to exercise  
+  // This is refactored to use preCalculateMinWidth... to exercise
   // a bug fix when textDynamic got formatted more than once.
-  var formatter = f.Formatter();
+  const formatter = f.Formatter();
   formatter.joinVoices([voice]);
   // const width = 250; //formatter.preCalculateMinTotalWidth([voice]);
   const width = formatter.preCalculateMinTotalWidth([voice]);

--- a/tests/tuplet_tests.ts
+++ b/tests/tuplet_tests.ts
@@ -3,12 +3,6 @@
 //
 // Tuplet Tests
 
-/* eslint-disable */
-// @ts-nocheck
-
-// TODO: Factory.Voice() requires its 'time' parameter to be a string.
-//       However, we pass { num_beats: 4, beat_value: 4 }.
-
 import { VexFlowTests, TestOptions } from './vexflow_test_helpers';
 import { Formatter } from 'formatter';
 import { Stem } from 'stem';

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -22,7 +22,7 @@ const VibratoTests = {
 };
 
 // Helper function to create TabNote objects.
-const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
+const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 
 /**
  * Default vibrato symbol (wavy line) on top of a tab with two notes fretted.

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -22,7 +22,7 @@ const VibratoTests = {
 };
 
 // Helper function to create TabNote objects.
-const tabNote = (struct: TabNoteStruct) => new TabNote(struct);
+const tabNote = (noteStruct: Partial<TabNoteStruct>) => new TabNote(noteStruct);
 
 /**
  * Default vibrato symbol (wavy line) on top of a tab with two notes fretted.


### PR DESCRIPTION
This builds directly on top of Rodrigo's https://github.com/0xfe/vexflow/pull/1141

It includes Rodrigo's 5 commits, so I believe if we merge this one, we can close https://github.com/0xfe/vexflow/pull/1141

This is part 1 of migrating away from using `Partial<...>`. The main goal is to prevent Partial types from leaking out into the public API.

Part 2 will come in a second PR, which will remove the rest of the Partial, and include a couple `Required<...>`. Part 2 also comes with improvements to how we handle fonts (for text on the score, not for the music engraving).

There are 2 visual diffs. Both are due to bug fixes.

### Stave.Vertical_Bar_Test.Bravura
BEFORE:
![Stave Vertical_Bar_Test Bravura_Reference](https://user-images.githubusercontent.com/239113/134323893-7ac5f2bb-b5a6-4507-b0a4-6d40f37195dd.png)

AFTER:
![Stave Vertical_Bar_Test Bravura_Current](https://user-images.githubusercontent.com/239113/134323890-c2296ec5-f347-4bad-8a73-b64cf1e31fa2.png)

DIFF:
![Stave Vertical_Bar_Test Bravura](https://user-images.githubusercontent.com/239113/134324420-3396ea91-8f86-438e-9c37-e5efd8ca7fd5.png)

The test now correctly shows a double vertical bar. This is due to Rodrigo's bug fix. Not sure why we have two methods that were almost identical.... (now they're actually identical!). We can address that in a future PR:
```
  stave.drawVerticalBar(50, true);
  stave.drawVerticalBar(150, false);
  stave.drawVertical(250, true);
  stave.drawVertical(300);
```

### Stave.Volta___Modifier_Measure_Test.Bravura
DIFF:
![Stave Volta___Modifier_Measure_Test Bravura](https://user-images.githubusercontent.com/239113/134324338-27c9f657-5fe8-4779-a122-f464469aa493.png)

The test now correctly shows the volta number.
It was a minor bug fix. The test previously passed in a constant that didn't exist. Thanks to TypeScript, we now realized it doesn't exist, and changed it to the correct constant.

Ready for review!