### PR TITLE
Parallel generate image 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,14 +57,17 @@
     "reference": "grunt reference",
     "lint": "grunt eslint",
     "qunit": "grunt test",
-    "generate:current": "node ./tools/generate_png_images.js ../build ./build/images/current",
-    "generate:reference": "node ./tools/generate_png_images.js ../reference ./build/images/reference",
-    "generate:blessed": "node ./tools/generate_png_images.js ../releases ./build/images/blessed",
+    "generate:current": "node ./tools/generate_png_images.js ../build ./build/images/current ${VF_GENERATE_OPTIONS}",
+    "generate:reference": "node ./tools/generate_png_images.js ../reference ./build/images/reference ${VF_GENERATE_OPTIONS}",
+    "generate:blessed": "node ./tools/generate_png_images.js ../releases ./build/images/blessed ${VF_GENERATE_OPTIONS}",
     "generate": "npm run generate:current && npm run generate:blessed",
     "diff": "./tools/visual_regression.sh blessed",
     "diff:reference": "./tools/visual_regression.sh reference",
     "test": "npm run lint && npm run qunit && npm run generate && npm run diff",
-    "test:reference": "npm run lint && npm run qunit && npm run generate:current && npm run generate:reference && npm run diff:reference"
+    "test:reference": "npm run lint && npm run qunit && npm run generate:current && npm run generate:reference && npm run diff:reference",
+    "cache:save:reference": "rm -rf ./reference/images && mv ./build/images/reference ./reference/images",
+    "cache:restore:reference": "mv ./reference/images ./build/images/reference",
+    "test:reference:cache": "npm run cache:save:reference && npm run lint && npm run qunit && npm run generate:current && npm run cache:restore:reference && npm run diff:reference"
   },
   "homepage": "http://vexflow.com",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "diff:reference": "./tools/visual_regression.sh reference",
     "test": "npm run lint && npm run qunit && npm run generate && npm run diff",
     "test:reference": "npm run lint && npm run qunit && npm run generate:current && npm run generate:reference && npm run diff:reference",
-    "cache:save:reference": "rm -rf ./reference/images && mv ./build/images/reference ./reference/images",
-    "cache:restore:reference": "mv ./reference/images ./build/images/reference",
+    "cache:save:reference": "if [ -d ./build/images/reference ]; then rm -rf ./reference/images && mv ./build/images/reference ./reference/images; fi;",
+    "cache:restore:reference": "if [ -d ./reference/images ]; then mv ./reference/images ./build/images/reference; else npm run generate:reference; fi;",
     "test:reference:cache": "npm run cache:save:reference && npm run lint && npm run qunit && npm run generate:current && npm run cache:restore:reference && npm run diff:reference"
   },
   "homepage": "http://vexflow.com",

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -202,7 +202,9 @@ export class MultiMeasureRest extends Element {
       },
     };
 
-    const spacing = this.hasSymbolSpacing ? options.symbol_spacing : rest_width * 1.35;
+
+    /* 10: normal spacingBetweenLines */
+    const spacing = this.hasSymbolSpacing ? options.symbol_spacing : 10;
 
     const width = n4 * glyphs[2].width + n2 * glyphs[2].width + n1 * glyphs[1].width + (n4 + n2 + n1 - 1) * spacing;
     let x = left + (right - left) * 0.5 - width * 0.5;

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -202,7 +202,6 @@ export class MultiMeasureRest extends Element {
       },
     };
 
-
     /* 10: normal spacingBetweenLines */
     const spacing = this.hasSymbolSpacing ? options.symbol_spacing : 10;
 

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -55,7 +55,7 @@ export interface MultimeasureRestRenderOptions {
   serif_thickness?: number;
 }
 
-let semibreve_rest: { glyph_font_scale: number; glyph_code: string; width: number };
+let semibreve_rest: { glyph_font_scale: number; glyph_code: string; width: number } | undefined;
 
 function get_semibreve_rest() {
   if (!semibreve_rest) {
@@ -184,6 +184,11 @@ export class MultiMeasureRest extends Element {
     const n1 = n % 2;
 
     const options = this.render_options;
+
+    // FIXME: TODO: invalidate semibreve_rest at the appropriate time
+    // (e.g., if the system font settings are changed).
+    semibreve_rest = undefined;
+
     const rest = get_semibreve_rest();
     const rest_scale = options.semibreve_rest_glyph_scale;
     const rest_width = rest.width * (rest_scale / rest.glyph_font_scale);

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -145,6 +145,7 @@ function diff_image() {
     return
   fi
 
+  # If the two files are byte-for-byte identical, skip the image comparison below.
   cmp -s $fileA $fileB && echo $name "0" >$diff.pass && return
 
   cp $fileA $diff-a.png

--- a/tools/visual_regression.sh
+++ b/tools/visual_regression.sh
@@ -145,6 +145,8 @@ function diff_image() {
     return
   fi
 
+  cmp -s $fileA $fileB && echo $name "0" >$diff.pass && return
+
   cp $fileA $diff-a.png
   cp $fileB $diff-b.png
 


### PR DESCRIPTION
This PR contains:

- generate_png_images.js: added some options:
  - `--parallel[=<jobs>]` : exec processes in parallel for each font
    - `<jobs>`:
      - `<jobs><=1`: explicitly to disable parallel execution
      - unspecified: enable parallel execution
      - otherwise: In the future, it may be possible to limit the number of processes
    - `*.Bravura.png` is generated as `*.png`.
    - see: https://github.com/0xfe/vexflow/blob/a4920f128ff65f683da029d76feb8a6919eb1bf4/tests/vexflow_test_helpers.ts#L223
  - `--backcompat`: generate test results for Bravura fonts with old-style file names
    - rename `*.Bravura.png` to `*.png`.
- visual_regression.sh: reduce execution time
  - by using `cmp -s`
- package.json: added some run commands:
  - environment variable for `generate*` run commands:
    - VF_GENERATE_OPTIONS:
      - `VF_GENERATE_OPTIONS=--backcompat npm run generate:reference`
        - output filenames are comparable to the set of files generated by specifying `--parallel`
      - `VF_GENERATE_OPTIONS=--parallel npm run generate:reference`
        - run tests in parallel
        - If you have enough cpu and memory in your environment, you may be able to reduce the execution time by specifying this option
      - `VF_GENERATE_OPTIONS=--fonts=Bravura npm run generate:reference`
        - run only Bravura test
      - `VF_GENERATE_OPTIONS=--parallel npm run test:reference`
        - Both `current` and `reference` run the tests for each font in parallel
      - etc.
  - `test:reference:cache` run command:
    - checkout reference version and `npm run reference` to build reference.
    - checkout current version and `npm run test:reference`
    - fix problems
    - `npm run test:reference:cache`
      - re-use ./build/images/reference
---

## Speed measurement
Core(TM) i7-4790S CPU @ 3.20GHz
ubuntu(18.04.6 LTS (Bionic Beaver)) VMware on window10
memory: 13G

|  command | this branch  | master|
| ---- | ---- |---- |
|time (VF_GENERATE_OPTIONS=--parallel npm run generate:reference) | real	0m13.259s| real	0m24.666s|
|time (npm run diff:reference) | real	0m10.512s (!!!!!)|real	2m4.742s|



