### PR TITLE
Demonstrate code splitting / lazy loading of fonts.

### DIFF
--- a/demos/fonts/all.html
+++ b/demos/fonts/all.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="outputBravura"></div>
+    <div id="outputGonville"></div>
+    <div id="outputPetaluma"></div>
+    <!-- Load the full vexflow build, which includes all three music fonts. -->
+    <script src="../../build/vexflow-full-min.js"></script>
+    <script>
+      console.log('VexFlow BUILD ' + Vex.Flow.BUILD);
+
+      ////////////////////////////////////////////////////////////////////////
+
+      Vex.Flow.DEFAULT_FONT_STACK = [Vex.Flow.Fonts.Bravura()];
+      const factoryBravura = new Vex.Flow.Factory({
+        renderer: { elementId: 'outputBravura', width: 500, height: 130 },
+      });
+      const scoreBravura = factoryBravura.EasyScore();
+      factoryBravura
+        .System()
+        .addStave({
+          voices: [
+            scoreBravura.voice(scoreBravura.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            scoreBravura.voice(scoreBravura.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+      factoryBravura.draw();
+
+      ////////////////////////////////////////////////////////////////////////
+      Vex.Flow.DEFAULT_FONT_STACK = [Vex.Flow.Fonts.Gonville()];
+      const factoryGonville = new Vex.Flow.Factory({
+        renderer: { elementId: 'outputGonville', width: 500, height: 130 },
+      });
+      const scoreGonville = factoryGonville.EasyScore();
+      factoryGonville
+        .System()
+        .addStave({
+          voices: [
+            scoreGonville.voice(scoreGonville.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            scoreGonville.voice(scoreGonville.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+      factoryGonville.draw();
+
+      ////////////////////////////////////////////////////////////////////////
+
+      Vex.Flow.DEFAULT_FONT_STACK = [Vex.Flow.Fonts.Petaluma()];
+      const factoryPetaluma = new Vex.Flow.Factory({
+        renderer: { elementId: 'outputPetaluma', width: 500, height: 130 },
+      });
+      const scorePetaluma = factoryPetaluma.EasyScore();
+      factoryPetaluma
+        .System()
+        .addStave({
+          voices: [
+            scorePetaluma.voice(scorePetaluma.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            scorePetaluma.voice(scorePetaluma.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+      factoryPetaluma.draw();
+    </script>
+  </body>
+</html>

--- a/demos/fonts/bravura.html
+++ b/demos/fonts/bravura.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="output"></div>
+    <script src="../../build/vexflow-core-min.js"></script>
+    <script src="../../build/vexflow-font-bravura-min.js"></script>
+    <script>
+      // TODO: Should we automatically set the default font stack to be Bravura only?
+
+      const factory = new Vex.Flow.Factory({ renderer: { elementId: 'output', width: 500, height: 200 } });
+      const score = factory.EasyScore();
+      const system = factory.System();
+
+      system
+        .addStave({
+          voices: [
+            score.voice(score.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            score.voice(score.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+
+      factory.draw();
+    </script>
+  </body>
+</html>

--- a/demos/fonts/glyphInspector.html
+++ b/demos/fonts/glyphInspector.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script type="module">
+      // Load the font face from a local folder.
+      // Render all SMUFL glyphs to divs along with their names and other text metrics
+      // that we can retrieve from the OTF alone.
+    </script>
+  </body>
+</html>

--- a/demos/fonts/gonville.html
+++ b/demos/fonts/gonville.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="output"></div>
+    <script src="../../build/vexflow-core-min.js"></script>
+    <script src="../../build/vexflow-font-gonville-min.js"></script>
+    <script>
+      // TODO: Should we automatically set the default font stack to be Gonville only?
+
+      const factory = new Vex.Flow.Factory({ renderer: { elementId: 'output', width: 500, height: 200 } });
+      const score = factory.EasyScore();
+      const system = factory.System();
+
+      system
+        .addStave({
+          voices: [
+            score.voice(score.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            score.voice(score.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+
+      factory.draw();
+    </script>
+  </body>
+</html>

--- a/demos/fonts/petaluma.html
+++ b/demos/fonts/petaluma.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="output"></div>
+    <script src="../../build/vexflow-core-min.js"></script>
+    <script src="../../build/vexflow-font-petaluma-min.js"></script>
+    <script>
+      // TODO: Should we automatically set the default font stack to be Petaluma only?
+
+      const factory = new Vex.Flow.Factory({ renderer: { elementId: 'output', width: 500, height: 200 } });
+      const score = factory.EasyScore();
+      const system = factory.System();
+
+      system
+        .addStave({
+          voices: [
+            score.voice(score.notes('C#5/q, B4, A4, G#4', { stem: 'up' })),
+            score.voice(score.notes('C#4/h, C#4', { stem: 'down' })),
+          ],
+        })
+        .addClef('treble')
+        .addTimeSignature('4/4');
+
+      factory.draw();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
@rvilarl I need your help :-) 

See the two comments starting from:
https://github.com/0xfe/vexflow/pull/1163#issuecomment-944351829

Folks are interested in the lazy font loading feature, but I haven't gotten it to work. This PR adds some demos, but I am getting errors like:

```
jsonp chunk loading:85 Uncaught TypeError: i.forEach is not a function
    at jsonp chunk loading:85
    at vexflow-core-min.js:6
    at universalModuleDefinition:11
    at universalModuleDefinition:9
    at universalModuleDefinition:1
(anonymous) @ jsonp chunk loading:85
(anonymous) @ vexflow-core-min.js:6
(anonymous) @ universalModuleDefinition:11
(anonymous) @ universalModuleDefinition:9
(anonymous) @ universalModuleDefinition:1
vexflow-font-bravura-min.js:6 Uncaught TypeError: (intermediate value)(intermediate value)(intermediate value).push is not a function
    at vexflow-font-bravura-min.js:6
(anonymous) @ vexflow-font-bravura-min.js:6
bravura.html:9 Uncaught ReferenceError: Vex is not defined
    at bravura.html:9
(anonymous) @ bravura.html:9
```

The `all.html` which loads `vexflow-full-min.js` works as expected. The individual demos throw the error above.

Can you check out this branch and help me investigate? It is also interesting that `vexflow-font-petaluma-min.js` is twice the size of `vexflow-font-bravura-min.js`.... not sure why. :-)