### PR TITLE
fix issues 555, 792.  Fix metrics with tremolo Gonville and Petaluma, and Petaluma grace notes

### DIFF
--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -92,20 +92,20 @@ export const GonvilleMetrics = {
 
   tremolo: {
     default: {
-      point: 40,
+      point: 25,
       spacing: 4,
-      offsetYStemUp: -9,
-      offsetYStemDown: -21,
-      offsetXStemUp: 6,
-      offsetXStemDown: -2,
+      offsetYStemUp: -17,
+      offsetYStemDown: -2,
+      offsetXStemUp: 9,
+      offsetXStemDown: -0.5,
     },
     grace: {
-      point: 30,
+      point: 15,
       spacing: 4,
-      offsetYStemUp: -9,
-      offsetYStemDown: -21,
-      offsetXStemUp: 6,
-      offsetXStemDown: -2,
+      offsetYStemUp: -17,
+      offsetYStemDown: -2,
+      offsetXStemUp: 6.5,
+      offsetXStemDown: -0.5,
     },
   },
 

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -117,7 +117,7 @@ export const PetalumaMetrics = {
       spacing: 5,
       offsetYStemUp: -5,
       offsetYStemDown: 5,
-      offsetXStemUp: 11,
+      offsetXStemUp: 13,
       offsetXStemDown: 1,
     },
     grace: {
@@ -125,7 +125,7 @@ export const PetalumaMetrics = {
       spacing: 4,
       offsetYStemUp: -5,
       offsetYStemDown: 5,
-      offsetXStemUp: 7,
+      offsetXStemUp: 8,
       offsetXStemDown: 1,
     },
   },
@@ -302,31 +302,13 @@ export const PetalumaMetrics = {
       minPadding: 2,
       standard: {
         noteheadBlackStemUp: {
-          shiftX: 1.625,
-          point: 34,
-        },
-        noteheadBlackStemDown: {
-          point: 34,
+          shiftX: 1.625
         },
         noteheadHalfStemUp: {
-          shiftX: 1.725,
-          point: 34,
-        },
-        noteheadHalfStemDown: {
-          point: 34,
+          shiftX: 1.725
         },
         noteheadWholeStemUp: {
-          shiftX: 1,
-          point: 34,
-        },
-        noteheadWholeStemDown: {
-          point: 34,
-        },
-        restQuarterStemUp: {
-          point: 35,
-        },
-        restQuarterStemDown: {
-          point: 35,
+          shiftX: 1
         },
       },
       custom: {

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -302,10 +302,10 @@ export const PetalumaMetrics = {
       minPadding: 2,
       standard: {
         noteheadBlackStemUp: {
-          shiftX: 1.625
+          shiftX: 0.5
         },
         noteheadHalfStemUp: {
-          shiftX: 1.725
+          shiftX: 0.725
         },
         noteheadWholeStemUp: {
           shiftX: 1


### PR DESCRIPTION
resolves #555, resolves #792 

Add/repair formatting for tremolo and grace notes for some fonts.  I am no designer and I don't have such a good eye for small visual details, but these look pretty good to me.   Gonville tremolo is hard to judge b/c it's so slanty.

before:
![image](https://user-images.githubusercontent.com/5438280/138606078-3bae87db-e3e3-49a4-af9e-8cba6664287b.png)
after:
![image](https://user-images.githubusercontent.com/5438280/138606103-03a9247d-de74-4b67-9270-5d6a1799f13f.png)

before:
![image](https://user-images.githubusercontent.com/5438280/138606124-21c25f2a-7ff1-4bed-91c5-82c02bf84c9d.png)
after:
![image](https://user-images.githubusercontent.com/5438280/138606138-bd8d414d-db41-4b3f-822a-ff0f9d32529b.png)
