### PR TITLE
OSMD VexflowPatch: stave & stavesection

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -258,12 +258,22 @@ export class CanvasContext extends RenderContext {
 
   measureText(text: string): TextMeasure {
     const metrics = this.context2D.measureText(text);
+
+    let y = 0;
+    let height = 0;
+    if (metrics.fontBoundingBoxAscent) {
+      y = -metrics.fontBoundingBoxAscent;
+      height = metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent;
+    } else {
+      y = -metrics.actualBoundingBoxAscent;
+      height = metrics.actualBoundingBoxDescent + metrics.actualBoundingBoxAscent;
+    }
     // Return x, y, width & height in the same manner as svg getBBox
     return {
       x: 0,
-      y: -metrics.fontBoundingBoxAscent,
+      y: y,
       width: metrics.width,
-      height: metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent,
+      height: height,
     };
   }
 

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -260,7 +260,7 @@ export class CanvasContext extends RenderContext {
     const metrics = this.context2D.measureText(text);
     return {
       width: metrics.width,
-      height: this.textHeight,
+      height: metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
     };
   }
 

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -258,9 +258,12 @@ export class CanvasContext extends RenderContext {
 
   measureText(text: string): TextMeasure {
     const metrics = this.context2D.measureText(text);
+    // Return x, y, width & height in the same manner as svg getBBox
     return {
+      x: 0,
+      y: -metrics.fontBoundingBoxAscent,
       width: metrics.width,
-      height: metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
+      height: metrics.fontBoundingBoxDescent + metrics.fontBoundingBoxAscent,
     };
   }
 

--- a/src/rendercontext.ts
+++ b/src/rendercontext.ts
@@ -4,6 +4,8 @@
 import { FontInfo } from './font';
 
 export interface TextMeasure {
+  x: number;
+  y: number;
   width: number;
   height: number;
 }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -310,9 +310,9 @@ export class Stave extends Element {
   }
 
   // Section functions
-  setSection(section: string, y: number, xOffset = 0, fontSize = 10) {
+  setSection(section: string, y: number, xOffset = 0, fontSize?: number) {
     const staveSection = new StaveSection(section, this.x + xOffset, y);
-    staveSection.setFontSize(fontSize);
+    if (fontSize) staveSection.setFontSize(fontSize);
     this.modifiers.push(staveSection);
     return this;
   }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -310,7 +310,7 @@ export class Stave extends Element {
   }
 
   // Section functions
-  setSection(section: string, y: number, xOffset = 0, fontSize = 12) {
+  setSection(section: string, y: number, xOffset = 0, fontSize = 10) {
     const staveSection = new StaveSection(section, this.x + xOffset, y);
     staveSection.setFontSize(fontSize);
     this.modifiers.push(staveSection);

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -310,8 +310,10 @@ export class Stave extends Element {
   }
 
   // Section functions
-  setSection(section: string, y: number): this {
-    this.modifiers.push(new StaveSection(section, this.x, y));
+  setSection(section: string, y: number, xOffset = 0, fontSize = 12) {
+    const staveSection = new StaveSection(section, this.x + xOffset, y);
+    staveSection.setFontSize(fontSize);
+    this.modifiers.push(staveSection);
     return this;
   }
 

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -29,7 +29,7 @@ export class StaveSection extends StaveModifier {
     this.x = x;
     this.shift_x = 0;
     this.shift_y = shift_y;
-    this.resetFont();
+    this.setFont('bold 12pt sans-serif');
   }
 
   setStaveSection(section: string): this {
@@ -55,16 +55,19 @@ export class StaveSection extends StaveModifier {
     ctx.setLineWidth(2);
     ctx.setFont(this.textFont);
 
-    const textWidth = ctx.measureText('' + this.section).width;
+    const textMeasurements = ctx.measureText('' + this.section);
+    const textWidth = textMeasurements.width;
+    const textHeight = textMeasurements.height;
     let width = textWidth + 6; // add left & right padding
     if (width < 18) width = 18;
-    const height = 20;
+    const height = textHeight;
+
     //  Seems to be a good default y
     const y = stave.getYForTopText(3) + this.shift_y;
     let x = this.x + shift_x;
     ctx.beginPath();
     ctx.setLineWidth(2);
-    ctx.rect(x, y, width, height);
+    ctx.rect(x, y + textHeight / 8, width, height);
     ctx.stroke();
     x += (width - textWidth) / 2;
     ctx.fillText('' + this.section, x, y + 16);

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -69,7 +69,7 @@ export class StaveSection extends StaveModifier {
     const x = this.x + shift_x;
     ctx.beginPath();
     ctx.setLineWidth(rectWidth);
-    ctx.rect(x, y - height + paddingY, width, height);
+    ctx.rect(x, y + textMeasurements.y - paddingY, width, height);
     ctx.stroke();
     ctx.fillText(this.section, x + paddingX, y);
     ctx.restore();

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -55,22 +55,23 @@ export class StaveSection extends StaveModifier {
     ctx.setLineWidth(2);
     ctx.setFont(this.textFont);
 
-    const textMeasurements = ctx.measureText('' + this.section);
+    const paddingX = 2;
+    const paddingY = 2;
+    const rectWidth = 2;
+    const textMeasurements = ctx.measureText(this.section);
     const textWidth = textMeasurements.width;
     const textHeight = textMeasurements.height;
-    let width = textWidth + 6; // add left & right padding
-    if (width < 18) width = 18;
-    const height = textHeight;
+    const width = textWidth + 2 * paddingX; // add left & right padding
+    const height = textHeight + 2 * paddingY; // add top & bottom padding
 
     //  Seems to be a good default y
-    const y = stave.getYForTopText(3) + this.shift_y;
-    let x = this.x + shift_x;
+    const y = stave.getYForTopText(2) + this.shift_y;
+    const x = this.x + shift_x;
     ctx.beginPath();
-    ctx.setLineWidth(2);
-    ctx.rect(x, y + textHeight / 4, width, height);
+    ctx.setLineWidth(rectWidth);
+    ctx.rect(x, y - height + paddingY, width, height);
     ctx.stroke();
-    x += (width - textWidth) / 2;
-    ctx.fillText('' + this.section, x, y + 16);
+    ctx.fillText(this.section, x + paddingX, y);
     ctx.restore();
     return this;
   }

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -12,7 +12,7 @@ export class StaveSection extends StaveModifier {
 
   static TEXT_FONT: Required<FontInfo> = {
     family: Font.SANS_SERIF,
-    size: 12,
+    size: 10,
     weight: FontWeight.BOLD,
     style: FontStyle.NORMAL,
   };
@@ -29,7 +29,7 @@ export class StaveSection extends StaveModifier {
     this.x = x;
     this.shift_x = 0;
     this.shift_y = shift_y;
-    this.setFont('bold 12pt sans-serif');
+    this.resetFont();
   }
 
   setStaveSection(section: string): this {
@@ -67,7 +67,7 @@ export class StaveSection extends StaveModifier {
     let x = this.x + shift_x;
     ctx.beginPath();
     ctx.setLineWidth(2);
-    ctx.rect(x, y + textHeight / 8, width, height);
+    ctx.rect(x, y + textHeight / 4, width, height);
     ctx.stroke();
     x += (width - textWidth) / 2;
     ctx.fillText('' + this.section, x, y + 16);

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -91,13 +91,7 @@ class MeasureTextCache {
     const bbox = txt.getBBox();
     svg.removeChild(txt);
 
-    const fontSizeInPt: string = attributes['font-size'];
-
-    // Remove the trailing 'pt' from the font size and scale to convert from points to canvas pixel units.
-    // CSS specifies dpi to be 96 and there are 72 points to an inch: 96/72 == 4/3.
-    const height = Font.convertSizeToPixelValue(fontSizeInPt);
-
-    return { width: bbox.width, height: height };
+    return { width: bbox.width, height: bbox.height };
   }
 }
 

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -91,7 +91,7 @@ class MeasureTextCache {
     const bbox = txt.getBBox();
     svg.removeChild(txt);
 
-    return { width: bbox.width, height: bbox.height };
+    return { x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height };
   }
 }
 

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -33,6 +33,7 @@ const StaveTests = {
     run('Stave Draw Test', draw);
     run('Open Stave Draw Test', drawOpenStave);
     run('Multiple Stave Barline Test', drawMultipleMeasures);
+    run('Multiple Stave Barline Test (14pt Section)', drawMultipleMeasures, { fontSize: 14 });
     run('Multiple Stave Repeats Test', drawRepeats);
     run('Stave End Modifiers Test', drawEndModifiers);
     run('Multiple Staves Volta Test', drawVolta);
@@ -147,7 +148,7 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
   const staveBar1 = new Stave(10, 50, 200);
   staveBar1.setBegBarType(BarlineType.REPEAT_BEGIN);
   staveBar1.setEndBarType(BarlineType.DOUBLE);
-  staveBar1.setSection('A', 0);
+  staveBar1.setSection('A', 0, 0, options.params?.fontSize);
   staveBar1.addClef('treble').setContext(ctx).draw();
   const notesBar1 = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),
@@ -161,7 +162,7 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
 
   // bar 2 - juxtaposing second bar next to first bar
   const staveBar2 = new Stave(staveBar1.getWidth() + staveBar1.getX(), staveBar1.getY(), 300);
-  staveBar2.setSection('B', 0);
+  staveBar2.setSection('B', 0, 0, options.params?.fontSize);
   staveBar2.setEndBarType(BarlineType.END);
   staveBar2.setContext(ctx).draw();
 


### PR DESCRIPTION
Fixes #1253
Fixes #1256 

@sschmidTU could you review this one?

@0xfe the visual regression does not show any difference although there is the difference bellow. Do you agree with this change? To me in makes more sense to use the text meassurement hieght and the question is also if we want to add a padding up / down

**Current**
![Stave Multiple_Stave_Barline_Test Bravura](https://user-images.githubusercontent.com/22865285/146637568-f264c5f6-c6f9-4648-9618-54e3890d66bc.png)
![Stave Multiple_Stave_Barline_Test Gonville](https://user-images.githubusercontent.com/22865285/146637570-3a159232-cbd8-4160-9604-ba1ad2698516.png)
![Stave Multiple_Stave_Barline_Test Petaluma](https://user-images.githubusercontent.com/22865285/146637571-d81442fc-d452-4d26-b79b-6634d63bec5d.png)

**Reference**
![Stave Multiple_Stave_Barline_Test Bravura](https://user-images.githubusercontent.com/22865285/146637593-f15960d7-5bd7-4053-aa00-f096742d3004.png)
![Stave Multiple_Stave_Barline_Test Gonville](https://user-images.githubusercontent.com/22865285/146637594-5ad0086c-624e-4213-a711-8ca454c8acef.png)
![Stave Multiple_Stave_Barline_Test Petaluma](https://user-images.githubusercontent.com/22865285/146637596-7e3c7a7f-a1a4-49b5-8ac4-73d3605a7d20.png)

