### PR TITLE
Easyscore support for muted, harmony, slash and ghost notes

### DIFF
--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -7,8 +7,8 @@ import { Glyph } from './glyph';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
-import { StaveNote } from './stavenote';
 import { Stem } from './stem';
+import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { isGraceNote, isStaveNote, isTabNote } from './typeguard';
 import { defined, log, RuntimeError } from './util';
@@ -231,7 +231,7 @@ export class Articulation extends Modifier {
     return true;
   }
 
-  static easyScoreHook({ articulations }: { articulations: string }, note: StaveNote, builder: Builder): void {
+  static easyScoreHook({ articulations }: { articulations: string }, note: StemmableNote, builder: Builder): void {
     if (!articulations) return;
 
     const articNameToCode: Record<string, string> = {

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -3,6 +3,7 @@
 
 import { Element } from './element';
 import { Fraction } from './fraction';
+import { GhostNote } from './ghostnote';
 import { Note } from './note';
 import { RenderContext } from './rendercontext';
 import { Stem } from './stem';
@@ -555,6 +556,8 @@ export class Beam extends Element {
       // iterate through notes, calculating y shift and stem extension
       for (let i = 1; i < notes.length; ++i) {
         const note = notes[i];
+        // Skip Ghostnotes
+        if (note instanceof GhostNote) continue;
         const adjustedStemTipY =
           this.getSlopeY(note.getStemX(), firstNote.getStemX(), firstNote.getStemExtents().topY, slope) + yShiftTemp;
 
@@ -689,6 +692,8 @@ export class Beam extends Element {
 
     for (let i = 0; i < notes.length; ++i) {
       const note = notes[i];
+      // Skip Ghostnotes
+      if (note instanceof GhostNote) continue;
       const stem = note.getStem();
       if (stem) {
         const stemX = note.getStemX();

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -7,7 +7,7 @@ import { Builder } from './easyscore';
 import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
-import { StaveNote } from './stavenote';
+import { StemmableNote } from './stemmablenote';
 import { RuntimeError } from './util';
 
 export class FretHandFinger extends Modifier {
@@ -102,7 +102,7 @@ export class FretHandFinger extends Modifier {
     return true;
   }
 
-  static easyScoreHook({ fingerings }: { fingerings?: string } = {}, note: StaveNote, builder: Builder): void {
+  static easyScoreHook({ fingerings }: { fingerings?: string } = {}, note: StemmableNote, builder: Builder): void {
     fingerings
       ?.split(',')
       .map((fingeringString: string) => {

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -2,6 +2,7 @@
 //
 // ## Description
 
+import { Annotation } from './annotation';
 import { ModifierContext } from './modifiercontext';
 import { NoteStruct } from './note';
 import { Stave } from './stave';
@@ -61,12 +62,14 @@ export class GhostNote extends StemmableNote {
   }
 
   draw(): void {
-    // Draw the modifiers
+    // Draw Annotations
     this.setRendered();
     for (let i = 0; i < this.modifiers.length; ++i) {
       const modifier = this.modifiers[i];
-      modifier.setContext(this.getContext());
-      modifier.drawWithStyle();
+      if (modifier instanceof Annotation) {
+        modifier.setContext(this.getContext());
+        modifier.drawWithStyle();
+      }
     }
   }
 }

--- a/src/note.ts
+++ b/src/note.ts
@@ -1,7 +1,9 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
+import { Accidental } from './accidental';
 import { Beam } from './beam';
+import { Dot } from './dot';
 import { Font } from './font';
 import { Fraction } from './fraction';
 import { GlyphProps } from './glyph';
@@ -556,6 +558,47 @@ export abstract class Note extends Tickable {
     this.modifiers.push(modifier);
     this.preFormatted = false;
     return this;
+  }
+
+  // Helper function to add an accidental to a key
+  addAccidental(index: number, accidental: Modifier): this {
+    return this.addModifier(accidental, index);
+  }
+
+  // Helper function to add an articulation to a key
+  addArticulation(index: number, articulation: Modifier): this {
+    return this.addModifier(articulation, index);
+  }
+
+  // Helper function to add an annotation to a key
+  addAnnotation(index: number, annotation: Modifier): this {
+    return this.addModifier(annotation, index);
+  }
+
+  // Helper function to add a dot on a specific key
+  addDot(index: number): this {
+    const dot = new Dot();
+    dot.setDotShiftY(this.glyph.dot_shiftY);
+    this.dots++;
+    return this.addModifier(dot, index);
+  }
+
+  // Convenience method to add dot to all keys in note
+  addDotToAll(): this {
+    for (let i = 0; i < this.keys.length; ++i) {
+      this.addDot(i);
+    }
+    return this;
+  }
+
+  // Get all accidentals in the `ModifierContext`
+  getAccidentals(): Accidental[] {
+    return this.checkModifierContext().getMembers(Accidental.CATEGORY) as Accidental[];
+  }
+
+  // Get all dots in the `ModifierContext`
+  getDots(): Dot[] {
+    return this.checkModifierContext().getMembers(Dot.CATEGORY) as Dot[];
   }
 
   /** Get the coordinates for where modifiers begin. */

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -8,10 +8,8 @@
 //
 // See `tests/stavenote_tests.ts` for usage examples.
 
-import { Accidental } from './accidental';
 import { Beam } from './beam';
 import { BoundingBox } from './boundingbox';
-import { Dot } from './dot';
 import { ElementStyle } from './element';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
@@ -865,47 +863,6 @@ export class StaveNote extends StemmableNote {
 
   getKeyLine(index: number): number {
     return this.keyProps[index].line;
-  }
-
-  // Helper function to add an accidental to a key
-  addAccidental(index: number, accidental: Modifier): this {
-    return this.addModifier(accidental, index);
-  }
-
-  // Helper function to add an articulation to a key
-  addArticulation(index: number, articulation: Modifier): this {
-    return this.addModifier(articulation, index);
-  }
-
-  // Helper function to add an annotation to a key
-  addAnnotation(index: number, annotation: Modifier): this {
-    return this.addModifier(annotation, index);
-  }
-
-  // Helper function to add a dot on a specific key
-  addDot(index: number): this {
-    const dot = new Dot();
-    dot.setDotShiftY(this.glyph.dot_shiftY);
-    this.dots++;
-    return this.addModifier(dot, index);
-  }
-
-  // Convenience method to add dot to all keys in note
-  addDotToAll(): this {
-    for (let i = 0; i < this.keys.length; ++i) {
-      this.addDot(i);
-    }
-    return this;
-  }
-
-  // Get all accidentals in the `ModifierContext`
-  getAccidentals(): Accidental[] {
-    return this.checkModifierContext().getMembers(Accidental.CATEGORY) as Accidental[];
-  }
-
-  // Get all dots in the `ModifierContext`
-  getDots(): Dot[] {
-    return this.checkModifierContext().getMembers(Dot.CATEGORY) as Dot[];
   }
 
   // Get the width of the note if it is displaced. Used for `Voice`

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -155,6 +155,7 @@ const validNoteTypes: Record<string, { name: string }> = {
   h: { name: 'harmonic' },
   m: { name: 'muted' },
   s: { name: 'slash' },
+  g: { name: 'ghost' },
 };
 
 const customNoteHeads: Record<string, { code: string }> = {
@@ -935,6 +936,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadDoubleWhole',
+      },
     },
   },
 
@@ -989,6 +994,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadWhole',
       },
     },
   },
@@ -1046,6 +1055,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadHalf',
+      },
     },
   },
 
@@ -1102,6 +1115,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },
@@ -1164,6 +1181,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1224,6 +1245,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },
@@ -1286,6 +1311,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1347,6 +1376,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1407,6 +1440,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -46,6 +46,7 @@
 
 import { Element } from './element';
 import { Formatter } from './formatter';
+import { GhostNote } from './ghostnote';
 import { Glyph } from './glyph';
 import { Note } from './note';
 import { Stem } from './stem';
@@ -273,6 +274,8 @@ export class Tuplet extends Element {
       // y_pos = first_note.getStemExtents().topY - 10;
 
       for (let i = 0; i < this.notes.length; ++i) {
+        // Skip Ghostnotes
+        if (this.notes[i] instanceof GhostNote) continue;
         const top_y =
           this.notes[i].getStemDirection() === Stem.UP
             ? this.notes[i].getStemExtents().topY - 10
@@ -286,6 +289,8 @@ export class Tuplet extends Element {
       y_pos = first_note.checkStave().getYForLine(4) + 20;
 
       for (let i = 0; i < this.notes.length; ++i) {
+        // Skip Ghostnotes
+        if (this.notes[i] instanceof GhostNote) continue;
         const bottom_y =
           this.notes[i].getStemDirection() === Stem.UP
             ? this.notes[i].getStemExtents().baseY + 20

--- a/tests/curve_tests.ts
+++ b/tests/curve_tests.ts
@@ -8,7 +8,7 @@ import { concat, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { CurvePosition } from '../src/curve';
 import { BuilderOptions } from '../src/easyscore';
 import { Factory } from '../src/factory';
-import { StaveNote } from '../src/stavenote';
+import { StemmableNote } from '../src/stemmablenote';
 
 const CurveTests = {
   Start(): void {
@@ -29,7 +29,11 @@ type NoteParams = [string, BuilderOptions];
  * a setupCurves() callback which uses Factory.Curve(...) to build the curves.
  * Curves can be used to indicate slurs (legato articulation).
  */
-function createTest(noteGroup1: NoteParams, noteGroup2: NoteParams, setupCurves: (f: Factory, n: StaveNote[]) => void) {
+function createTest(
+  noteGroup1: NoteParams,
+  noteGroup2: NoteParams,
+  setupCurves: (f: Factory, n: StemmableNote[]) => void
+) {
   return (options: TestOptions) => {
     const factory = VexFlowTests.makeFactory(options, 350, 200);
     const stave = factory.Stave({ y: 50 });

--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -25,6 +25,11 @@ const EasyScoreTests = {
     test('Options', options);
     const run = VexFlowTests.runTests;
     run('Draw Basic', drawBasicTest);
+    run('Draw Basic Muted', drawBasicMutedTest);
+    run('Draw Basic Harmonic', drawBasicHarmonicTest);
+    run('Draw Basic Slash', drawBasicSlashTest);
+    run('Draw Ghostnote Basic', drawGhostBasicTest);
+    run('Draw Ghostnote Dotted', drawGhostDottedTest);
     run('Draw Accidentals', drawAccidentalsTest);
     run('Draw Beams', drawBeamsTest);
     run('Draw Tuplets', drawTupletsTest);
@@ -55,8 +60,8 @@ function createShortcuts(score: EasyScore) {
  */
 function basic(): void {
   const score = new EasyScore();
-  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/x', 'c3//x'];
-  const mustFail = ['', '()', '7', '(c#4 e5 g6'];
+  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/m', 'c3//m', 'c3//h', 'c3/s', 'c3//s', 'c3/g', 'c3//g', '/q/g'];
+  const mustFail = ['()', '7', '(c#4 e5 g6'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
   mustFail.forEach((line) => equal(score.parse(line).success, false, line));
@@ -68,7 +73,7 @@ function accidentals(): void {
     'c3',
     'c##3, cb3',
     'Cn3',
-    'f3//x',
+    'f3//m',
     '(c##3 cbb3 cn3), cb3',
     'cbbs7',
     'cbb7',
@@ -121,7 +126,7 @@ function accidentals(): void {
 function durations(): void {
   const score = new EasyScore();
   const mustPass = ['c3/4', 'c##3/w, cb3', 'c##3/w, cb3/q', 'c##3/q, cb3/32', '(c##3 cbb3 cn3), cb3'];
-  const mustFail = ['Cn3/]', '/', '(cq cbb3 cn3), cb3', '(cdd7 cbb3 cn3), cb3'];
+  const mustFail = ['Cn3/]', '(cq cbb3 cn3), cb3', '(cdd7 cbb3 cn3), cb3'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
   mustFail.forEach((line) => equal(score.parse(line).success, false, line));
@@ -135,7 +140,7 @@ function chords(): void {
     '(c##4 cbb4 cn4)/w, (c#5 cb2 a3)/32',
     '(d##4 cbb4 cn4)/w/r, (c#5 cb2 a3)',
     '(c##4 cbb4 cn4)/4, (c#5 cb2 a3)',
-    '(c##4 cbb4 cn4)/x, (c#5 cb2 a3)',
+    '(c##4 cbb4 cn4)/m, (c#5 cb2 a3)',
   ];
   const mustFail = ['(c)'];
 
@@ -154,7 +159,7 @@ function dots(): void {
     '(c5).',
     '(c##4 cbb4 cn4)/w.., (c#5 cb2 a3)/32',
   ];
-  const mustFail = ['.', 'c.#', 'c#4./4'];
+  const mustFail = ['c.#', 'c#4./4'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
   mustFail.forEach((line) => equal(score.parse(line).success, false, line));
@@ -162,7 +167,7 @@ function dots(): void {
 
 function types(): void {
   const score = new EasyScore();
-  const mustPass = ['c3/4/x.', 'c##3//r.., cb3', 'c##3/x.., cb3', 'c##3/r.., cb3', 'd##3/w/s, cb3/q...', 'Fb4'];
+  const mustPass = ['c3/4/m.', 'c##3//r.., cb3', 'c##3/m.., cb3', 'c##3/r.., cb3', 'd##3/w/s, cb3/q...', 'Fb4'];
   const mustFail = ['c4/q/U', '(c##4, cbb4 cn4)/w.., (c#5 cb2 a3)/32', 'z#3'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
@@ -207,6 +212,143 @@ function drawBasicTest(options: TestOptions): void {
     })
     .addClef('bass');
   system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicMutedTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/m, c4/q/m, c4/q/r, c4/q/m', { stem: 'down' })),
+        voice(notes('c#5/h/m., c5/q/m', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/m, cn3/q/m, bb3/q/m, d##3/q/m', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicHarmonicTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/h, c4/q/h, c4/q/r, c4/q/h', { stem: 'down' })),
+        voice(notes('c#5/h/h., c5/q/h', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/h, cn3/q/h, bb3/q/h, d##3/q/h', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicSlashTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/s, c4/q/s, c4/q/r, c4/q/s', { stem: 'down' })),
+        voice(notes('c#5/h/s., c5/q/s', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/s, cn3/q/s, bb3/q/s, d##3/q/s', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawGhostBasicTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 550);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  system.addStave({
+    voices: [
+      score.voice(
+        [
+          ...score.notes('f#5/4, f5, db5, c5', { stem: 'up' }),
+          ...score.beam(score.notes('c5/8, d5, fn5, e5', { stem: 'up' })),
+          ...score.beam(score.notes('d5, c5', { stem: 'up' })),
+        ],
+        { time: '7/4' }
+      ),
+      score.voice(score.notes('/h/g, f4/4, /4/g, e4/4, /8/g, d##4/8, c4/8, c4/8', { stem: 'down' }), {
+        time: '7/4',
+      }),
+    ],
+  });
+
+  f.draw();
+  expect(0);
+}
+
+function drawGhostDottedTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 550);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  system.addStave({
+    voices: [
+      score.voice(
+        [
+          ...score.notes('/4/g., fbb5/8, d5/4', { stem: 'up' }),
+          ...score.beam(score.notes('c5/8, c#5/16, d5/16', { stem: 'up' })),
+          ...score.notes('/2/g.., fn5/8', { stem: 'up' }),
+        ],
+        { time: '8/4' }
+      ),
+      score.voice(
+        [
+          ...score.notes('f#4/4', { stem: 'down' }),
+          ...score.beam(score.notes('e4/8, d4/8', { stem: 'down' })),
+          ...score.notes('/4/g.., cb4/16, c#4/h, d4/4', { stem: 'down' }),
+          ...score.beam(score.notes('fn4/8, e4/8', { stem: 'down' })),
+        ],
+        { time: '8/4' }
+      ),
+    ],
+  });
 
   f.draw();
   expect(0);

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -22,6 +22,7 @@ import {
   Stave,
   StaveConnector,
   StaveNote,
+  StemmableNote,
   StringNumber,
   TextBracket,
   Tuplet,
@@ -553,7 +554,7 @@ function proportional(options: TestOptions): void {
     score.tuplet(score.notes('a4/32, a4, a4, a4, a4, a4, a4'), { notes_occupied: 8 }),
   ];
 
-  const createVoice = (notes: StaveNote[]) => score.voice(notes, { time: '1/4' });
+  const createVoice = (notes: StemmableNote[]) => score.voice(notes, { time: '1/4' });
   const createStave = (voice: Voice) =>
     system
       .addStave({ voices: [voice], debugNoteMetrics: debug })

--- a/tests/stavetie_tests.ts
+++ b/tests/stavetie_tests.ts
@@ -8,8 +8,8 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { BuilderOptions } from '../src/easyscore';
 import { Factory } from '../src/factory';
 import { Stave } from '../src/stave';
-import { StaveNote } from '../src/stavenote';
 import { Stem } from '../src/stem';
+import { StemmableNote } from '../src/stemmablenote';
 
 const StaveTieTests = {
   Start(): void {
@@ -30,7 +30,10 @@ const StaveTieTests = {
 /**
  * Used by the 7 tests below to set up the stave, easyscore, notes, voice, and to format & draw.
  */
-function createTest(notesData: [string, BuilderOptions], setupTies: (f: Factory, n: StaveNote[], s: Stave) => void) {
+function createTest(
+  notesData: [string, BuilderOptions],
+  setupTies: (f: Factory, n: StemmableNote[], s: Stave) => void
+) {
   return (options: TestOptions) => {
     const factory = VexFlowTests.makeFactory(options, 300);
     const stave = factory.Stave();


### PR DESCRIPTION
Fixes #705
Fixes #463

- `EasyScore` now also supports  types `h`, `m` (`x` was not a valid type, `m` should be used), `g` (for `GhostNote`)
