### PR TITLE
Use constants in Font class. Fix font related bugs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,6 +362,18 @@ export default Vex;`;
     ]
   );
 
+  // `grunt watchDevelop`
+  // This is the fastest way to build vexflow-debug-with-tests.js.
+  // Open tests/flow.html to see the test output.
+  grunt.registerTask(
+    'watchDevelop',
+    `Watch src/ & tests/ for changes and generate a development build.`, //
+    [
+      'clean:build', //
+      'webpack:watchDebugPlusTests',
+    ]
+  );
+
   // `grunt test`
   grunt.registerTask(
     'test',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "vexflow",
-  "version": "3.0.9",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vexflow",
-      "version": "3.0.9",
+      "version": "4.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
       "devDependencies": {
-        "@types/offscreencanvas": "^2019.6.4",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "canvas": "^2.8.0",
@@ -221,8 +223,7 @@
     "node_modules/@types/offscreencanvas": {
       "version": "2019.6.4",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
-      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
-      "dev": true
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
     "node_modules/@types/raf": {
       "version": "3.4.0",
@@ -9775,8 +9776,7 @@
     "@types/offscreencanvas": {
       "version": "2019.6.4",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
-      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q==",
-      "dev": true
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
     "@types/raf": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
   "bugs": {
     "url": "https://github.com/0xfe/vexflow/issues"
   },
+  "dependencies": {
+    "@types/offscreencanvas": "^2019.6.4"
+  },
   "devDependencies": {
-    "@types/offscreencanvas": "^2019.6.4",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
     "canvas": "^2.8.0",

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -1,10 +1,10 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
-import { globalObject, isHTMLCanvas } from '.';
 import { Font, FontInfo } from './font';
 import { GroupAttributes, RenderContext, TextMeasure } from './rendercontext';
-import { warn } from './util';
+import { isHTMLCanvas } from './typeguard';
+import { globalObject, warn } from './util';
 
 /**
  * A rendering context for the Canvas backend. This class serves as a proxy for the

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -375,12 +375,7 @@ export class ChordSymbol extends Modifier {
     let family = 'Roboto Slab, Times, serif';
     if (Tables.currentMusicFont().getName() === 'Petaluma') {
       // Fixes Issue #1180
-      // https://github.com/0xfe/vexflow/issues/1180
-      // family = 'PetalumaScript, Arial, sans-serif';
-
-      // RONYEH: A mismatched font family results in loading Roboto Slab's metrics instead.
-      // DELETE THE FOLLOWING LINE AND RESTORE THE ONE ABOVE.
-      family = 'petalumaScript,Arial';
+      family = 'PetalumaScript, Arial, sans-serif';
     }
     return {
       family,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -2,6 +2,7 @@
 // @author Mohit Cheppudira
 // MIT License
 
+import { AnnotationHorizontalJustify, AnnotationVerticalJustify } from '.';
 import { Accidental } from './accidental';
 import { Annotation } from './annotation';
 import { Articulation } from './articulation';
@@ -12,7 +13,7 @@ import { ClefNote } from './clefnote';
 import { Curve, CurveOptions } from './curve';
 import { EasyScore, EasyScoreOptions } from './easyscore';
 import { Element } from './element';
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { FontInfo } from './font';
 import { Formatter, FormatterOptions } from './formatter';
 import { FretHandFinger } from './frethandfinger';
 import { GhostNote } from './ghostnote';
@@ -335,27 +336,23 @@ export class Factory {
     return accid;
   }
 
-  Annotation(params?: { text?: string; vJustify?: string; hJustify?: string; font?: FontInfo }): Annotation {
+  Annotation(params?: {
+    text?: string;
+    hJustify?: string | AnnotationHorizontalJustify;
+    vJustify?: string | AnnotationVerticalJustify;
+    font?: FontInfo;
+  }): Annotation {
     const p = {
       text: 'p',
-      vJustify: 'below',
-      hJustify: 'center',
-      options: {},
+      hJustify: AnnotationHorizontalJustify.CENTER,
+      vJustify: AnnotationVerticalJustify.BOTTOM,
       ...params,
     };
 
-    // RONYEH: Factory.Annotation has a different default font from new Annotation()...
-    const font = {
-      family: 'Times' /* RONYEH: Font.SERIF */,
-      size: 14,
-      weight: FontWeight.BOLD,
-      style: FontStyle.ITALIC,
-      ...p.font,
-    };
     const annotation = new Annotation(p.text);
     annotation.setJustification(p.hJustify);
     annotation.setVerticalJustification(p.vJustify);
-    annotation.setFont(font);
+    annotation.setFont(p.font);
     annotation.setContext(this.context);
     return annotation;
   }

--- a/src/fonts/textfonts.ts
+++ b/src/fonts/textfonts.ts
@@ -12,10 +12,9 @@ export function loadTextFonts() {
     const fontData = RobotoSlabFont;
     const { fontFamily, resolution, glyphs } = fontData;
     Font.load(fontFamily, fontData);
-    // H isn't actually the tallest or the widest.
-    // Interestingly, the lowercase b is the tallest.
-    const maxSizeGlyph = 'H'; // Two lines of lyrics touch each other because we don't allow enough vertical space.
-    // const maxSizeGlyph = 'b'; // RONYEH: introduces a visual diff, but the spacing is better.
+    // Previously we used 'H', but it isn't actually the tallest or the widest.
+    // Interestingly, the lowercase 'b' is the tallest glyph.
+    const maxSizeGlyph = 'b';
     TextFormatter.registerInfo({
       family: fontFamily,
       resolution,
@@ -36,9 +35,9 @@ export function loadTextFonts() {
     const fontData = PetalumaScriptFont;
     const { fontFamily, resolution, glyphs } = fontData;
     Font.load(fontFamily, fontData);
-    // M is wider, but H is taller. :-) We continue to use H for consistency / legacy reasons.
+    // M is wider, but H is taller. :-)
     // Lowercase b is also taller in this font.
-    const maxSizeGlyph = 'H';
+    const maxSizeGlyph = 'b';
     TextFormatter.registerInfo({
       family: fontFamily,
       resolution,

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -4,7 +4,7 @@
 // Class to draws string numbers into the notation.
 
 import { Builder } from './easyscore';
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { StaveNote } from './stavenote';
@@ -16,7 +16,7 @@ export class FretHandFinger extends Modifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'sans-serif' /* RONYEH: Font.SANS_SERIF */,
+    family: Font.SANS_SERIF,
     size: 9,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/gracetabnote.ts
+++ b/src/gracetabnote.ts
@@ -8,7 +8,7 @@
 //
 // See `tests/gracetabnote_tests.ts` for usage examples.
 
-// import { Font } from './font'; // RONYEH
+import { Font } from './font';
 import { TabNote, TabNoteStruct } from './tabnote';
 
 export class GraceTabNote extends TabNote {
@@ -26,8 +26,7 @@ export class GraceTabNote extends TabNote {
       // grace glyph scale
       scale: 0.6,
       // grace tablature font
-      font: `7.5pt Arial`,
-      // font: `7.5pt ${Font.SANS_SERIF}`, // RONYEH
+      font: `7.5pt ${Font.SANS_SERIF}`,
     };
 
     this.updateWidth();

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export * from './stringnumber';
 export * from './strokes';
 export * from './svgcontext';
 export * from './system';
-// Do not export './tables'.
+// Do not export './tables' because it is internal.
 export * from './tabnote';
 export * from './tabslide';
 export * from './tabstave';

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -4,7 +4,7 @@
 import { BoundingBox, Bounds } from './boundingbox';
 import { Clef } from './clef';
 import { Element, ElementStyle } from './element';
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { KeySignature } from './keysignature';
 import { Barline, BarlineType } from './stavebarline';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
@@ -65,7 +65,7 @@ export class Stave extends Element {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'sans-serif' /* RONYEH: Font.SANS_SERIF*/,
+    family: Font.SANS_SERIF,
     size: 8,
     weight: FontWeight.NORMAL,
     style: FontStyle.NORMAL,

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -2,7 +2,7 @@
 // MIT License
 
 import { Element } from './element';
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { RenderContext } from './rendercontext';
 import { Stave } from './stave';
@@ -36,7 +36,7 @@ export class StaveConnector extends Element {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'Times' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: 16,
     weight: FontWeight.NORMAL,
     style: FontStyle.NORMAL,

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -1,7 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Larry Kuhns 2011
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
@@ -12,7 +12,7 @@ export class Repetition extends StaveModifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'Times' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: 12,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -1,7 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Larry Kuhns 2011
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
 
@@ -11,7 +11,7 @@ export class StaveSection extends StaveModifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'sans-serif' /* RONYEH: Font.SANS_SERIF */,
+    family: Font.SANS_SERIF,
     size: 12,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -1,7 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Radosaw Eichler 2012
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
@@ -20,7 +20,7 @@ export class StaveTempo extends StaveModifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'Times' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: 14,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -1,7 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Taehoon Moon 2014
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Justification, TextNote } from './textnote';
@@ -13,7 +13,7 @@ export class StaveText extends StaveModifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'Times' /* RONYEH: Font.SERIF*/,
+    family: Font.SERIF,
     size: 16,
     weight: FontWeight.NORMAL,
     style: FontStyle.NORMAL,

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -1,7 +1,7 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // Author Larry Kuhns 2011
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
 
@@ -23,7 +23,7 @@ export class Volta extends StaveModifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'sans-serif' /* RONYEH: Font.SANS_SERIF */,
+    family: Font.SANS_SERIF,
     size: 9,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -19,7 +19,7 @@ export class StringNumber extends Modifier {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'sans-serif' /* RONYEH: Font.SANS_SERIF */,
+    family: Font.SANS_SERIF,
     size: Font.SIZE,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -28,7 +28,7 @@ export class Stroke extends Modifier {
   };
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'serif' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: Font.SIZE,
     weight: FontWeight.BOLD,
     style: FontStyle.ITALIC,

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -8,7 +8,7 @@
 // See `tests/tabnote_tests.ts` for usage examples.
 
 import { Dot } from './dot';
-// import { Font } from './font'; // RONYEH
+import { Font } from './font';
 import { Glyph, GlyphProps } from './glyph';
 import { Modifier } from './modifier';
 import { Stave } from './stave';
@@ -160,8 +160,7 @@ export class TabNote extends StemmableNote {
       // normal glyph scale
       scale: 1.0,
       // default tablature font
-      font: `10pt Arial`,
-      // font: `${Font.SIZE}pt ${Font.SANS_SERIF}`, // RONYEH
+      font: `${Font.SIZE}pt ${Font.SANS_SERIF}`,
     };
 
     this.glyph = Tables.getGlyphProps(this.duration, this.noteType);

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -4,7 +4,7 @@
 // This class implements varies types of ties between contiguous notes. The
 // ties include: regular ties, hammer ons, pull offs, and slides.
 
-import { FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { TieNotes } from './stavetie';
 import { TabNote } from './tabnote';
 import { TabTie } from './tabtie';
@@ -16,7 +16,7 @@ export class TabSlide extends TabTie {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'Times' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: 10,
     weight: FontWeight.BOLD,
     style: FontStyle.ITALIC,

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -40,7 +40,7 @@ export class TextBracket extends Element {
   }
 
   static TEXT_FONT: Required<FontInfo> = {
-    family: 'serif' /* RONYEH: Font.SERIF */,
+    family: Font.SERIF,
     size: 15,
     weight: FontWeight.NORMAL,
     style: FontStyle.ITALIC,

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -9,10 +9,12 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { ModifierPosition } from '../src';
 import { Annotation } from '../src/annotation';
 import { Beam } from '../src/beam';
 import { Bend } from '../src/bend';
 import { Flow } from '../src/flow';
+import { Font, FontStyle, FontWeight } from '../src/font';
 import { Formatter } from '../src/formatter';
 import { Registry } from '../src/registry';
 import { ContextBuilder } from '../src/renderer';
@@ -77,8 +79,9 @@ function lyrics(options: TestOptions): void {
       const verse = Math.floor(ix / 3);
       const noteGroupID = 'n' + (ix % 3);
       const noteGroup = registry.getElementById(noteGroupID) as Tickable;
-      noteGroup.addModifier(f.Annotation({ text }).setFont('Roboto Slab', fontSize, 'normal'), verse);
-      // noteGroup.addModifier(f.Annotation({ text }).setFont('Roboto Slab', fontSize), verse); // RONYEH
+      const lyricsAnnotation = f.Annotation({ text }).setFont('Roboto Slab', fontSize);
+      lyricsAnnotation.setPosition(ModifierPosition.ABOVE);
+      noteGroup.addModifier(lyricsAnnotation, verse);
     });
 
     // Second row doesn't have any lyrics.
@@ -100,8 +103,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
-  ctx.font = ' 10pt Arial';
-  // ctx.font = '10pt Arial, sans-serif'; // RONYEH
+  ctx.font = '10pt Arial, sans-serif';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
   const notes = [
@@ -131,8 +133,7 @@ function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.strokeStyle = '#221';
   const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
 
-  const annotation = (text: string) => new Annotation(text).setFont('Times', FONT_SIZE, 'normal', 'italic'); // BUG: Previously passed 'italic' into font weight.
-  // const annotation = (text: string) => new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic'); // RONYEH
+  const annotation = (text: string) => new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic');
 
   const notes = [
     staveNote({ keys: ['c/4', 'e/4'], duration: 'h' }).addAnnotation(0, annotation('quiet')),
@@ -148,8 +149,7 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
-  ctx.font = ' 10pt Arial';
-  // ctx.font = '10pt Arial'; // RONYEH
+  ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
   const notes = [
@@ -164,8 +164,7 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
       positions: [{ str: 2, fret: 9 }],
       duration: 'h',
     })
-      .addModifier(new Annotation('(8va)').setFont('Times', FONT_SIZE, 'normal', 'italic'), 0) // BUG: Previously passed 'italic' into font weight.
-      // .addModifier(new Annotation('(8va)').setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic'), 0) // RONYEH
+      .addModifier(new Annotation('(8va)').setFont(Font.SERIF, FONT_SIZE, FontWeight.NORMAL, FontStyle.ITALIC), 0)
       .addModifier(new Annotation('A.H.'), 0),
   ];
 
@@ -178,12 +177,11 @@ function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
   ctx.setFillStyle('#221');
   ctx.setStrokeStyle('#221');
-  ctx.setFont('Arial', FONT_SIZE);
-  // ctx.setFont(Font.SANS_SERIF, FONT_SIZE); // RONYEH
+  ctx.setFont(Font.SANS_SERIF, FONT_SIZE);
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
-  const annotation = (text: string) => new Annotation(text).setFont('Times', FONT_SIZE, 'italic');
-  // const annotation = (text: string) => new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic'); // RONYEH
+  const annotation = (text: string) =>
+    new Annotation(text).setFont(Font.SERIF, FONT_SIZE, FontWeight.NORMAL, FontStyle.ITALIC);
 
   const notes = [
     tabNote({
@@ -226,8 +224,7 @@ function bottom(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string) =>
-    new Annotation(text).setFont('Times', FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM);
-  // new Annotation(text).setFont(Font.SERIF, FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM); // RONYEH
+    new Annotation(text).setFont(Font.SERIF, FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM);
 
   const notes = [
     staveNote({ keys: ['f/4'], duration: 'w' }).addAnnotation(0, annotation('F')),
@@ -281,8 +278,7 @@ function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilde
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)
-      .setFont('Arial', FONT_SIZE)
-      // .setFont(Font.SANS_SERIF, FONT_SIZE) // RONYEH
+      .setFont(Font.SANS_SERIF, FONT_SIZE)
       .setJustification(hJustification)
       .setVerticalJustification(vJustification);
 
@@ -310,8 +306,7 @@ function justificationStemDown(options: TestOptions, contextBuilder: ContextBuil
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)
-      .setFont('Arial', FONT_SIZE)
-      // .setFont(Font.SANS_SERIF, FONT_SIZE) // RONYEH
+      .setFont(Font.SANS_SERIF, FONT_SIZE)
       .setJustification(hJustification)
       .setVerticalJustification(vJustification);
 
@@ -331,8 +326,7 @@ function justificationStemDown(options: TestOptions, contextBuilder: ContextBuil
 
 function tabNotes(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 600, 200);
-  ctx.font = '10pt Arial';
-  // ctx.font = '10pt Arial, sans-serif'; // RONYEH
+  ctx.font = '10pt Arial, sans-serif';
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
   stave.draw();

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -7,12 +7,18 @@
 
 import { concat, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Beam } from '../src/beam';
-import { StaveNoteStruct } from '../src/stavenote';
-import { Stem } from '../src/stem';
-import { StemmableNote } from '../src/stemmablenote';
-import { TabNoteStruct } from '../src/tabnote';
-import { Voice } from '../src/voice';
+import {
+  AnnotationVerticalJustify,
+  Beam,
+  Font,
+  FontStyle,
+  FontWeight,
+  StaveNoteStruct,
+  Stem,
+  StemmableNote,
+  TabNoteStruct,
+  Voice,
+} from '../src/index';
 
 const BeamTests = {
   Start(): void {
@@ -709,8 +715,8 @@ function tabBeamsAutoStem(options: TestOptions): void {
 }
 
 function complexWithAnnotation(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 500, 200);
-  const stave = f.Stave({ y: 40 });
+  const factory = VexFlowTests.makeFactory(options, 500, 200);
+  const stave = factory.Stave({ y: 40 });
 
   const s1: StaveNoteStruct[] = [
     { keys: ['e/4'], duration: '128', stem_direction: 1 },
@@ -732,18 +738,33 @@ function complexWithAnnotation(options: TestOptions): void {
     { keys: ['c/5'], duration: '32', stem_direction: -1 },
   ];
 
-  const notes1 = s1.map((struct) => f.StaveNote(struct).addModifier(f.Annotation({ text: '1', vJustify: 'above' }), 0));
+  const font = {
+    family: Font.SERIF,
+    size: 14,
+    weight: FontWeight.BOLD,
+    style: FontStyle.ITALIC,
+  };
 
-  const notes2 = s2.map((struct) => f.StaveNote(struct).addModifier(f.Annotation({ text: '3', vJustify: 'below' }), 0));
+  const notes1 = s1.map((struct) =>
+    factory
+      .StaveNote(struct) //
+      .addModifier(factory.Annotation({ text: '1', vJustify: AnnotationVerticalJustify.TOP, font }), 0)
+  );
 
-  f.Beam({ notes: notes1 });
-  f.Beam({ notes: notes2 });
+  const notes2 = s2.map((struct) =>
+    factory
+      .StaveNote(struct) //
+      .addModifier(factory.Annotation({ text: '3', vJustify: AnnotationVerticalJustify.BOTTOM, font }), 0)
+  );
 
-  const voice = f.Voice().setMode(Voice.Mode.SOFT).addTickables(notes1).addTickables(notes2);
+  factory.Beam({ notes: notes1 });
+  factory.Beam({ notes: notes2 });
 
-  f.Formatter().joinVoices([voice]).formatToStave([voice], stave, { stave: stave });
+  const voice = factory.Voice().setMode(Voice.Mode.SOFT).addTickables(notes1).addTickables(notes2);
 
-  f.draw();
+  factory.Formatter().joinVoices([voice]).formatToStave([voice], stave, { stave: stave });
+
+  factory.draw();
 
   ok(true, 'Complex beam annotations');
 }

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -5,6 +5,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Font } from '../src';
 import { Bend, BendPhrase } from '../src/bend';
 import { Formatter } from '../src/formatter';
 import { ModifierContext } from '../src/modifiercontext';
@@ -40,8 +41,7 @@ function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.scale(1.5, 1.5);
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
-  ctx.setRawFont(' 10pt Arial');
-  // ctx.font = '10pt Arial'; // RONYEH
+  ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
   const notes = [
@@ -134,8 +134,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
   ctx.scale(1.5, 1.5);
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
-  ctx.setRawFont('10pt Arial');
-  // ctx.font = Font.SIZE + 'pt ' + Font.SANS_SERIF; // RONYEH
+  ctx.setFont('10pt Arial');
 
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -188,8 +187,7 @@ function bendPhrase(options: TestOptions, contextBuilder: ContextBuilder): void 
   ctx.scale(1.5, 1.5);
   ctx.fillStyle = '#221';
   ctx.strokeStyle = '#221';
-  ctx.setRawFont(' 10pt Arial');
-  // ctx.font = '10pt ' + Font.SANS_SERIF; // RONYEH We can use some constatns defined in Font.
+  ctx.font = Font.SIZE + 'pt ' + Font.SANS_SERIF; // Optionally use constants defined in Font.
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
   const phrase1 = [

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -39,9 +39,11 @@
       // Support a query param to choose which VexFlow version to load.
       // ver=(build|reference|releases|etc...)
       // If omitted, `ver` defaults to 'build'.
-      // `ver` can also specify a version hosted on unpkg.com:
-      // ver=unpkg@3.0.9  or  ver=unpkg@1.2.77
-      // See: https://unpkg.com/vexflow@3.0.9/releases/vexflow-debug.js
+      // `ver` can also specify a version hosted on unpkg.com / jsdelivr.com:
+      // ver=unpkg@3.0.9     => https://unpkg.com/vexflow@3.0.9/releases/vexflow-debug.js
+      // ver=unpkg@1.2.77    => https://unpkg.com/vexflow@1.2.77/releases/vexflow-debug.js
+      // ver=jsdelivr@4.0.0  => https://cdn.jsdelivr.net/npm/vexflow@4.0.0/build/vexflow-debug.js
+      // ver=jsdelivr@1.2.90 => https://cdn.jsdelivr.net/npm/vexflow@1.2.90/releases/vexflow-debug.js
       const params = new URLSearchParams(window.location.search);
       const ver = params.get('ver') ?? 'build';
 
@@ -50,18 +52,31 @@
       let vexPlusTestsURL;
       let isVersionFourOrNewer = true;
 
+      // Determine if we are loading VexFlow from a CDN.
+      let cdnURLPath;
       if (ver.includes('unpkg')) {
+        cdnURLPath = 'https://unpkg.com/';
+      } else if (ver.includes('jsdelivr')) {
+        cdnURLPath = 'https://cdn.jsdelivr.net/npm/';
+      }
+      // If we are loading from a CDN, build the URLs.
+      if (typeof cdnURLPath !== 'undefined') {
         const version = ver.split('@')[1];
-        vexURL = `https://unpkg.com/vexflow@${version}/releases/vexflow-debug.js`;
-        testsURL = `https://unpkg.com/vexflow@${version}/releases/vexflow-tests.js`;
         if (parseFloat(version) < 4) {
           isVersionFourOrNewer = false;
+          vexURL = `${cdnURLPath}vexflow@${version}/releases/vexflow-debug.js`;
+          testsURL = `${cdnURLPath}vexflow@${version}/releases/vexflow-tests.js`;
+        } else {
+          // VexFlow 4 moved the build output from releases/ to build/.
+          vexURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug.js`;
+          vexPlusTestsURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug-with-tests.js`;
         }
       } else {
+        // We are NOT loading from a CDN.
+        // We are loading from the local filesystem (vexflow/build/ | vexflow/reference | vexflow/releases/).
         const path = ver;
 
-        // RONYEH: For now, we assume the 'releases' folder is version 3.0.9.
-        // Before we ship 4.0, we'll need to update this to reflect any changes to the releases/ folder.
+        // We assume the 'releases' folder is version 3.0.9 or older, since 4.0.0 moved to the build/ folder.
         if (path === 'releases') {
           isVersionFourOrNewer = false;
         }

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -5,19 +5,24 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Font, FontGlyph } from '../src';
-import { Annotation } from '../src/annotation';
-import { Beam } from '../src/beam';
-import { Bend } from '../src/bend';
-import { Flow } from '../src/flow';
-import { Formatter } from '../src/formatter';
-import { Note } from '../src/note';
-import { Registry } from '../src/registry';
-import { Stave } from '../src/stave';
-import { StaveConnector } from '../src/staveconnector';
-import { StaveNote } from '../src/stavenote';
+import {
+  Annotation,
+  Beam,
+  Bend,
+  Flow,
+  Font,
+  FontGlyph,
+  FontWeight,
+  Formatter,
+  Note,
+  Registry,
+  Stave,
+  StaveConnector,
+  StaveNote,
+  Voice,
+  VoiceTime,
+} from '../src/index';
 import { Tables } from '../src/tables';
