### PR TITLE
Easyscore support for muted, harmony, slash and ghost notes I (muted, harmony, slash)

### DIFF
--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -175,7 +175,7 @@ export class EasyScoreGrammar implements Grammar {
     return { token: '[0-9whq]+' };
   }
   TYPES(): Rule {
-    return { token: '[rRsSxX]' };
+    return { token: '[rRsSmMhH]' };
   }
   LPAREN(): Rule {
     return { token: '[(]' };

--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -25,6 +25,9 @@ const EasyScoreTests = {
     test('Options', options);
     const run = VexFlowTests.runTests;
     run('Draw Basic', drawBasicTest);
+    run('Draw Basic Muted', drawBasicMutedTest);
+    run('Draw Basic Harmonic', drawBasicHarmonicTest);
+    run('Draw Basic Slash', drawBasicSlashTest);
     run('Draw Accidentals', drawAccidentalsTest);
     run('Draw Beams', drawBeamsTest);
     run('Draw Tuplets', drawTupletsTest);
@@ -55,7 +58,7 @@ function createShortcuts(score: EasyScore) {
  */
 function basic(): void {
   const score = new EasyScore();
-  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/x', 'c3//x'];
+  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/m', 'c3//m', 'c3//h', 'c3/s', 'c3//s'];
   const mustFail = ['', '()', '7', '(c#4 e5 g6'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
@@ -68,7 +71,7 @@ function accidentals(): void {
     'c3',
     'c##3, cb3',
     'Cn3',
-    'f3//x',
+    'f3//m',
     '(c##3 cbb3 cn3), cb3',
     'cbbs7',
     'cbb7',
@@ -135,7 +138,7 @@ function chords(): void {
     '(c##4 cbb4 cn4)/w, (c#5 cb2 a3)/32',
     '(d##4 cbb4 cn4)/w/r, (c#5 cb2 a3)',
     '(c##4 cbb4 cn4)/4, (c#5 cb2 a3)',
-    '(c##4 cbb4 cn4)/x, (c#5 cb2 a3)',
+    '(c##4 cbb4 cn4)/m, (c#5 cb2 a3)',
   ];
   const mustFail = ['(c)'];
 
@@ -162,7 +165,7 @@ function dots(): void {
 
 function types(): void {
   const score = new EasyScore();
-  const mustPass = ['c3/4/x.', 'c##3//r.., cb3', 'c##3/x.., cb3', 'c##3/r.., cb3', 'd##3/w/s, cb3/q...', 'Fb4'];
+  const mustPass = ['c3/4/m.', 'c##3//r.., cb3', 'c##3/m.., cb3', 'c##3/r.., cb3', 'd##3/w/s, cb3/q...', 'Fb4'];
   const mustFail = ['c4/q/U', '(c##4, cbb4 cn4)/w.., (c#5 cb2 a3)/32', 'z#3'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
@@ -204,6 +207,87 @@ function drawBasicTest(options: TestOptions): void {
   system
     .addStave({
       voices: [voice(notes('c#3/q, cn3/q, bb3/q, d##3/q', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicMutedTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/m, c4/q/m, c4/q/r, c4/q/m', { stem: 'down' })),
+        voice(notes('c#5/h/m., c5/q/m', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/m, cn3/q/m, bb3/q/m, d##3/q/m', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicHarmonicTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/h, c4/q/h, c4/q/r, c4/q/h', { stem: 'down' })),
+        voice(notes('c#5/h/h., c5/q/h', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/h, cn3/q/h, bb3/q/h, d##3/q/h', { clef: 'bass' }))],
+    })
+    .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawBasicSlashTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q/s, c4/q/s, c4/q/r, c4/q/s', { stem: 'down' })),
+        voice(notes('c#5/h/s., c5/q/s', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q/s, cn3/q/s, bb3/q/s, d##3/q/s', { clef: 'bass' }))],
     })
     .addClef('bass');
   system.addConnector().setType(StaveConnector.type.BRACKET);


### PR DESCRIPTION
Fixes #705

No visual changes. 

Additional tests:

**Muted**
![EasyScore Draw_Basic_Muted Bravura](https://user-images.githubusercontent.com/22865285/146630816-d0fb28e6-547b-4c3a-ba20-bf210e5fc61d.png)
![EasyScore Draw_Basic_Muted Gonville](https://user-images.githubusercontent.com/22865285/146630817-4b6d851d-615b-456f-8b0e-35b0a2bd7995.png)
![EasyScore Draw_Basic_Muted Petaluma](https://user-images.githubusercontent.com/22865285/146630818-28a350a4-2ec2-4628-a14e-b6bc9f494822.png)

** Harmonic **                  
![EasyScore Draw_Basic_Harmonic Bravura](https://user-images.githubusercontent.com/22865285/146630844-cc49fa54-2f49-4105-9ba7-cd7fd5cb305a.png)
![EasyScore Draw_Basic_Harmonic Gonville](https://user-images.githubusercontent.com/22865285/146630846-10e0d29b-7ef3-43f6-86d6-4e6b4dc7716e.png)
![EasyScore Draw_Basic_Harmonic Petaluma](https://user-images.githubusercontent.com/22865285/146630847-7d9a0ba1-afcd-49b5-be9a-581a9ae6bd7e.png)
 
**Slash**
![EasyScore Draw_Basic_Slash Bravura](https://user-images.githubusercontent.com/22865285/146630867-b08f5833-16f5-464d-a11f-d15f95869110.png)
![EasyScore Draw_Basic_Slash Gonville](https://user-images.githubusercontent.com/22865285/146630868-82479ab5-aabe-4343-a5e9-fae4aee9dc6e.png)
![EasyScore Draw_Basic_Slash Petaluma](https://user-images.githubusercontent.com/22865285/146630870-ce5b1f1b-9bf2-410a-80cd-b73696d517f4.png)

