### PR TITLE
OSMD VexflowPatch: support for big tremolo

### DIFF
--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -116,17 +116,17 @@ export const GonvilleMetrics = {
   tremolo: {
     default: {
       point: 25,
-      spacing: 4,
-      offsetYStemUp: -17,
-      offsetYStemDown: -2,
+      spacing: 5,
+      offsetYStemUp: -5,
+      offsetYStemDown: 5,
       offsetXStemUp: 9,
       offsetXStemDown: -0.5,
     },
     grace: {
       point: 15,
       spacing: 4,
-      offsetYStemUp: -17,
-      offsetYStemDown: -2,
+      offsetYStemUp: -5,
+      offsetYStemDown: 5,
       offsetXStemUp: 6.5,
       offsetXStemDown: -0.5,
     },

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -116,17 +116,17 @@ export const GonvilleMetrics = {
   tremolo: {
     default: {
       point: 25,
-      spacing: 5,
-      offsetYStemUp: -5,
-      offsetYStemDown: 5,
+      spacing: 4,
+      offsetYStemUp: -7,
+      offsetYStemDown: 7,
       offsetXStemUp: 9,
       offsetXStemDown: -0.5,
     },
     grace: {
       point: 15,
       spacing: 4,
-      offsetYStemUp: -5,
-      offsetYStemDown: 5,
+      offsetYStemUp: -7,
+      offsetYStemDown: 7,
       offsetXStemUp: 6.5,
       offsetXStemDown: -0.5,
     },

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -409,6 +409,14 @@ export const GonvilleMetrics = {
         reportedWidth: 5,
       },
     },
+    tremolo: {
+      default: {
+        shiftY: -10,
+      },
+      grace: {
+        shiftY: -5,
+      },
+    },
     tuplet: {
       noteHeadOffset: 20,
       stemOffset: 10,

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -263,14 +263,15 @@ export class Glyph extends Element {
       point = data.point;
     }
 
-    const scale = ((point * 72.0) / (metrics.font.getResolution() * 100.0)) * metrics.scale * (options?.scale ?? 1);
+    const customScale = options?.scale ?? 1;
+    const scale = ((point * 72.0) / (metrics.font.getResolution() * 100.0)) * metrics.scale * customScale;
 
     Glyph.renderOutline(
       ctx,
       metrics.outline,
       scale,
-      x_pos + metrics.x_shift * (options?.scale ?? 1),
-      y_pos + metrics.y_shift * (options?.scale ?? 1)
+      x_pos + metrics.x_shift * customScale,
+      y_pos + metrics.y_shift * customScale
     );
     return metrics;
   }

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -263,9 +263,9 @@ export class Glyph extends Element {
       point = data.point;
     }
 
-    const scale = (point * 72.0) / (metrics.font.getResolution() * 100.0);
+    const scale = ((point * 72.0) / (metrics.font.getResolution() * 100.0)) * metrics.scale;
 
-    Glyph.renderOutline(ctx, metrics.outline, scale * metrics.scale, x_pos + metrics.x_shift, y_pos + metrics.y_shift);
+    Glyph.renderOutline(ctx, metrics.outline, scale, x_pos + metrics.x_shift * scale, y_pos + metrics.y_shift * scale);
     return metrics;
   }
 

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -255,7 +255,7 @@ export class Glyph extends Element {
     y_pos: number,
     point: number,
     code: string,
-    options?: { category: string }
+    options?: { category?: string; scale?: number }
   ): GlyphMetrics {
     const data = Glyph.cache.lookup(code, options?.category);
     const metrics = data.metrics;
@@ -263,9 +263,15 @@ export class Glyph extends Element {
       point = data.point;
     }
 
-    const scale = ((point * 72.0) / (metrics.font.getResolution() * 100.0)) * metrics.scale;
+    const scale = ((point * 72.0) / (metrics.font.getResolution() * 100.0)) * metrics.scale * (options?.scale ?? 1);
 
-    Glyph.renderOutline(ctx, metrics.outline, scale, x_pos + metrics.x_shift * scale, y_pos + metrics.y_shift * scale);
+    Glyph.renderOutline(
+      ctx,
+      metrics.outline,
+      scale,
+      x_pos + metrics.x_shift * (options?.scale ?? 1),
+      y_pos + metrics.y_shift * (options?.scale ?? 1)
+    );
     return metrics;
   }
 

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -63,12 +63,11 @@ export class Tremolo extends Modifier {
       y += musicFont.lookupMetric(`${category}.offsetYStemUp`) * scale;
     }
 
-    // add extra_stroke_scale for big strokes(#1258)
-    const fontScale = musicFont.lookupMetric(`${category}.point`) * this.extra_stroke_scale;
+    const fontScale = musicFont.lookupMetric(`${category}.point`);
 
     x += musicFont.lookupMetric(`${category}.offsetXStem${stemDirection === Stem.UP ? 'Up' : 'Down'}`);
     for (let i = 0; i < this.num; ++i) {
-      Glyph.renderGlyph(ctx, x, y, fontScale, this.code, { category });
+      Glyph.renderGlyph(ctx, x, y, fontScale, this.code, { category, scale: this.extra_stroke_scale });
       y += y_spacing;
     }
   }

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -16,6 +16,10 @@ export class Tremolo extends Modifier {
 
   protected readonly code: string;
   protected readonly num: number;
+  /** Extra spacing required for big strokes. */
+  public y_spacing_scale: number;
+  /** Font scaling for big strokes. */
+  public extra_stroke_scale: number;
 
   /**
    * @param num number of bars
@@ -26,6 +30,9 @@ export class Tremolo extends Modifier {
     this.num = num;
     this.position = Modifier.Position.CENTER;
     this.code = 'tremolo1';
+    // big strokes scales initialised to 1 (no scale)
+    this.y_spacing_scale = 1;
+    this.extra_stroke_scale = 1;
   }
 
   /** Draw the tremolo on the rendering context. */
@@ -44,7 +51,9 @@ export class Tremolo extends Modifier {
     const category = `tremolo.${gn ? 'grace' : 'default'}`;
 
     const musicFont = Tables.currentMusicFont();
-    const y_spacing = musicFont.lookupMetric(`${category}.spacing`) * stemDirection;
+    let y_spacing = musicFont.lookupMetric(`${category}.spacing`) * stemDirection;
+    // add y_spacing_scale for big strokes (#1258)
+    y_spacing *= this.y_spacing_scale;
     const height = this.num * y_spacing;
     let y = note.getStemExtents().baseY - height;
 
@@ -54,7 +63,8 @@ export class Tremolo extends Modifier {
       y += musicFont.lookupMetric(`${category}.offsetYStemUp`) * scale;
     }
 
-    const fontScale = musicFont.lookupMetric(`${category}.point`);
+    // add extra_stroke_scale for big strokes(#1258)
+    const fontScale = musicFont.lookupMetric(`${category}.point`) * this.extra_stroke_scale;
 
     x += musicFont.lookupMetric(`${category}.offsetXStem${stemDirection === Stem.UP ? 'Up' : 'Down'}`);
     for (let i = 0; i < this.num; ++i) {

--- a/tests/tremolo_tests.ts
+++ b/tests/tremolo_tests.ts
@@ -13,6 +13,7 @@ const TremoloTests = {
     QUnit.module('Tremolo');
     const run = VexFlowTests.runTests;
     run('Tremolo - Basic', tremoloBasic);
+    run('Tremolo - Big', tremoloBig);
   },
 };
 
@@ -51,6 +52,61 @@ function tremoloBasic(options: TestOptions): void {
   f.draw();
 
   ok(true, 'Tremolo - Basic');
+}
+
+function tremoloBig(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 200);
+  const score = f.EasyScore();
+
+  // bar 1
+  const stave1 = f.Stave({ width: 250 }).setEndBarType(Barline.type.DOUBLE);
+
+  const notes1 = score.notes('e4/4, e4, e4, e4', { stem: 'up' });
+
+  const tremolo1 = new Tremolo(3);
+  tremolo1.extra_stroke_scale = 1.7;
+  tremolo1.y_spacing_scale = 1.5;
+  const tremolo2 = new Tremolo(2);
+  tremolo2.extra_stroke_scale = 1.7;
+  tremolo2.y_spacing_scale = 1.5;
+  const tremolo3 = new Tremolo(1);
+  tremolo3.extra_stroke_scale = 1.7;
+  tremolo3.y_spacing_scale = 1.5;
+  notes1[0].addModifier(tremolo1);
+  notes1[1].addModifier(tremolo2);
+  notes1[2].addModifier(tremolo3);
+
+  const voice1 = score.voice(notes1);
+
+  f.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
+
+  // bar 2
+  const stave2 = f
+    .Stave({ x: stave1.getWidth() + stave1.getX(), y: stave1.getY(), width: 300 })
+    .setEndBarType(Barline.type.DOUBLE);
+
+  const notes2 = score.notes('e5/4, e5, e5, e5', { stem: 'down' });
+
+  const tremolo4 = new Tremolo(1);
+  tremolo4.extra_stroke_scale = 1.7;
+  tremolo4.y_spacing_scale = 1.5;
+  const tremolo5 = new Tremolo(2);
+  tremolo5.extra_stroke_scale = 1.7;
+  tremolo5.y_spacing_scale = 1.5;
+  const tremolo6 = new Tremolo(3);
+  tremolo6.extra_stroke_scale = 1.7;
+  tremolo6.y_spacing_scale = 1.5;
+  notes2[1].addModifier(tremolo4);
+  notes2[2].addModifier(tremolo5);
+  notes2[3].addModifier(tremolo6);
+
+  const voice2 = score.voice(notes2);
+
+  f.Formatter().joinVoices([voice2]).formatToStave([voice2], stave2);
+
+  f.draw();
+
+  ok(true, 'Tremolo - Big');
 }
 
 VexFlowTests.register(TremoloTests);

--- a/tests/tremolo_tests.ts
+++ b/tests/tremolo_tests.ts
@@ -72,9 +72,9 @@ function tremoloBig(options: TestOptions): void {
   const tremolo3 = new Tremolo(1);
   tremolo3.extra_stroke_scale = 1.7;
   tremolo3.y_spacing_scale = 1.5;
-  notes1[0].addModifier(tremolo1);
-  notes1[1].addModifier(tremolo2);
-  notes1[2].addModifier(tremolo3);
+  notes1[0].addModifier(0, tremolo1);
+  notes1[1].addModifier(0, tremolo2);
+  notes1[2].addModifier(0, tremolo3);
 
   const voice1 = score.voice(notes1);
 
@@ -96,9 +96,9 @@ function tremoloBig(options: TestOptions): void {
   const tremolo6 = new Tremolo(3);
   tremolo6.extra_stroke_scale = 1.7;
   tremolo6.y_spacing_scale = 1.5;
-  notes2[1].addModifier(tremolo4);
-  notes2[2].addModifier(tremolo5);
-  notes2[3].addModifier(tremolo6);
+  notes2[1].addModifier(0, tremolo4);
+  notes2[2].addModifier(0, tremolo5);
+  notes2[3].addModifier(0, tremolo6);
 
   const voice2 = score.voice(notes2);
 


### PR DESCRIPTION
fixes #1258

@sschmidTU could you review these changes? I do not get it right.

No visual diffs but incorrect result in new test with `Gonville` (this might be fixed once #1243 is merged):

![Tremolo Tremolo___Big Bravura](https://user-images.githubusercontent.com/22865285/146631919-93de89a0-b4cc-44c6-976a-9b9eecc107a1.png)
![Tremolo Tremolo___Big Gonville](https://user-images.githubusercontent.com/22865285/146631927-e0fccef1-9850-42ef-98f7-0a2c55bbbe5c.png)
![Tremolo Tremolo___Big Petaluma](https://user-images.githubusercontent.com/22865285/146631937-99b6e1ff-0b31-4fad-80d8-b0bc8e0ac077.png)