-import { Voice, VoiceTime } from '../src/voice';
 import { MockTickable } from './mocks';
 
 const FormatterTests = {
@@ -712,8 +717,7 @@ function annotations(options: TestOptions): void {
           0,
           new Annotation(sm.lyrics[iii])
             .setVerticalJustification(Annotation.VerticalJustify.BOTTOM)
-            .setFont('Times', 12, 'normal')
-          // .setFont(Font.SERIF, 12, FontWeight.NORMAL) // RONYEH
+            .setFont(Font.SERIF, 12, FontWeight.NORMAL)
         );
       }
       notes.push(note);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,27 @@
 // vexflow-debug-with-tests.ts includes this module via:
 //   export * from '../../tests';
-// To add a new test class, add an export * statement to this file for that class.
-// The test file needs to call VexFlowTests.register(...).
+//
+// To add a new test module, add a new line:
+//   `export * from './xxxx_tests';`
+// to this file that points to the new file `xxxx_tests.ts`.
+//
+// The test module needs to call VexFlowTests.register(...).
+// For example, in annotation_tests.ts, the last two lines are:
+//   VexFlowTests.register(AnnotationTests);
+//   export { AnnotationTests };
+//
 // In vexflow_test_helpers.ts: VexFlowTests.run() will run all registered tests.
