### PR TITLE
Delay call to document.createElementNS() to support loading VexFlow in NodeJS with jsdom.

### DIFF
--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -42,17 +42,11 @@ interface State {
 }
 
 class MeasureTextCache {
-  protected txt: SVGTextElement;
+  protected txt?: SVGTextElement;
 
   // The cache is keyed first by the text string, then by the font attributes
   // joined together.
   protected cache: Record<string, Record<string, TextMeasure>> = {};
-
-  constructor() {
-    // Create the SVG elements that will be used to measure the text in the event
-    // of a cache miss.
-    this.txt = document.createElementNS(SVG_NS, 'text');
-  }
 
   lookup(text: string, svg: SVGSVGElement, attributes: Attributes): TextMeasure {
     let entries = this.cache[text];
@@ -76,14 +70,22 @@ class MeasureTextCache {
   }
 
   measureImpl(text: string, svg: SVGSVGElement, attributes: Attributes): TextMeasure {
-    this.txt.textContent = text;
-    this.txt.setAttributeNS(null, 'font-family', attributes['font-family']);
-    this.txt.setAttributeNS(null, 'font-size', attributes['font-size']);
-    this.txt.setAttributeNS(null, 'font-style', attributes['font-style']);
-    this.txt.setAttributeNS(null, 'font-weight', attributes['font-weight']);
-    svg.appendChild(this.txt);
-    const bbox = this.txt.getBBox();
-    svg.removeChild(this.txt);
+    let txt = this.txt;
+    if (!txt) {
+      // Create the SVG text element that will be used to measure text in the event
+      // of a cache miss.
+      txt = document.createElementNS(SVG_NS, 'text');
+      this.txt = txt;
+    }
+
+    txt.textContent = text;
+    txt.setAttributeNS(null, 'font-family', attributes['font-family']);
+    txt.setAttributeNS(null, 'font-size', attributes['font-size']);
+    txt.setAttributeNS(null, 'font-style', attributes['font-style']);
+    txt.setAttributeNS(null, 'font-weight', attributes['font-weight']);
+    svg.appendChild(txt);
+    const bbox = txt.getBBox();
+    svg.removeChild(txt);
 
     // Remove the trailing 'pt' from the font size and scale to convert from points
     // to canvas units.


### PR DESCRIPTION
This PR modifies SVGContext's `MeasureTextCache` to call `document.createElementNS(SVG_NS, 'text')` as late as possible.

This allows us to load VexFlow in NodeJS as in the vexflow/demos/node/ folder.

Before:
```
node demos/node/svg.js

this.txt = document.createElementNS(SVG_NS, 'text');
ReferenceError: document is not defined
    at new MeasureTextCache (vexflow/build/vexflow-debug.js:26163:20)

```

After:
```
node demos/node/svg.js

<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500"><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 80L410 80"></path><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 90L410 90"></path><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 100L410 100"></path><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 110L410 110"></path><path stroke-width="1" fill="none" stroke="#999999" stroke-dasharray="none" d="M10 120L410 120"></path><rect stroke-width="0.3" fill="black" stroke="black" stroke-dasharray="none" x="10" y="79.5" width="1" height="41"></rect><rect stroke-width="0.3" fill="black" stroke="black" stroke-dasharray="none" x="410" y="79.5" width="1" height="41"></rect><path stroke-width="0.3" fill="black" stroke="none" stroke-dasharray="none" d="M15 111M28.280256 120.199872C29.116608 120.199872,30.079680000000003 12 .......
```

I have verified what Tom saw in https://github.com/0xfe/vexflow/issues/1150

When I call 
```
node demos/node/svg.js > output.svg
convert output.svg output.png
```

The before (SVG) and after (PNG) look like this:
![output_svg](https://user-images.githubusercontent.com/239113/134719570-613f92e8-9562-4e21-8050-20b8f54852d7.png)

![output](https://user-images.githubusercontent.com/239113/134719388-8560ed67-3c2c-4f45-881e-eb5c86d0c52f.png)

The SVG output works fine in browsers and Affinity Designer on macOS, so `convert` is probably being picky with the SVG spec :-). I wonder what attribute or syntax we are missing....
