### PR TITLE
Allow a RenderContext to be passed directly to the Renderer constructor

### DIFF
--- a/demos/node/README.md
+++ b/demos/node/README.md
@@ -5,3 +5,5 @@ You can use VexFlow in Node JS by calling `const Vex = require(...)` on the JS l
 `node canvas.js > output.html` creates an HTML page containing the VexFlow output.
 
 `node svg.js > output.svg` creates a SVG image file containing the VexFlow output.
+
+`node customcontext.js` demonstrates how to use VexFlow with a custom RenderContext.

--- a/demos/node/customcontext.js
+++ b/demos/node/customcontext.js
@@ -1,0 +1,192 @@
+// node customcontext.js
+
+/* eslint-disable no-console */
+
+const { createCanvas } = require('canvas');
+const Vex = require('../../build/vexflow-debug');
+const VF = Vex.Flow;
+
+// A custom Vex.Flow.RenderContext implementation.
+// This is just a stub for demonstration purposes that console.logs all method
+// calls and arguments.
+class CustomContext {
+  constructor() {
+    this.font = '';
+    this.fillStyle = '';
+    this.strokeStyle = '';
+  }
+
+  log(func, ...args) {
+    for (let i = 0; i < args.length; ++i) {
+      if (typeof args[i] == 'string') {
+        args[i] = `"${args[i]}"`;
+      }
+    }
+    console.log(`${func}(${args.join(', ')})`);
+  }
+
+  clear() {
+    this.log('clear');
+  }
+
+  setFont(family, size, weight = '') {
+    this.log('setFont', family, size, weight);
+    return this;
+  }
+
+  setRawFont(font) {
+    this.log('setRawFont', font);
+    return this;
+  }
+
+  setFillStyle(style) {
+    this.log('setFillStyle', style);
+    return this;
+  }
+
+  setBackgroundFillStyle(style) {
+    this.log('setBackgroundFillStyle', style);
+    return this;
+  }
+
+  setStrokeStyle(style) {
+    this.log('setStrokeStyle', style);
+    return this;
+  }
+
+  setShadowColor(color) {
+    this.log('setShadowColor', color);
+    return this;
+  }
+
+  setShadowBlur(blur) {
+    this.log('setShadowBlur', blur);
+    return this;
+  }
+
+  setLineWidth(width) {
+    this.log('setLineWidth', width);
+    return this;
+  }
+
+  setLineCap(capType) {
+    this.log('setLineCap', capType);
+    return this;
+  }
+
+  setLineDash(dashPattern) {
+    this.log('setLineDash', `[${dashPattern.join(', ')}]`);
+    return this;
+  }
+
+  scale(x, y) {
+    this.log('scale', x, y);
+    return this;
+  }
+
+  rect(x, y, width, height) {
+    this.log('rect', x, y, width, height);
+    return this;
+  }
+
+  resize(width, height) {
+    this.log('resize', width, height);
+    return this;
+  }
+
+  fillRect(x, y, width, height) {
+    this.log('fillRect', x, y, width, height);
+    return this;
+  }
+
+  clearRect(x, y, width, height) {
+    this.log('clearRect', x, y, width, height);
+    return this;
+  }
+
+  beginPath() {
+    this.log('beginPath');
+    return this;
+  }
+
+  moveTo(x, y) {
+    this.log('moveTo', x, y);
+    return this;
+  }
+
+  lineTo(x, y) {
+    this.log('lineTo', x, y);
+    return this;
+  }
+
+  bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y) {
+    this.log('bezierCurveTo', cp1x, cp1y, cp2x, cp2y, x, y);
+    return this;
+  }
+
+  quadraticCurveTo(cpx, cpy, x, y) {
+    this.log('quadraticCurveTo', cpx, cpy, x, y);
+    return this;
+  }
+
+  arc(x, y, radius, startAngle, endAngle, antiClockwise) {
+    this.log('arc', x, y, radius, startAngle, endAngle, antiClockwise);
+    return this;
+  }
+
+  fill(attributes) {
+    this.log('fill');
+    return this;
+  }
+
+  stroke() {
+    this.log('stroke');
+    return this;
+  }
+
+  closePath() {
+    this.log('closePath');
+    return this;
+  }
+
+  fillText(text, x, y) {
+    this.log('fillText', text, x, y);
+    return this;
+  }
+
+  save() {
+    this.log('save');
+    return this;
+  }
+
+  restore() {
+    this.log('restore');
+    return this;
+  }
+
+  openGroup(cls, id, attrs) {
+    this.log('openGroup', cls, id);
+  }
+
+  closeGroup() {
+    this.log('closeGroup');
+  }
+
+  add(child) {
+    this.log('add');
+  }
+
+  measureText(text) {
+    this.log('measureText', text);
+    return { width: 0, height: 10 };
+  }
+}
+
+const renderer = new VF.Renderer(new CustomContext());
+const context = renderer.getContext();
+context.setFont('Arial', 10, '').setBackgroundFillStyle('#eed');
+
+const stave = new VF.Stave(10, 40, 400);
+stave.addClef('treble');
+stave.addTimeSignature('4/4');
+stave.setContext(context).draw();

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -146,18 +146,29 @@ export class CanvasContext implements RenderContext {
     return this;
   }
 