+//
+// To iterate faster during development, you can comment out most of this file
+// and focus on just testing the module(s) you are currently working on.
+//
+// For example, you can open two terminals and run the following:
+//   grunt watchDevelop
+//   fswatch build/vexflow-debug-with-tests.js | xargs -n1 -I{} npm run generate:current
+// The first `grunt watchDevelop` command will build a new vexflow-debug-with-tests.js
+// every time you edit a file. The second command render PNGs for each test module that is
+// not commented out. It will do this every time the first command produces a new build.
+
 export * from './accidental_tests';
 export * from './annotation_tests';
 export * from './articulation_tests';

--- a/tests/multimeasurerest_tests.ts
+++ b/tests/multimeasurerest_tests.ts
@@ -6,6 +6,7 @@
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 import { Flow } from '../src/flow';
+import { Font } from '../src/font';
 import { MultimeasureRestRenderOptions } from '../src/multimeasurerest';
 
 const MultiMeasureRestTests = {
@@ -95,8 +96,7 @@ function simple(options: TestOptions): void {
   const str = 'TACET';
   const context = f.getContext();
   context.save();
-  context.setFont('Times', 16, 'bold');
-  // context.setFont(Font.SERIF, 16, 'bold'); // RONYEH
+  context.setFont(Font.SERIF, 16, 'bold');
   const metrics = context.measureText(str);
   context.fillText(str, xs.left + (xs.right - xs.left) * 0.5 - metrics.width * 0.5, strY);
   context.restore();

--- a/tests/percussion_tests.ts
+++ b/tests/percussion_tests.ts
@@ -8,14 +8,20 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Factory } from '../src/factory';
-import { RenderContext } from '../src/rendercontext';
-import { ContextBuilder } from '../src/renderer';
-import { Stave } from '../src/stave';
-import { StaveNote, StaveNoteStruct } from '../src/stavenote';
-import { StemmableNote } from '../src/stemmablenote';
-import { TickContext } from '../src/tickcontext';
-import { Tremolo } from '../src/tremolo';
+import {
+  ContextBuilder,
+  Factory,
+  Font,
+  FontStyle,
+  FontWeight,
+  RenderContext,
+  Stave,
+  StaveNote,
+  StaveNoteStruct,
+  StemmableNote,
+  TickContext,
+  Tremolo,
+} from '../src/index';
 
 const PercussionTests = {
   Start(): void {
@@ -178,14 +184,21 @@ const basic2 = createSingleMeasureTest((f) => {
 });
 
 const snare0 = createSingleMeasureTest((f) => {
+  const font = {
+    family: Font.SERIF,
+    size: 14,
+    weight: FontWeight.BOLD,
+    style: FontStyle.ITALIC,
+  };
+
   f.Voice().addTickables([
     f
       .StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 })
       .addArticulation(0, f.Articulation({ type: 'a>' }))
-      .addModifier(f.Annotation({ text: 'L' }), 0),
-    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'R' }), 0),
-    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'L' }), 0),
-    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'L' }), 0),
+      .addModifier(f.Annotation({ text: 'L', font }), 0),
+    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'R', font }), 0),
+    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'L', font }), 0),
+    f.StaveNote({ keys: ['c/5'], duration: '4', stem_direction: -1 }).addModifier(f.Annotation({ text: 'L', font }), 0),
   ]);
 });
 

