### PR TITLE
bug introduced in PR #1192 resolved

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -211,7 +211,7 @@ export const Flow = {
     Tables.STEM_HEIGHT = value;
   },
   get STEM_WIDTH(): number {
-    return Tables.STEM_HEIGHT;
+    return Tables.STEM_WIDTH;
   },
   set STEM_WIDTH(value: number) {
     Tables.STEM_WIDTH = value;


### PR DESCRIPTION
minor bug resolved.

I saw it while cosidering if the members of `Table` should me camelCase. ie.: `Table.stemWidth` rather than `Table.STEM_WIDTH`. @0xfe what is your preference? `Table` is now internal.