-  // Only called if Renderer.USE_CANVAS_PROXY is true.
   scale(x: number, y: number): this {
     this.vexFlowCanvasContext.scale(x, y);
     return this;
   }
 
-  // CanvasRenderingContext2D does not have a resize function.
-  // renderer.ts calls ctx.scale() instead, so this method is never used.
-  // eslint-disable-next-line
   resize(width: number, height: number): this {
-    // DO NOTHING.
-    return this;
+    const canvasElement = this.vexFlowCanvasContext.canvas;
+    const devicePixelRatio = window.devicePixelRatio || 1;
+
+    // Scale the canvas size by the device pixel ratio clamping to the maximum
+    // supported size.
+    [width, height] = CanvasContext.SanitizeCanvasDims(width * devicePixelRatio, height * devicePixelRatio);
+
+    // Divide back down by the pixel ratio and convert to integers.
+    width = (width / devicePixelRatio) | 0;
+    height = (height / devicePixelRatio) | 0;
+
+    canvasElement.width = width * devicePixelRatio;
+    canvasElement.height = height * devicePixelRatio;
+    canvasElement.style.width = width + 'px';
+    canvasElement.style.height = height + 'px';
+
+    return this.scale(devicePixelRatio, devicePixelRatio);
   }
 
   rect(x: number, y: number, width: number, height: number): this {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -150,11 +150,11 @@ export class Factory {
 
   initRenderer(): void {
     const { elementId, width, height, background } = this.options.renderer;
-    if (elementId === null) {
+    if (elementId == null) {
       return;
     }
 
-    if (elementId === '') {
+    if (elementId == '') {
       L(this);
       throw new RuntimeError('renderer.elementId not set in FactoryOptions');
     }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -174,7 +174,11 @@ export class Factory {
     let backend = this.options.renderer.backend;
     if (backend === undefined) {
       const elem = document.getElementById(elementId);
-      backend = elem instanceof HTMLCanvasElement ? Renderer.Backends.CANVAS : Renderer.Backends.SVG;
+      if (elem instanceof window.HTMLCanvasElement) {
+        backend = Renderer.Backends.CANVAS;
+      } else {
+        backend = Renderer.Backends.SVG;
+      }
     }
 
     this.context = Renderer.buildContext(elementId as string, backend, width, height, background);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -9,29 +9,16 @@ import { RuntimeError } from './util';
 // A ContextBuilder is either Renderer.getSVGContext or Renderer.getCanvasContext.
 export type ContextBuilder = typeof Renderer.getSVGContext | typeof Renderer.getCanvasContext;
 
+// eslint-disable-next-line
+function isRenderContext(obj: any): obj is RenderContext {
+  return obj.setShadowBlur !== undefined;
+}
+
 /**
  * Support Canvas & SVG rendering contexts.
  */
 export class Renderer {
-  protected elementId?: string;
-  protected element: HTMLCanvasElement | HTMLDivElement;
-  protected backend: number;
-
   protected ctx: RenderContext;
-  // eslint-disable-next-line
-  protected paper: any;
-
-  static readonly Backends = {
-    CANVAS: 1,
-    SVG: 2,
-  };
-
-  // End of line types
-  static readonly LineEndType = {
-    NONE: 1, // No leg
-    UP: 2, // Upward leg
-    DOWN: 3, // Downward leg
-  };
 
   static lastContext?: RenderContext = undefined;
 
@@ -108,67 +95,75 @@ export class Renderer {
    *   - a div element, which will contain the SVG output
    * @param backend Renderer.Backends.CANVAS or Renderer.Backends.SVG
    */
-  constructor(canvasId: string | HTMLCanvasElement | HTMLDivElement, backend: number) {
-    if (!canvasId) {
-      throw new RuntimeError('BadArgument', 'Invalid id for renderer.');
-    } else if (typeof canvasId === 'string') {
-      this.elementId = canvasId;
-      this.element = document.getElementById(canvasId as string) as HTMLCanvasElement | HTMLDivElement;
-    } else if ('getContext' in canvasId /* HTMLCanvasElement */) {
-      this.element = canvasId as HTMLCanvasElement;
+  constructor(context: RenderContext);
+  constructor(canvas: string | HTMLCanvasElement, backend: Renderer.Backends.CANVAS);
+  constructor(canvas: string | HTMLDivElement, backend: Renderer.Backends.SVG);
+  constructor(arg0: string | HTMLCanvasElement | HTMLDivElement | RenderContext, arg1?: number) {
+    if (isRenderContext(arg0)) {
+      // The user has provided what looks like a RenderContext, let's just use it.
+      // TODO(tommadams): RenderContext is an interface, can we introduce a context base class
+      // to make this check more robust?
+      this.ctx = arg0;
     } else {
-      // Assume it's a HTMLDivElement.
-      this.element = canvasId as HTMLDivElement;
-    }
-
-    // Verify backend and create context
-    this.backend = backend;
-    if (this.backend === Renderer.Backends.CANVAS) {
-      const canvasElement = this.element as HTMLCanvasElement;
-      if (!canvasElement.getContext) {
-        throw new RuntimeError('BadElement', `Can't get canvas context from element: ${canvasId}`);
-      } else {
-        const context = canvasElement.getContext('2d');
-        if (context) {
-          this.ctx = new CanvasContext(context);
-        } else {
-          throw new RuntimeError('BadElement', `Can't get canvas context from element: ${canvasId}`);
-        }
+      if (arg1 === undefined) {
+        // The backend must be specified if the render context isn't directly provided.
+        throw new RuntimeError('InvalidArgument', 'Missing backend argument');
       }
-    } else if (this.backend === Renderer.Backends.SVG) {
-      this.ctx = new SVGContext(this.element);
-    } else {
-      throw new RuntimeError('InvalidBackend', `No support for backend: ${this.backend}`);
+      const backend: number = arg1;
+
+      let element: HTMLElement;
+      if (typeof arg0 == 'string') {
+        const maybeElement = document.getElementById(arg0);
+        if (maybeElement == null) {
+          throw new RuntimeError('BadElementId', `Can't find element with ID "${maybeElement}"`);
+        }
+        element = maybeElement;
+      } else {
+        element = arg0 as HTMLElement;
+      }
+
+      // Verify backend and create context
+      if (backend === Renderer.Backends.CANVAS) {
+        if (!(element instanceof HTMLCanvasElement)) {
+          throw new RuntimeError('BadElement', 'CANVAS context requires an HTMLCanvasElement');
+        }
+        const context = element.getContext('2d');
+        if (!context) {
+          throw new RuntimeError('BadElement', "Can't get canvas context");
+        }
+        this.ctx = new CanvasContext(context);
+      } else if (backend === Renderer.Backends.SVG) {
+        if (!(element instanceof HTMLDivElement)) {
+          throw new RuntimeError('BadElement', 'SVG context requires an HTMLDivElement.');
+        }
+        this.ctx = new SVGContext(element);
+      } else {
+        throw new RuntimeError('InvalidBackend', `No support for backend: ${backend}`);
+      }
     }
   }
 
   resize(width: number, height: number): this {
-    if (this.backend === Renderer.Backends.CANVAS) {
-      const canvasElement = this.element as HTMLCanvasElement;
-      const devicePixelRatio = window.devicePixelRatio || 1;
-
-      // Scale the canvas size by the device pixel ratio clamping to the maximum
-      // supported size.
-      [width, height] = CanvasContext.SanitizeCanvasDims(width * devicePixelRatio, height * devicePixelRatio);
-
-      // Divide back down by the pixel ratio and convert to integers.
-      width = (width / devicePixelRatio) | 0;
-      height = (height / devicePixelRatio) | 0;
-
-      canvasElement.width = width * devicePixelRatio;
-      canvasElement.height = height * devicePixelRatio;
-      canvasElement.style.width = width + 'px';
-      canvasElement.style.height = height + 'px';
-
-      this.ctx.scale(devicePixelRatio, devicePixelRatio);
-    } else {
-      this.ctx.resize(width, height);
-    }
-
+    this.ctx.resize(width, height);
     return this;
   }
 
   getContext(): RenderContext {
     return this.ctx;
+  }
+}
+
+// eslint-disable-next-line
+export namespace Renderer {
+  export enum Backends {
+    CANVAS = 1,
+    SVG = 2,
+  }
+
+  // End of line types
+  export enum LineEndType {
+    NONE = 1, // No leg
+    UP = 2, // Upward leg
+    DOWN = 3, // Downward leg
   }
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -124,7 +124,7 @@ export class Renderer {
 
       // Verify backend and create context
       if (backend === Renderer.Backends.CANVAS) {
-        if (!(element instanceof HTMLCanvasElement)) {
+        if (!(element instanceof window.HTMLCanvasElement)) {
           throw new RuntimeError('BadElement', 'CANVAS context requires an HTMLCanvasElement');
         }
         const context = element.getContext('2d');

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -131,7 +131,7 @@ export class Renderer {
         }
         this.ctx = new CanvasContext(context);
       } else if (backend === Renderer.Backends.SVG) {
-        if (!(element instanceof HTMLDivElement)) {
+        if (!(element instanceof window.HTMLDivElement)) {
           throw new RuntimeError('BadElement', 'SVG context requires an HTMLDivElement.');
         }
         this.ctx = new SVGContext(element);

--- a/tests/renderer_tests.ts
+++ b/tests/renderer_tests.ts
@@ -7,12 +7,15 @@
 /* eslint-disable */
 // @ts-nocheck
 
+import { CanvasContext } from 'canvascontext';
 import { Factory, FactoryOptions } from 'factory';
 import { Formatter } from 'formatter';
 import { Renderer } from 'renderer';
 import { Stave } from 'stave';
 import { StaveNote } from 'stavenote';
+import { SVGContext } from 'svgcontext';
 import { RenderContext } from 'types/common';
+import { RuntimeError } from 'util';
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 // TODO: Should FactoryOptions.renderer.elementId also accept a canvas | div?
@@ -42,6 +45,7 @@ const RendererTests = {
     //   Pass in:  element ID string  OR  canvas/div element.
     run('Renderer API with element ID string', stringElementId, USE_RENDERER);
     run('Renderer API with canvas or div', canvasOrDivElement, USE_RENDERER);
+    run('Renderer API with context', passRenderContext);
     run('Factory API with element ID string', stringElementId, USE_FACTORY);
     run('Factory API with canvas or div', canvasOrDivElement, USE_FACTORY);
   },
@@ -152,6 +156,28 @@ function canvasOrDivElement(options: TestOptions): void {
   } else {
     useFactoryAPI(element, options.backend);
   }
+  ok(true);
+}
+
+/**
+ * Pass the render context directly to the Renderer constructor.
+ */
+function passRenderContext(options: TestOptions): void {
+  let context: RenderContext;
+  const element = document.getElementById(options.elementId) as HTMLCanvasElement | HTMLDivElement;
+  if (element instanceof HTMLCanvasElement) {
+    const ctx = element.getContext('2d');
+    if (!ctx) {
+      throw new RuntimeError(`Couldn't get context from element "${options.elemendId}"`);
+    }
+    context = new CanvasContext(ctx);
+  } else {
+    context = new SVGContext(element);
+  }
+
+  const renderer = new Renderer(context);
+  renderer.resize(STAVE_WIDTH, STAVE_HEIGHT);
+  drawStave(new Stave(0, 0, STAVE_WIDTH - STAVE_RIGHT_MARGIN).setContext(context), context);
   ok(true);
 }
 

--- a/tests/renderer_tests.ts
+++ b/tests/renderer_tests.ts
@@ -165,7 +165,7 @@ function canvasOrDivElement(options: TestOptions): void {
 function passRenderContext(options: TestOptions): void {
   let context: RenderContext;
   const element = document.getElementById(options.elementId) as HTMLCanvasElement | HTMLDivElement;
-  if (element instanceof HTMLCanvasElement) {
+  if (element instanceof window.HTMLCanvasElement) {
     const ctx = element.getContext('2d');
     if (!ctx) {
       throw new RuntimeError(`Couldn't get context from element "${options.elemendId}"`);


### PR DESCRIPTION
fixes #827
fixes #724

This enables users to create their own `RenderContext` implementations.

The required a couple of changes:
 - Move the `CanvasContext` resize logic out of `Renderer` and into `CanvasContext`.
 - Overload the `Renderer` constructor to accept a `RenderContext`.

This PR also fixes a bug in the `Factory` where it would always create an `SVGContext` even if you passed it the element ID for a `HTMLCanvasElement`. Consequently, there are a few image diffs because the `Factory.Draw` test now actually renders something for the canvas test :)