--- a/tests/staveline_tests.ts
+++ b/tests/staveline_tests.ts
@@ -5,6 +5,8 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Font, FontStyle } from '../src/font';
+
 const StaveLineTests = {
   Start(): void {
     QUnit.module('StaveLine');
@@ -33,8 +35,7 @@ function simple0(options: TestOptions): void {
     first_indices: [0],
     last_indices: [0],
     options: {
-      font: { family: 'serif', size: 12, style: 'italic' }, // BUG: originally the weight was set to italic. We changed it to style.
-      // font: { family: Font.SERIF, size: 12, style: 'italic' }, // RONYEH
+      font: { family: Font.SERIF, size: 12, style: FontStyle.ITALIC },
       text: 'gliss.',
     },
   });

--- a/tests/tabnote_tests.ts
+++ b/tests/tabnote_tests.ts
@@ -6,6 +6,7 @@
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 import { Flow } from '../src/flow';
+import { Font, FontWeight } from '../src/font';
 import { Formatter } from '../src/formatter';
 import { RenderContext } from '../src/rendercontext';
 import { ContextBuilder } from '../src/renderer';
@@ -382,8 +383,7 @@ function drawStemsUpThrough(options: TestOptions, contextBuilder: ContextBuilder
     return tabNote;
   });
 
