### PR TITLE
SystemParam / FormatOptions renamed

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -38,7 +38,7 @@ export interface FormatterOptions {
   maxIterations?: number;
 }
 
-export interface FormatOptions {
+export interface FormatParams {
   align_rests?: boolean;
   padding?: number;
   stave?: Stave;
@@ -262,7 +262,7 @@ export class Formatter {
     ctx: RenderContext,
     stave: Stave,
     notes: StemmableNote[],
-    params?: FormatOptions | boolean
+    params?: FormatParams | boolean
   ): BoundingBox | undefined {
     let options = {
       auto_beam: false,
@@ -314,7 +314,7 @@ export class Formatter {
     tabnotes: TabNote[],
     notes: Tickable[],
     autobeam: boolean,
-    params: FormatOptions
+    params: FormatParams
   ): void {
     let opts = {
       auto_beam: autobeam,
@@ -994,7 +994,7 @@ export class Formatter {
    * Set `options.context` to the rendering context. Set `options.align_rests`
    * to true to enable rest alignment.
    */
-  format(voices: Voice[], justifyWidth?: number, options?: FormatOptions): this {
+  format(voices: Voice[], justifyWidth?: number, options?: FormatParams): this {
     const opts = {
       align_rests: false,
       ...options,
@@ -1017,8 +1017,8 @@ export class Formatter {
   }
 
   // This method is just like `format` except that the `justifyWidth` is inferred from the `stave`.
-  formatToStave(voices: Voice[], stave: Stave, optionsParam?: FormatOptions): this {
-    const options: FormatOptions = { padding: 10, context: stave.getContext(), ...optionsParam };
+  formatToStave(voices: Voice[], stave: Stave, optionsParam?: FormatParams): this {
+    const options: FormatParams = { padding: 10, context: stave.getContext(), ...optionsParam };
 
     // eslint-disable-next-line
     const justifyWidth = stave.getNoteEndX() - stave.getNoteStartX() - Stave.defaultPadding;

--- a/src/system.ts
+++ b/src/system.ts
@@ -4,7 +4,7 @@
 import { BoundingBox } from './boundingbox';
 import { Element } from './element';
 import { Factory } from './factory';
-import { FormatOptions, Formatter, FormatterOptions } from './formatter';
+import { FormatParams, Formatter, FormatterOptions } from './formatter';
 import { Note } from './note';
 import { RenderContext } from './rendercontext';
 import { Stave, StaveOptions } from './stave';
@@ -16,7 +16,7 @@ export interface SystemFormatterOptions extends FormatterOptions {
   alpha?: number;
 }
 
-export interface SystemParams {
+export interface SystemStave {
   voices: Voice[];
   stave?: Stave;
   noJustification?: boolean;
@@ -48,7 +48,7 @@ export interface SystemOptions {
   width?: number;
   y?: number;
   details?: SystemFormatterOptions;
-  formatOptions?: FormatOptions;
+  formatOptions?: FormatParams;
   noJustification?: boolean;
 }
 
@@ -67,7 +67,7 @@ export class System extends Element {
   protected formatter?: Formatter;
   protected startX?: number;
   protected lastY?: number;
-  protected parts: Required<SystemParams>[];
+  protected parts: Required<SystemStave>[];
   protected connector?: StaveConnector;
   protected debugNoteMetricsYs?: { y: number; voice: Voice }[];
 
@@ -143,7 +143,7 @@ export class System extends Element {
    *
    *  `score.voice(score.notes('C#4/h, C#4', {stem: 'down'}))]});`
    */
-  addStave(params: SystemParams): Stave {
+  addStave(params: SystemStave): Stave {
     const staveOptions: StaveOptions = { left_bar: false, ...params.options };
 
     const stave =


### PR DESCRIPTION
Fixes #1149 

Following the proposal:
- `SystemParams` -> `SystemStave`
- `...Options` class options provided to the constructor, 
- `...Params` group of parameters used on functions: `FormatOptions` -> `FormatParams`