### PR TITLE
Easyscore support for muted, harmony, slash and ghost notes II (ghost)

### DIFF
--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -7,10 +7,9 @@ import { Glyph } from './glyph';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
-import { StaveNote } from './stavenote';
-import { StemmableNote  } from './stemmablenote';
 import { Stave } from './stave';
 import { Stem } from './stem';
+import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { isGraceNote, isStaveNote, isTabNote } from './typeguard';
 import { defined, log, RuntimeError } from './util';
@@ -267,7 +266,7 @@ export class Articulation extends Modifier {
     return true;
   }
 
-  static easyScoreHook({ articulations }: { articulations: string }, note: StaveNote, builder: Builder): void {
+  static easyScoreHook({ articulations }: { articulations: string }, note: StemmableNote, builder: Builder): void {
     if (!articulations) return;
 
     const articNameToCode: Record<string, string> = {

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -555,18 +555,20 @@ export class Beam extends Element {
       // iterate through notes, calculating y shift and stem extension
       for (let i = 1; i < notes.length; ++i) {
         const note = notes[i];
-        const adjustedStemTipY =
-          this.getSlopeY(note.getStemX(), firstNote.getStemX(), firstNote.getStemExtents().topY, slope) + yShiftTemp;
+        if (note.hasStem() || note.isRest()) {
+          const adjustedStemTipY =
+            this.getSlopeY(note.getStemX(), firstNote.getStemX(), firstNote.getStemExtents().topY, slope) + yShiftTemp;
 
-        const stemTipY = note.getStemExtents().topY;
-        // beam needs to be shifted up to accommodate note
-        if (stemTipY * stemDirection < adjustedStemTipY * stemDirection) {
-          const diff = Math.abs(stemTipY - adjustedStemTipY);
-          yShiftTemp += diff * -stemDirection;
-          totalStemExtension += diff * i;
-        } else {
-          // beam overshoots note, account for the difference
-          totalStemExtension += (stemTipY - adjustedStemTipY) * stemDirection;
+          const stemTipY = note.getStemExtents().topY;
+          // beam needs to be shifted up to accommodate note
+          if (stemTipY * stemDirection < adjustedStemTipY * stemDirection) {
+            const diff = Math.abs(stemTipY - adjustedStemTipY);
+            yShiftTemp += diff * -stemDirection;
+            totalStemExtension += diff * i;
+          } else {
+            // beam overshoots note, account for the difference
+            totalStemExtension += (stemTipY - adjustedStemTipY) * stemDirection;
+          }
         }
       }
 
@@ -705,8 +707,6 @@ export class Beam extends Element {
           const totalBeamWidth = (beam_count - 1) * beamWidth * 1.5 + beamWidth;
           stem.setVisibility(true).setStemlet(true, totalBeamWidth + stemlet_extension);
         }
-      } else {
-        throw new RuntimeError('NoStem', 'stem undefined.');
       }
     }
   }

--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -9,8 +9,8 @@ import { Music } from './music';
 import { Note } from './note';
 import { Grammar, Match, Parser, Result, Rule, RuleFunction } from './parser';
 import { RenderContext } from './rendercontext';
-import { StaveNote } from './stavenote';
 import { Stem } from './stem';
+import { StemmableNote } from './stemmablenote';
 import { TupletOptions } from './tuplet';
 import { defined, log, RuntimeError } from './util';
 import { Voice } from './voice';
@@ -22,7 +22,7 @@ function L(...args: any[]): void {
 }
 
 // eslint-disable-next-line
-export type CommitHook = (obj: any, note: StaveNote, builder: Builder) => void;
+export type CommitHook = (obj: any, note: StemmableNote, builder: Builder) => void;
 
 export class EasyScoreGrammar implements Grammar {
   builder: Builder;
@@ -175,7 +175,7 @@ export class EasyScoreGrammar implements Grammar {
     return { token: '[0-9whq]+' };
   }
   TYPES(): Rule {
-    return { token: '[rRsSmMhH]' };
+    return { token: '[rRsSmMhHgG]' };
   }
   LPAREN(): Rule {
     return { token: '[(]' };
@@ -227,7 +227,7 @@ export class Piece {
 }
 
 export interface BuilderElements {
-  notes: StaveNote[];
+  notes: StemmableNote[];
   accidentals: (Accidental | undefined)[][];
 }
 
@@ -358,8 +358,11 @@ export class Builder {
     );
     const auto_stem = stem === 'auto'; // StaveNoteStruct expects the underscore & lowercase.
 
-    // Build a StaveNote using the information we gathered.
-    const note = factory.StaveNote({ keys, duration, dots, type, clef, auto_stem });
+    // Build a GhostNote or StaveNote using the information we gathered.
+    const note =
+      type?.toLowerCase() == 'g'
+        ? factory.GhostNote({ duration, dots })
+        : factory.StaveNote({ keys, duration, dots, type, clef, auto_stem });
     if (!auto_stem) note.setStemDirection(stem === 'up' ? Stem.UP : Stem.DOWN);
 
     // Attach accidentals.
@@ -404,7 +407,7 @@ export interface EasyScoreDefaults extends Record<string, any> {
 /**
  * Commit hook used by EasyScore.setOptions().
  */
-function setId(options: { id?: string }, note: StaveNote) {
+function setId(options: { id?: string }, note: StemmableNote) {
   if (options.id === undefined) return;
   note.setAttribute('id', options.id);
 }
@@ -415,7 +418,7 @@ const commaSeparatedRegex = /\s*,\s*/;
 /**
  * Commit hook used by EasyScore.setOptions().
  */
-function setClass(options: { class?: string }, note: StaveNote) {
+function setClass(options: { class?: string }, note: StemmableNote) {
   if (options.class === undefined) return;
   options.class.split(commaSeparatedRegex).forEach((className: string) => note.addClass(className));
 }
@@ -497,17 +500,17 @@ export class EasyScore {
     return result;
   }
 
-  beam(notes: StaveNote[], options?: { autoStem?: boolean; secondaryBeamBreaks?: number[] }): StaveNote[] {
+  beam(notes: StemmableNote[], options?: { autoStem?: boolean; secondaryBeamBreaks?: number[] }): StemmableNote[] {
     this.factory.Beam({ notes, options });
     return notes;
   }
 
-  tuplet(notes: StaveNote[], options?: TupletOptions): StaveNote[] {
+  tuplet(notes: StemmableNote[], options?: TupletOptions): StemmableNote[] {
     this.factory.Tuplet({ notes, options });
     return notes;
   }
 
-  notes(line: string, options: BuilderOptions = {}): StaveNote[] {
+  notes(line: string, options: BuilderOptions = {}): StemmableNote[] {
     options = { clef: this.defaults.clef, stem: this.defaults.stem, ...options };
     this.parse(line, options);
     return this.builder.getElements().notes;

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -7,7 +7,7 @@ import { Builder } from './easyscore';
 import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
-import { StaveNote } from './stavenote';
+import { StemmableNote } from './stemmablenote';
 import { RuntimeError } from './util';
 
 export class FretHandFinger extends Modifier {
@@ -102,7 +102,7 @@ export class FretHandFinger extends Modifier {
     return true;
   }
 
-  static easyScoreHook({ fingerings }: { fingerings?: string } = {}, note: StaveNote, builder: Builder): void {
+  static easyScoreHook({ fingerings }: { fingerings?: string } = {}, note: StemmableNote, builder: Builder): void {
     fingerings
       ?.split(',')
       .map((fingeringString: string) => {

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -2,6 +2,7 @@
 //
 // ## Description
 
+import { Annotation } from './annotation';
 import { ModifierContext } from './modifiercontext';
 import { NoteStruct } from './note';
 import { Stave } from './stave';
@@ -61,12 +62,14 @@ export class GhostNote extends StemmableNote {
   }
 
   draw(): void {
-    // Draw the modifiers
+    // Draw Annotations
     this.setRendered();
     for (let i = 0; i < this.modifiers.length; ++i) {
       const modifier = this.modifiers[i];
-      modifier.setContext(this.getContext());
-      modifier.drawWithStyle();
+      if (modifier instanceof Annotation) {
+        modifier.setContext(this.getContext());
+        modifier.drawWithStyle();
+      }
     }
   }
 }

--- a/src/note.ts
+++ b/src/note.ts
@@ -1,7 +1,9 @@
 // [VexFlow](https://vexflow.com) - Copyright (c) Mohit Muthanna 2010.
 // MIT License
 
+import { Accidental } from './accidental';
 import { Beam } from './beam';
+import { Dot } from './dot';
 import { Font } from './font';
 import { Fraction } from './fraction';
 import { GlyphProps } from './glyph';
@@ -556,6 +558,47 @@ export abstract class Note extends Tickable {
     this.modifiers.push(modifier);
     this.preFormatted = false;
     return this;
+  }
+
+  // Helper function to add an accidental to a key
+  addAccidental(index: number, accidental: Modifier): this {
+    return this.addModifier(accidental, index);
+  }
+
+  // Helper function to add an articulation to a key
+  addArticulation(index: number, articulation: Modifier): this {
+    return this.addModifier(articulation, index);
+  }
+
+  // Helper function to add an annotation to a key
+  addAnnotation(index: number, annotation: Modifier): this {
+    return this.addModifier(annotation, index);
+  }
+
+  // Helper function to add a dot on a specific key
+  addDot(index: number): this {
+    const dot = new Dot();
+    dot.setDotShiftY(this.glyph.dot_shiftY);
+    this.dots++;
+    return this.addModifier(dot, index);
+  }
+
+  // Convenience method to add dot to all keys in note
+  addDotToAll(): this {
+    for (let i = 0; i < this.keys.length; ++i) {
+      this.addDot(i);
+    }
+    return this;
+  }
+
+  // Get all accidentals in the `ModifierContext`
+  getAccidentals(): Accidental[] {
+    return this.checkModifierContext().getMembers(Accidental.CATEGORY) as Accidental[];
+  }
+
+  // Get all dots in the `ModifierContext`
+  getDots(): Dot[] {
+    return this.checkModifierContext().getMembers(Dot.CATEGORY) as Dot[];
   }
 
   /** Get the coordinates for where modifiers begin. */

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -8,10 +8,8 @@
 //
 // See `tests/stavenote_tests.ts` for usage examples.
 
-import { Accidental } from './accidental';
 import { Beam } from './beam';
 import { BoundingBox } from './boundingbox';
-import { Dot } from './dot';
 import { ElementStyle } from './element';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
@@ -869,47 +867,6 @@ export class StaveNote extends StemmableNote {
 
   getKeyLine(index: number): number {
     return this.keyProps[index].line;
-  }
-
-  // Helper function to add an accidental to a key
-  addAccidental(index: number, accidental: Modifier): this {
-    return this.addModifier(accidental, index);
-  }
-
-  // Helper function to add an articulation to a key
-  addArticulation(index: number, articulation: Modifier): this {
-    return this.addModifier(articulation, index);
-  }
-
-  // Helper function to add an annotation to a key
-  addAnnotation(index: number, annotation: Modifier): this {
-    return this.addModifier(annotation, index);
-  }
-
-  // Helper function to add a dot on a specific key
-  addDot(index: number): this {
-    const dot = new Dot();
-    dot.setDotShiftY(this.glyph.dot_shiftY);
-    this.dots++;
-    return this.addModifier(dot, index);
-  }
-
-  // Convenience method to add dot to all keys in note
-  addDotToAll(): this {
-    for (let i = 0; i < this.keys.length; ++i) {
-      this.addDot(i);
-    }
-    return this;
-  }
-
-  // Get all accidentals in the `ModifierContext`
-  getAccidentals(): Accidental[] {
-    return this.checkModifierContext().getMembers(Accidental.CATEGORY) as Accidental[];
-  }
-
-  // Get all dots in the `ModifierContext`
-  getDots(): Dot[] {
-    return this.checkModifierContext().getMembers(Dot.CATEGORY) as Dot[];
   }
 
   // Get the width of the note if it is displaced. Used for `Voice`

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -155,6 +155,7 @@ const validNoteTypes: Record<string, { name: string }> = {
   h: { name: 'harmonic' },
   m: { name: 'muted' },
   s: { name: 'slash' },
+  g: { name: 'ghost' },
 };
 
 const customNoteHeads: Record<string, { code: string }> = {
@@ -933,6 +934,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadDoubleWhole',
+      },
     },
   },
 
@@ -985,6 +990,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadWhole',
       },
     },
   },
@@ -1040,6 +1049,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadHalf',
+      },
     },
   },
 
@@ -1094,6 +1107,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },
@@ -1155,6 +1172,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1214,6 +1235,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },
@@ -1275,6 +1300,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1335,6 +1364,10 @@ const durationCodes: Record<string, any> = {
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
       },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
+      },
     },
   },
 
@@ -1394,6 +1427,10 @@ const durationCodes: Record<string, any> = {
         // Drawn with canvas primitives
         getWidth: () => Tables.SLASH_NOTEHEAD_WIDTH,
         position: 'B/4',
+      },
+      g: {
+        // Ghostnote
+        code_head: 'noteheadBlack',
       },
     },
   },

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -273,25 +273,29 @@ export class Tuplet extends Element {
       // y_pos = first_note.getStemExtents().topY - 10;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        const top_y =
-          this.notes[i].getStemDirection() === Stem.UP
-            ? this.notes[i].getStemExtents().topY - 10
-            : this.notes[i].getStemExtents().baseY - 20;
+        if (this.notes[i].hasStem() || this.notes[i].isRest()) {
+          const top_y =
+            this.notes[i].getStemDirection() === Stem.UP
+              ? this.notes[i].getStemExtents().topY - 10
+              : this.notes[i].getStemExtents().baseY - 20;
 
-        if (top_y < y_pos) {
-          y_pos = top_y;
+          if (top_y < y_pos) {
+            y_pos = top_y;
+          }
         }
       }
     } else {
       y_pos = first_note.checkStave().getYForLine(4) + 20;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        const bottom_y =
-          this.notes[i].getStemDirection() === Stem.UP
-            ? this.notes[i].getStemExtents().baseY + 20
-            : this.notes[i].getStemExtents().topY + 10;
-        if (bottom_y > y_pos) {
-          y_pos = bottom_y;
+        if (this.notes[i].hasStem() || this.notes[i].isRest()) {
+          const bottom_y =
+            this.notes[i].getStemDirection() === Stem.UP
+              ? this.notes[i].getStemExtents().baseY + 20
+              : this.notes[i].getStemExtents().topY + 10;
+          if (bottom_y > y_pos) {
+            y_pos = bottom_y;
+          }
         }
       }
     }

--- a/tests/curve_tests.ts
+++ b/tests/curve_tests.ts
@@ -8,7 +8,7 @@ import { concat, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { CurvePosition } from '../src/curve';
 import { BuilderOptions } from '../src/easyscore';
 import { Factory } from '../src/factory';
-import { StaveNote } from '../src/stavenote';
+import { StemmableNote } from '../src/stemmablenote';
 
 const CurveTests = {
   Start(): void {
@@ -29,7 +29,11 @@ type NoteParams = [string, BuilderOptions];
  * a setupCurves() callback which uses Factory.Curve(...) to build the curves.
  * Curves can be used to indicate slurs (legato articulation).
  */
-function createTest(noteGroup1: NoteParams, noteGroup2: NoteParams, setupCurves: (f: Factory, n: StaveNote[]) => void) {
+function createTest(
+  noteGroup1: NoteParams,
+  noteGroup2: NoteParams,
+  setupCurves: (f: Factory, n: StemmableNote[]) => void
+) {
   return (options: TestOptions) => {
     const factory = VexFlowTests.makeFactory(options, 350, 200);
     const stave = factory.Stave({ y: 50 });

--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -28,6 +28,8 @@ const EasyScoreTests = {
     run('Draw Basic Muted', drawBasicMutedTest);
     run('Draw Basic Harmonic', drawBasicHarmonicTest);
     run('Draw Basic Slash', drawBasicSlashTest);
+    run('Draw Ghostnote Basic', drawGhostBasicTest);
+    run('Draw Ghostnote Dotted', drawGhostDottedTest);
     run('Draw Accidentals', drawAccidentalsTest);
     run('Draw Beams', drawBeamsTest);
     run('Draw Tuplets', drawTupletsTest);
@@ -58,7 +60,7 @@ function createShortcuts(score: EasyScore) {
  */
 function basic(): void {
   const score = new EasyScore();
-  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/m', 'c3//m', 'c3//h', 'c3/s', 'c3//s'];
+  const mustPass = ['c4', 'c#4', 'c4/r', 'c#5', 'c3/m', 'c3//m', 'c3//h', 'c3/s', 'c3//s', 'c3/g', 'c3//g'];
   const mustFail = ['', '()', '7', '(c#4 e5 g6'];
 
   mustPass.forEach((line) => equal(score.parse(line).success, true, line));
@@ -291,6 +293,62 @@ function drawBasicSlashTest(options: TestOptions): void {
     })
     .addClef('bass');
   system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawGhostBasicTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 550);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  system.addStave({
+    voices: [
+      score.voice(
+        [
+          ...score.notes('f#5/4, f5, db5, c5', { stem: 'up' }),
+          ...score.beam(score.notes('c5/8, d5, fn5, e5', { stem: 'up' })),
+          ...score.beam(score.notes('d5, c5', { stem: 'up' })),
+        ],
+        { time: '7/4' }
+      ),
+      score.voice(score.notes('c4/h/g, f4/4, c4/4/g, e4/4, c4/8/g, d##4/8, c4/8, c4/8', { stem: 'down' }), {
+        time: '7/4',
+      }),
+    ],
+  });
+
+  f.draw();
+  expect(0);
+}
+
+function drawGhostDottedTest(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 550);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  system.addStave({
+    voices: [
+      score.voice(
+        [
+          ...score.notes('c4/4/g., fbb5/8, d5/4', { stem: 'up' }),
+          ...score.beam(score.notes('c5/8, c#5/16, d5/16', { stem: 'up' })),
+          ...score.notes('c4/2/g.., fn5/8', { stem: 'up' }),
+        ],
+        { time: '8/4' }
+      ),
+      score.voice(
+        [
+          ...score.notes('f#4/4', { stem: 'down' }),
+          ...score.beam(score.notes('e4/8, d4/8', { stem: 'down' })),
+          ...score.notes('c4/4/g.., cb4/16, c#4/h, d4/4', { stem: 'down' }),
+          ...score.beam(score.notes('fn4/8, e4/8', { stem: 'down' })),
+        ],
+        { time: '8/4' }
+      ),
+    ],
+  });
 
   f.draw();
   expect(0);

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -22,6 +22,7 @@ import {
   Stave,
   StaveConnector,
   StaveNote,
+  StemmableNote,
   StringNumber,
   TextBracket,
   Tuplet,
@@ -553,7 +554,7 @@ function proportional(options: TestOptions): void {
     score.tuplet(score.notes('a4/32, a4, a4, a4, a4, a4, a4'), { notes_occupied: 8 }),
   ];
 
-  const createVoice = (notes: StaveNote[]) => score.voice(notes, { time: '1/4' });
+  const createVoice = (notes: StemmableNote[]) => score.voice(notes, { time: '1/4' });
   const createStave = (voice: Voice) =>
     system
       .addStave({ voices: [voice], debugNoteMetrics: debug })

--- a/tests/stavetie_tests.ts
+++ b/tests/stavetie_tests.ts
@@ -8,8 +8,8 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { BuilderOptions } from '../src/easyscore';
 import { Factory } from '../src/factory';
 import { Stave } from '../src/stave';
-import { StaveNote } from '../src/stavenote';
 import { Stem } from '../src/stem';
+import { StemmableNote } from '../src/stemmablenote';
 
 const StaveTieTests = {
   Start(): void {
@@ -30,7 +30,10 @@ const StaveTieTests = {
 /**
  * Used by the 7 tests below to set up the stave, easyscore, notes, voice, and to format & draw.
  */
-function createTest(notesData: [string, BuilderOptions], setupTies: (f: Factory, n: StaveNote[], s: Stave) => void) {
+function createTest(
+  notesData: [string, BuilderOptions],
+  setupTies: (f: Factory, n: StemmableNote[], s: Stave) => void
+) {
   return (options: TestOptions) => {
     const factory = VexFlowTests.makeFactory(options, 300);
     const stave = factory.Stave();


### PR DESCRIPTION
Fixes #463

@0xfe this one includes #1259, if you merge #1259 first the number of changes will be reduced.

The support of `Ghostnotes` in `EasyScore` involves three main topics:
- Change return type of `EasyScore.notes(...)` from `StaveNote` to `StemmableNote`
- Move `AddArticulation` ... from `StaveNote` to `Note` where the handling of modifiers is already.
- Support for `GhostNote` in `Beam` and `Tuplet`

No visual diffs. Tests in addition to those in #1259:

**Basic  (replica from Ghostnote_Basic using EasyScore)**
![EasyScore Draw_Ghostnote_Basic Bravura](https://user-images.githubusercontent.com/22865285/146631526-b60fcfda-c402-4af7-9914-8d8f4c2f1004.png)
![EasyScore Draw_Ghostnote_Basic Gonville](https://user-images.githubusercontent.com/22865285/146631527-2053a846-0da7-4151-85e6-3cef045e01c6.png)
![EasyScore Draw_Ghostnote_Basic Petaluma](https://user-images.githubusercontent.com/22865285/146631528-294a782d-3772-46ea-9791-98559797d3d1.png)

**Dotted  (replica from Ghostnote_Dotted using EasyScore)**
![EasyScore Draw_Ghostnote_Dotted Bravura](https://user-images.githubusercontent.com/22865285/146631529-cd43ed42-c5c5-464e-ba1b-190028b9e44e.png)
![EasyScore Draw_Ghostnote_Dotted Gonville](https://user-images.githubusercontent.com/22865285/146631531-d07f85a1-0ff8-48f2-adbe-efe099c62305.png)
![EasyScore Draw_Ghostnote_Dotted Petaluma](https://user-images.githubusercontent.com/22865285/146631532-8a745e59-e021-4348-93a7-be9d70aeaf0b.png)
 