-  ctx.setFont('sans-serif', 10, 'bold');
-  // ctx.setFont(Font.SANS_SERIF, 10, FontWeight.BOLD); // RONYEH
+  ctx.setFont(Font.SANS_SERIF, 10, FontWeight.BOLD);
   const voice = new Voice(Flow.TIME4_4).setMode(VoiceMode.SOFT);
   voice.addTickables(notes);
   new Formatter().joinVoices([voice]).formatToStave([voice], stave);

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -43,8 +43,7 @@ function setupContext(options: TestOptions, w: number = 0, h: number = 0): { con
   const context = options.contextBuilder!(options.elementId, w || 350, h || 160);
   context.fillStyle = '#221';
   context.strokeStyle = '#221';
-  context.setFont('Arial', VexFlowTests.Font.size, '');
-  // context.setFont('Arial', VexFlowTests.Font.size); // RONYEH. setFont() params are optional, so no need to pass ''.
+  context.setFont('Arial', VexFlowTests.Font.size);
 
   const stave = new TabStave(10, 10, w || 350).addTabGlyph().setContext(context).draw();
 

--- a/tests/textbracket_tests.ts
+++ b/tests/textbracket_tests.ts
@@ -75,8 +75,8 @@ function simple1(options: TestOptions): void {
       options: {
         position: 'top',
         superscript: 'superscript',
-        font: { family: 'Arial', size: 15, weight: '', style: '' }, // BUG: Using weight='' is discouraged. However, we interpret '' as 'normal'.
-        // font: { family: 'Arial', size: 15, weight: 'normal', style: 'normal' }, // RONYEH weight and style can be left undefined, in which case they will fall back to the default defined in textbracket.ts.
+        // weight & style below can be left undefined. They will fall back to the default defined in textbracket.ts.
+        font: { family: 'Arial', size: 15, weight: 'normal', style: 'normal' },
       },
     }),
   ];

