### PR TITLE
Remove "as StaveNote" from src

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -90,7 +90,7 @@ export class Accidental extends Modifier {
     // First determine the accidentals' Y positions from the note.keys
     for (let i = 0; i < accidentals.length; ++i) {
       const acc = accidentals[i];
-      const note = acc.getNote() as StaveNote;
+      const note = acc.getNote();
       const stave = note.getStave();
       const index = acc.checkIndex();
       const props = note.getKeyProps()[index];

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -316,9 +316,7 @@ export class Articulation extends Modifier {
 
     if (!isTab) {
       const offsetDirection = position === ABOVE ? -1 : +1;
-      const noteLine = isTab
-        ? (note as TabNote).getPositions()[index].str
-        : (note as StaveNote).getKeyProps()[index].line;
+      const noteLine = note.getKeyProps()[index].line;
       const distanceFromNote = (note.getYs()[index] - y) / staffSpace;
       const articLine = distanceFromNote + Number(noteLine);
       const snappedLine = snapLineToStaff(canSitBetweenLines, articLine, position, offsetDirection);

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -29,7 +29,7 @@ export class FretHandFinger extends Modifier {
 
     for (let i = 0; i < nums.length; ++i) {
       const num = nums[i];
-      const note = num.getNote() as StaveNote;
+      const note = num.getNote();
       const pos = num.getPosition();
       const index = num.checkIndex();
       const props = note.getKeyProps()[index];


### PR DESCRIPTION
Minor chnage to remove unnecessary casting to `StaveNote`