### PR TITLE
Remove redundant moveTo in Glyph.renderOutline

### DIFF
--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -297,7 +297,6 @@ export class Glyph extends Element {
     const go = new GlyphOutline(outline, x_pos, y_pos, scale);
 
     ctx.beginPath();
-    ctx.moveTo(x_pos, y_pos);
     let x, y: number;
     while (!go.done()) {
       switch (go.next()) {


### PR DESCRIPTION
All glyphs already start with an `M` command, so the `moveTo` at the start of `Glyph.renderOutline` doesn't do anything and seems to break ImageMagick's SVG rendering for some reason.

This fixes #1150.

Output from from ImageMagick's converter: `convert bach.svg bach.png`

![imagemagick bach demo](https://user-images.githubusercontent.com/7587269/134756608-ec47abab-b2bf-4af4-b94f-5a306118fdbf.png)