--- a/tests/textnote_tests.ts
+++ b/tests/textnote_tests.ts
@@ -5,6 +5,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Font } from '../src';
 import { Crescendo } from '../src/crescendo';
 import { Flow } from '../src/flow';
 import { Note } from '../src/note';
@@ -137,9 +138,7 @@ function superscriptAndSubscript(options: TestOptions): void {
 
   voice2.getTickables().forEach((note) => {
     const textNote = note as TextNote;
-    // textNote.font = { family: 'Serif', size: 15, weight: '' }; // 3.0.9 API was not consistent. Usually .font is a string.
-    textNote.setFont({ family: 'Serif', size: 15 }); // In 4.0.0, use setFont(fontInfo) instead.
-    // textNote.setFont({ family: Font.SERIF, size: 15 }); // RONYEH Instead of specifying 'Serif', you can use the constant.
+    textNote.setFont({ family: Font.SERIF, size: 15 });
     textNote.setLine(13);
     textNote.setJustification(TextNote.Justification.LEFT);
   });

--- a/tests/types/qunit.d.ts
+++ b/tests/types/qunit.d.ts
@@ -16,8 +16,6 @@
 // Let the TS compiler know that QUnit and its related functions are available globally.
 // https://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation
 declare global {
-  const VF: any;
-
   // See: https://api.qunitjs.com/QUnit/
   const QUnit: {
     module: (name: string) => void;

--- a/tests/vexflow_test_helpers.ts
+++ b/tests/vexflow_test_helpers.ts
@@ -3,7 +3,7 @@
 //
 // VexFlow Test Support Library
 
-import { ContextBuilder, Factory, Flow, RenderContext, Renderer } from '../src/';
+import { ContextBuilder, Factory, Flow, Font, RenderContext, Renderer } from '../src/';
 import { Assert } from './types/qunit';
 
 /* eslint-disable */
@@ -63,6 +63,14 @@ if (!global.$) {
       text(t: string) {
         element.textContent = t;
         return $element;
+      },
+      html(h?: string) {
+        if (!h) {
+          return element.innerHTML;
+        } else {
+          element.innerHTML = h;
+          return $element;
+        }
       },
       append(...elementsToAppend: HTMLElement[]) {
         elementsToAppend.forEach((e) => {
@@ -180,7 +188,8 @@ export class VexFlowTests {
    * @param tagName
    */
   static createTest(elementId: string, testTitle: string, tagName: string, titleId: string = ''): HTMLElement {
-    const title = $('<div/>').addClass('name').attr('id', titleId).text(testTitle).get(0);
+    const anchorTestTitle = `<a href="#${titleId}">${testTitle}</a>`;
+    const title = $('<div/>').addClass('name').attr('id', titleId).html(anchorTestTitle).get(0);
     const vexOutput = $(`<${tagName}/>`).addClass('vex-tabdiv').attr('id', elementId).get(0);
     const container = $('<div/>').addClass('testcanvas').append(title, vexOutput).get(0);
     $('#vexflow_testoutput').append(container);
@@ -287,8 +296,7 @@ export class VexFlowTests {
    */
   static plotLegendForNoteWidth(ctx: RenderContext, x: number, y: number): void {
     ctx.save();
-    ctx.setFont('Arial', 8, '');
-    // ctx.setFont(Font.SANS_SERIF, 8); // RONYEH
+    ctx.setFont(Font.SANS_SERIF, 8);
 
     const spacing = 12;
     let lastY = y;

--- a/tests/vf_prefix_tests.ts
+++ b/tests/vf_prefix_tests.ts
@@ -7,98 +7,103 @@
 
 import { VexFlowTests } from './vexflow_test_helpers';
 
-import { Accidental } from '../src/accidental';
-import { Annotation } from '../src/annotation';
-import { Articulation } from '../src/articulation';
-import { BarNote } from '../src/barnote';
-import { Beam } from '../src/beam';
-import { Bend } from '../src/bend';
-import { BoundingBox } from '../src/boundingbox';
-import { BoundingBoxComputation } from '../src/boundingboxcomputation';
-import { ChordSymbol } from '../src/chordsymbol';
-import { Clef } from '../src/clef';
-import { ClefNote } from '../src/clefnote';
-import { Crescendo } from '../src/crescendo';
-import { Curve } from '../src/curve';
-import { Dot } from '../src/dot';
-import { EasyScore } from '../src/easyscore';
-import { Element } from '../src/element';
-import { Factory } from '../src/factory';
-import { Flow } from '../src/flow';
-import { Font } from '../src/font';
-import { Formatter } from '../src/formatter';
-import { Fraction } from '../src/fraction';
-import { FretHandFinger } from '../src/frethandfinger';
-import { GhostNote } from '../src/ghostnote';
-import { Glyph } from '../src/glyph';
-import { GlyphNote } from '../src/glyphnote';
-import { GraceNote } from '../src/gracenote';
-import { GraceNoteGroup } from '../src/gracenotegroup';
-import { GraceTabNote } from '../src/gracetabnote';
-import { KeyManager } from '../src/keymanager';
-import { KeySignature } from '../src/keysignature';
-import { KeySigNote } from '../src/keysignote';
-import { Modifier } from '../src/modifier';
-import { ModifierContext } from '../src/modifiercontext';
-import { MultiMeasureRest } from '../src/multimeasurerest';
-import { Music } from '../src/music';
-import { Note } from '../src/note';
-import { NoteHead } from '../src/notehead';
-import { NoteSubGroup } from '../src/notesubgroup';
-import { Ornament } from '../src/ornament';
-import { Parser } from '../src/parser';
-import { PedalMarking } from '../src/pedalmarking';
-import { Registry } from '../src/registry';
-import { Renderer } from '../src/renderer';
-import { RepeatNote } from '../src/repeatnote';
-import { Stave } from '../src/stave';
-import { Barline } from '../src/stavebarline';
-import { StaveConnector } from '../src/staveconnector';
-import { StaveHairpin } from '../src/stavehairpin';
-import { StaveLine } from '../src/staveline';
-import { StaveModifier } from '../src/stavemodifier';
-import { StaveNote } from '../src/stavenote';
-import { Repetition } from '../src/staverepetition';
-import { StaveTempo } from '../src/stavetempo';
-import { StaveText } from '../src/stavetext';
-import { StaveTie } from '../src/stavetie';
-import { Volta } from '../src/stavevolta';
-import { Stem } from '../src/stem';
-import { StringNumber } from '../src/stringnumber';
-import { Stroke } from '../src/strokes';
-import { System } from '../src/system';
-import { TabNote } from '../src/tabnote';
-import { TabSlide } from '../src/tabslide';
-import { TabStave } from '../src/tabstave';
-import { TabTie } from '../src/tabtie';
-import { TextBracket } from '../src/textbracket';
-import { TextDynamics } from '../src/textdynamics';
-import { TextFormatter } from '../src/textformatter';
-import { TextNote } from '../src/textnote';
-import { TickContext } from '../src/tickcontext';
-import { TimeSignature } from '../src/timesignature';
-import { TimeSigNote } from '../src/timesignote';
-import { Tremolo } from '../src/tremolo';
-import { Tuning } from '../src/tuning';
-import { Tuplet } from '../src/tuplet';
-import { Vibrato } from '../src/vibrato';
-import { VibratoBracket } from '../src/vibratobracket';
-import { Voice } from '../src/voice';
+import {
+  Accidental,
+  Annotation,
+  Articulation,
+  Barline,
+  BarNote,
+  Beam,
+  Bend,
+  BoundingBox,
+  BoundingBoxComputation,
+  ChordSymbol,
+  Clef,
+  ClefNote,
+  Crescendo,
+  Curve,
+  Dot,
+  EasyScore,
+  Element,
+  Factory,
+  Flow,
+  Font,
+  Formatter,
+  Fraction,
+  FretHandFinger,
+  GhostNote,
+  Glyph,
+  GlyphNote,
+  GraceNote,
+  GraceNoteGroup,
+  GraceTabNote,
+  KeyManager,
+  KeySignature,
+  KeySigNote,
+  Modifier,
+  ModifierContext,
+  MultiMeasureRest,
+  Music,
+  Note,
+  NoteHead,
+  NoteSubGroup,
+  Ornament,
+  Parser,
+  PedalMarking,
+  Registry,
+  Renderer,
+  RepeatNote,
+  Repetition,
+  Stave,
+  StaveConnector,
+  StaveHairpin,
+  StaveLine,
+  StaveModifier,
+  StaveNote,
+  StaveTempo,
+  StaveText,
+  StaveTie,
+  Stem,
+  StringNumber,
+  Stroke,
+  System,
+  TabNote,
+  TabSlide,
+  TabStave,
+  TabTie,
+  TextBracket,
+  TextDynamics,
+  TextFormatter,
+  TextNote,
+  TickContext,
+  TimeSignature,
+  TimeSigNote,
+  Tremolo,
+  Tuning,
+  Tuplet,
+  Vibrato,
+  VibratoBracket,
+  Voice,
+  Volta,
+} from '../src/index';
+
+// Tell TypeScript that we want very flexible typing,
+// so we can use the Vex.Flow.* API in unusual ways without warnings.
+// eslint-disable-next-line
+declare let Vex: Record<string, any> & { Flow: typeof Flow & Record<string, any> };
 
 const VFPrefixTests = {
   Start(): void {
     QUnit.module('VF.* API');
     test('VF.* API', VF_Prefix);
+    test('VF Alias', VF_Alias);
   },
 };
-
-// eslint-disable-next-line
-declare let Vex: any;
 
 function VF_Prefix(): void {
   // Intentionally use Vex.Flow here so we can verify that the Vex.Flow.* API
   // is equivalent to using the individual classes in TypeScript.
-  const VF = Vex.Flow as unknown as typeof Flow;
+  const VF = Vex.Flow;
   equal(Accidental, VF.Accidental);
   equal(Annotation, VF.Annotation);
   equal(Articulation, VF.Articulation);
@@ -166,7 +171,7 @@ function VF_Prefix(): void {
   equal(TabTie, VF.TabTie);
   equal(TextBracket, VF.TextBracket);
   equal(TextDynamics, VF.TextDynamics);
-  equal(TextFormatter, VF.TextFormatter); // RONYEH: Renamed TextFont to TextFormatter.
+  equal(TextFormatter, VF.TextFormatter);
   equal(TextNote, VF.TextNote);
   equal(TickContext, VF.TickContext);
   equal(TimeSignature, VF.TimeSignature);
@@ -178,6 +183,35 @@ function VF_Prefix(): void {
   equal(VibratoBracket, VF.VibratoBracket);
   equal(Voice, VF.Voice);
   equal(Volta, VF.Volta);
+}
+
+/**
+ * If you have name collisions with VexFlow classes, consider extracting classes from Vex.Flow
+ * and renaming them with a VF prefix.
+ */
+function VF_Alias(): void {
+  const Flow = Vex.Flow;
+  const VFAliases = {
+    get VFAccidental() {
+      return Flow.Accidental;
+    },
+    get VFAnnotation() {
+      return Flow.Annotation;
+    },
+    get VFVibrato() {
+      return Flow.Vibrato;
+    },
+  };
+  const { VFVibrato, VFAccidental, VFAnnotation } = VFAliases;
+  equal(Accidental, VFAccidental);
+  equal(Annotation, VFAnnotation);
+
+  const vibrato = new VFVibrato();
+  ok(vibrato);
+
+  const acc1 = new VFAccidental('##');
+  const acc2 = new Accidental('##');
+  equal(acc1.type, acc2.type);
 }
 
 VexFlowTests.register(VFPrefixTests);

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -5,12 +5,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Bend } from '../src/bend';
-import { Formatter } from '../src/formatter';
-import { ContextBuilder } from '../src/renderer';
-import { TabNote, TabNoteStruct } from '../src/tabnote';
-import { TabStave } from '../src/tabstave';
-import { Vibrato } from '../src/vibrato';
+import { Bend, ContextBuilder, Font, Formatter, TabNote, TabNoteStruct, TabStave, Vibrato } from '../src/index';
 
 const VibratoTests = {
   Start(): void {
@@ -90,8 +85,7 @@ function withBend(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.3, 1.3);
   ctx.setFillStyle('#221');
   ctx.setStrokeStyle('#221');
-  ctx.setFont('Arial', VexFlowTests.Font.size, '');
-  // ctx.setFont(Font.SANS_SERIF, VexFlowTests.Font.size); // RONYEH
+  ctx.setFont(Font.SANS_SERIF, VexFlowTests.Font.size);
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
   const notes = [


### PR DESCRIPTION
Introduces visual diffs. The outlines of text elements are slightly different, due to use of constant font family:

```
  /** Default sans-serif font family. */
  static SANS_SERIF: string = 'Arial, sans-serif';

  /** Default serif font family. */
  static SERIF: string = 'Times New Roman, serif';
```

Previously, each text element declared a slightly different sans-serif or serif font family.