### PR TITLE
OSMD VexflowPatch: StaveRepetition, TO_CODA support and position fix.

### DIFF
--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -142,6 +142,14 @@ export const BravuraMetrics = {
     },
   },
 
+  staveRepetition: {
+    default: {
+      offsetY: 25,
+      offsetSymbol: 12,
+      spacing: 5,
+    },
+  },
+
   // noteHead: {
   // },
 

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -132,6 +132,14 @@ export const GonvilleMetrics = {
     },
   },
 
+  staveRepetition: {
+    default: {
+      offsetY: 25,
+      offsetSymbol: 12,
+      spacing: 5,
+    },
+  },
+
   // noteHead: {
   // },
 

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -143,6 +143,14 @@ export const PetalumaMetrics = {
     },
   },
 
+  staveRepetition: {
+    default: {
+      offsetY: 25,
+      offsetSymbol: 12,
+      spacing: 5,
+    },
+  },
+
   noteHead: {
     displaced: {
       shiftX: -2,

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -292,13 +292,8 @@ export class Stave extends Element {
     return start_x;
   }
 
-  // Coda & Segno Symbol functions
-  setRepetitionTypeLeft(type: number, y: number): this {
-    this.modifiers.push(new Repetition(type, this.x, y));
-    return this;
-  }
-
-  setRepetitionTypeRight(type: number, y: number): this {
+  /** Coda & Segno Symbol functions */
+  setRepetitionType(type: number, y: number): this {
     this.modifiers.push(new Repetition(type, this.x, y));
     return this;
   }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -293,8 +293,8 @@ export class Stave extends Element {
   }
 
   /** Coda & Segno Symbol functions */
-  setRepetitionType(type: number, y: number): this {
-    this.modifiers.push(new Repetition(type, this.x, y));
+  setRepetitionType(type: number, yShift: number = 0): this {
+    this.modifiers.push(new Repetition(type, this.x, yShift));
     return this;
   }
 

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -97,7 +97,6 @@ export class Repetition extends StaveModifier {
       case Repetition.type.FINE:
         this.drawSymbolText(stave, x, 'Fine', false);
         break;
-      // VexFlowPatch: added TO_CODA type, handling
       case Repetition.type.TO_CODA:
         this.drawSymbolText(stave, x, 'To', true);
         break;
@@ -138,7 +137,6 @@ export class Repetition extends StaveModifier {
       text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width;
       // TODO this is weird. setting the x position should probably be refactored, parameters aren't clear here.
     } else {
-      // VexFlowPatch: fix placement, like for DS_AL_CODA
       this.x_shift = -(text_x + ctx.measureText(text).width + 12 + stave.options.vertical_bar_width + 12);
       // TO_CODA and DS_AL_CODA draw in the next measure without this x_shift, not sure why not for other symbols.
       text_x = this.x + this.x_shift + stave.options.vertical_bar_width;

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -125,22 +125,29 @@ export class Repetition extends StaveModifier {
     ctx.save();
     ctx.setFont(this.textFont);
 
-    // Default to right symbol
-    let text_x = 0 + this.x_shift;
-    let symbol_x = x + this.x_shift;
-    if (this.symbol_type === Repetition.type.CODA_LEFT) {
-      // Offset Coda text to right of stave beginning
-      text_x = this.x + stave.getVerticalBarWidth();
-      symbol_x = text_x + ctx.measureText(text).width + 12;
-    } else if (this.symbol_type === Repetition.type.DS) {
-      const modifierWidth = stave.getNoteStartX() - this.x;
-      text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width;
-      // TODO this is weird. setting the x position should probably be refactored, parameters aren't clear here.
-    } else {
-      this.x_shift = -(text_x + ctx.measureText(text).width + 12 + stave.options.vertical_bar_width + 12);
-      // TO_CODA and DS_AL_CODA draw in the next measure without this x_shift, not sure why not for other symbols.
-      text_x = this.x + this.x_shift + stave.options.vertical_bar_width;
-      symbol_x = text_x + ctx.measureText(text).width + 12;
+    let text_x = 0;
+    let symbol_x = 0;
+    const modifierWidth = stave.getNoteStartX() - this.x;
+    switch (this.symbol_type) {
+      // To the left with symbol
+      case Repetition.type.CODA_LEFT:
+        // Offset Coda text to right of stave beginning
+        text_x = this.x + stave.getVerticalBarWidth();
+        symbol_x = text_x + ctx.measureText(text).width + 12;
+        break;
+      // To the right without symbol
+      case Repetition.type.DC:
+      case Repetition.type.DC_AL_FINE:
+      case Repetition.type.DS:
+      case Repetition.type.DS_AL_FINE:
+      case Repetition.type.FINE:
+        text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width;
+        break;
+      // To the right with symbol
+      default:
+        text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width - 12;
+        symbol_x = text_x + ctx.measureText(text).width + 12;
+        break;
     }
 
     const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift + 25;

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -5,6 +5,7 @@ import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
+import { Tables } from './tables';
 
 export class Repetition extends StaveModifier {
   static get CATEGORY(): string {
@@ -109,13 +110,27 @@ export class Repetition extends StaveModifier {
 
   drawCodaFixed(stave: Stave, x: number): this {
     const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift;
-    Glyph.renderGlyph(stave.checkContext(), this.x + x + this.x_shift, y + 25, 40, 'coda', { category: 'coda' });
+    Glyph.renderGlyph(
+      stave.checkContext(),
+      this.x + x + this.x_shift,
+      y + Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetY'),
+      40,
+      'coda',
+      { category: 'coda' }
+    );
     return this;
   }
 
   drawSignoFixed(stave: Stave, x: number): this {
     const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift;
-    Glyph.renderGlyph(stave.checkContext(), this.x + x + this.x_shift, y + 25, 30, 'segno', { category: 'segno' });
+    Glyph.renderGlyph(
+      stave.checkContext(),
+      this.x + x + this.x_shift,
+      y + Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetY'),
+      30,
+      'segno',
+      { category: 'segno' }
+    );
     return this;
   }
 
@@ -133,7 +148,10 @@ export class Repetition extends StaveModifier {
       case Repetition.type.CODA_LEFT:
         // Offset Coda text to right of stave beginning
         text_x = this.x + stave.getVerticalBarWidth();
-        symbol_x = text_x + ctx.measureText(text).width + 12;
+        symbol_x =
+          text_x +
+          ctx.measureText(text).width +
+          Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetSymbol');
         break;
       // To the right without symbol
       case Repetition.type.DC:
@@ -141,16 +159,37 @@ export class Repetition extends StaveModifier {
       case Repetition.type.DS:
       case Repetition.type.DS_AL_FINE:
       case Repetition.type.FINE:
-        text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width;
+        text_x =
+          this.x +
+          x +
+          this.x_shift +
+          stave.getWidth() -
+          Tables.currentMusicFont().lookupMetric('staveRepetition.default.spacing') -
+          modifierWidth -
+          ctx.measureText(text).width;
         break;
       // To the right with symbol
       default:
-        text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width - 12;
-        symbol_x = text_x + ctx.measureText(text).width + 12;
+        text_x =
+          this.x +
+          x +
+          this.x_shift +
+          stave.getWidth() -
+          Tables.currentMusicFont().lookupMetric('staveRepetition.default.spacing') -
+          modifierWidth -
+          ctx.measureText(text).width -
+          Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetSymbol');
+        symbol_x =
+          text_x +
+          ctx.measureText(text).width +
+          Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetSymbol');
         break;
     }
 
-    const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift + 25;
+    const y =
+      stave.getYForTopText(stave.getNumLines()) +
+      this.y_shift +
+      Tables.currentMusicFont().lookupMetric('staveRepetition.default.offsetY');
     if (draw_coda) {
       Glyph.renderGlyph(ctx, symbol_x, y, 40, 'coda', { category: 'coda' });
     }

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -31,6 +31,7 @@ export class Repetition extends StaveModifier {
     DS_AL_CODA: 10, // D.S. al coda at end of stave
     DS_AL_FINE: 11, // D.S. al Fine at end of stave
     FINE: 12, // Fine at end of stave
+    TO_CODA: 13, // To Coda at end of stave
   };
 
   protected symbol_type: number;
@@ -96,6 +97,10 @@ export class Repetition extends StaveModifier {
       case Repetition.type.FINE:
         this.drawSymbolText(stave, x, 'Fine', false);
         break;
+      // VexFlowPatch: added TO_CODA type, handling
+      case Repetition.type.TO_CODA:
+        this.drawSymbolText(stave, x, 'To', true);
+        break;
       default:
         break;
     }
@@ -133,12 +138,14 @@ export class Repetition extends StaveModifier {
       text_x = this.x + x + this.x_shift + stave.getWidth() - 5 - modifierWidth - ctx.measureText(text).width;
       // TODO this is weird. setting the x position should probably be refactored, parameters aren't clear here.
     } else {
-      // Offset Signo text to left stave end
-      symbol_x = this.x + x + stave.getWidth() - 5 + this.x_shift;
-      text_x = symbol_x - +ctx.measureText(text).width - 12;
+      // VexFlowPatch: fix placement, like for DS_AL_CODA
+      this.x_shift = -(text_x + ctx.measureText(text).width + 12 + stave.options.vertical_bar_width + 12);
+      // TO_CODA and DS_AL_CODA draw in the next measure without this x_shift, not sure why not for other symbols.
+      text_x = this.x + this.x_shift + stave.options.vertical_bar_width;
+      symbol_x = text_x + ctx.measureText(text).width + 12;
     }
 
-    const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift;
+    const y = stave.getYForTopText(stave.getNumLines()) + this.y_shift + 25;
     if (draw_coda) {
       Glyph.renderGlyph(ctx, symbol_x, y, 40, 'coda', { category: 'coda' });
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export const VERSION: string = '4.0.0';
-export const ID: string = '806f6abbacc9908136cc74b425982052218c0253';
-export const DATE: string = '2021-12-29T17:59:12.128Z';
+export const ID: string = 'e436a0d4d951185afb5c8b83f6e70dc81a41c616';
+export const DATE: string = '2022-01-08T17:07:22.790Z';

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -36,6 +36,7 @@ const StaveTests = {
     run('Multiple Stave Barline Test (14pt Section)', drawMultipleMeasures, { fontSize: 14 });
     run('Multiple Stave Repeats Test', drawRepeats);
     run('Stave End Modifiers Test', drawEndModifiers);
+    run('Stave Repetition (CODA) Positioning', drawStaveRepetition);
     run('Multiple Staves Volta Test', drawVolta);
     run('Volta + Modifier Measure Test', drawVoltaModifier);
     run('Tempo Test', drawTempo);
@@ -401,6 +402,70 @@ function drawEndModifiers(options: TestOptions, contextBuilder: ContextBuilder):
   drawStavesInTwoLines(BarlineType.REPEAT_BOTH);
 }
 
+function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilder): void {
+  expect(0);
+
+  // Get the rendering context
+  const ctx = contextBuilder(options.elementId, 725, 200);
+
+  // bar 1
+  const mm1 = new Stave(10, 50, 150);
+  mm1.addClef('treble');
+  mm1.setRepetitionType(Repetition.type.DS_AL_FINE, 0);
+  mm1.setMeasure(1);
+  mm1.setContext(ctx).draw();
+  const notesmm1 = [
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+  ];
+  // Helper function to justify and draw a 4/4 voice
+  Formatter.FormatAndDraw(ctx, mm1, notesmm1);
+
+  // bar 2 - juxtapose second measure
+  const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 150);
+  mm2.setRepetitionType(Repetition.type.TO_CODA, 0);
+  mm2.setMeasure(2);
+  mm2.setContext(ctx).draw();
+  const notesmm2 = [
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+  ];
+  // Helper function to justify and draw a 4/4 voice
+  Formatter.FormatAndDraw(ctx, mm2, notesmm2);
+
+  // bar 3 - juxtapose third measure
+  const mm3 = new Stave(mm2.getWidth() + mm2.getX(), mm1.getY(), 150);
+  mm3.setRepetitionType(Repetition.type.DS_AL_CODA, 0);
+  mm3.setMeasure(3);
+  mm3.setContext(ctx).draw();
+  const notesmm3 = [
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+  ];
+  // Helper function to justify and draw a 4/4 voice
+  Formatter.FormatAndDraw(ctx, mm3, notesmm3);
+
+  // bar 4 - juxtapose fourth measure
+  const mm4 = new Stave(mm3.getWidth() + mm3.getX(), mm1.getY(), 150);
+  mm4.setRepetitionType(Repetition.type.CODA_LEFT, 0);
+  mm4.setMeasure(4);
+  mm4.setContext(ctx).draw();
+  const notesmm4 = [
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }),
+    new StaveNote({ keys: ['a/4'], duration: 'q' }),
+  ];
+  // Helper function to justify and draw a 4/4 voice
+  Formatter.FormatAndDraw(ctx, mm4, notesmm4);
+}
+
 function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   expect(0);
 
@@ -410,7 +475,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 1
   const mm1 = new Stave(10, 50, 125);
   mm1.setBegBarType(BarlineType.REPEAT_BEGIN);
-  mm1.setRepetitionTypeLeft(Repetition.type.SEGNO_LEFT, -18);
+  mm1.setRepetitionType(Repetition.type.SEGNO_LEFT, 0);
   mm1.addClef('treble');
   mm1.addKeySignature('A');
   mm1.setMeasure(1);
@@ -422,7 +487,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   // bar 2 - juxtapose second measure
   const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 60);
-  mm2.setRepetitionTypeRight(Repetition.type.CODA_RIGHT, 0);
+  mm2.setRepetitionType(Repetition.type.CODA_RIGHT, 0);
   mm2.setMeasure(2);
   mm2.setContext(ctx).draw();
   const notesmm2 = [new StaveNote({ keys: ['d/4'], duration: 'w' })];
@@ -479,7 +544,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 8 - juxtapose eighth measure
   const mm8 = new Stave(mm7.getWidth() + mm7.getX(), mm1.getY(), 60);
   mm8.setEndBarType(BarlineType.DOUBLE);
-  mm8.setRepetitionTypeRight(Repetition.type.DS_AL_CODA, 25);
+  mm8.setRepetitionType(Repetition.type.DS_AL_CODA, 0);
   mm8.setMeasure(8);
   mm8.setContext(ctx).draw();
   const notesmm8 = [new StaveNote({ keys: ['c/5'], duration: 'w' })];
@@ -489,7 +554,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 9 - juxtapose ninth measure
   const mm9 = new Stave(mm8.getWidth() + mm8.getX() + 20, mm1.getY(), 125);
   mm9.setEndBarType(BarlineType.END);
-  mm9.setRepetitionTypeLeft(Repetition.type.CODA_LEFT, 25);
+  mm9.setRepetitionType(Repetition.type.CODA_LEFT, 0);
   mm9.addClef('treble');
   mm9.addKeySignature('A');
   mm9.setMeasure(9);
@@ -522,7 +587,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 2: volta begin_mid, with modifiers (clef, keysignature)
   const mm2 = new Stave(mm1.getX() + mm1.getWidth(), mm1.getY(), 175);
   mm2.setBegBarType(BarlineType.REPEAT_BEGIN);
-  mm2.setRepetitionTypeRight(Repetition.type.DS, 25);
+  mm2.setRepetitionType(Repetition.type.DS, 0);
   mm2.setVoltaType(VoltaType.BEGIN, '2.', -5);
   mm2.addClef('treble');
   mm2.addKeySignature('A');
@@ -534,7 +599,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 3: volta mid, with modifiers (clef, keysignature)
   const mm3 = new Stave(mm2.getX() + mm2.getWidth(), mm2.getY(), 175);
   mm3.setVoltaType(VoltaType.MID, '', -5);
-  mm3.setRepetitionTypeRight(Repetition.type.DS, 25);
+  mm3.setRepetitionType(Repetition.type.DS, 0);
   mm3.addClef('treble');
   mm3.addKeySignature('B');
   mm3.setMeasure(3);
@@ -546,7 +611,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 4: volta end, with modifiers (clef, keysignature)
   const mm4 = new Stave(mm3.getX() + mm3.getWidth(), mm3.getY(), 175);
   mm4.setVoltaType(VoltaType.END, '1.', -5);
-  mm4.setRepetitionTypeRight(Repetition.type.DS, 25);
+  mm4.setRepetitionType(Repetition.type.DS, 0);
   mm4.addClef('treble');
   mm4.addKeySignature('A');
   mm4.setMeasure(4);
@@ -559,7 +624,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   const mm5 = new Stave(mm4.getX() + mm4.getWidth(), mm4.getY(), 175);
   // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
   mm5.setEndBarType(BarlineType.DOUBLE);
-  mm5.setRepetitionTypeRight(Repetition.type.DS, 25);
+  mm5.setRepetitionType(Repetition.type.DS, 0);
   mm5.addClef('treble');
   mm5.addKeySignature('A');
   mm5.setMeasure(5);
@@ -571,7 +636,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 6: d.s. without modifiers
   const mm6 = new Stave(mm5.getX() + mm5.getWidth(), mm5.getY(), 175);
   // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
-  mm6.setRepetitionTypeRight(Repetition.type.DS, 25);
+  mm6.setRepetitionType(Repetition.type.DS, 0);
   mm6.setMeasure(6);
   mm6.setSection('E', 0);
   mm6.setContext(ctx).draw();

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -36,7 +36,9 @@ const StaveTests = {
     run('Multiple Stave Barline Test (14pt Section)', drawMultipleMeasures, { fontSize: 14 });
     run('Multiple Stave Repeats Test', drawRepeats);
     run('Stave End Modifiers Test', drawEndModifiers);
-    run('Stave Repetition (CODA) Positioning', drawStaveRepetition);
+    run('Stave Repetition (CODA) Positioning', drawStaveRepetition, { yShift: 0 });
+    run('Stave Repetition (CODA) Positioning (-20)', drawStaveRepetition, { yShift: -20 });
+    run('Stave Repetition (CODA) Positioning (+10)', drawStaveRepetition, { yShift: +10 });
     run('Multiple Staves Volta Test', drawVolta);
     run('Volta + Modifier Measure Test', drawVoltaModifier);
     run('Tempo Test', drawTempo);
@@ -411,7 +413,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
   // bar 1
   const mm1 = new Stave(10, 50, 150);
   mm1.addClef('treble');
-  mm1.setRepetitionType(Repetition.type.DS_AL_FINE, 0);
+  mm1.setRepetitionType(Repetition.type.DS_AL_FINE, options.params.yShift);
   mm1.setMeasure(1);
   mm1.setContext(ctx).draw();
   const notesmm1 = [
@@ -425,7 +427,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
 
   // bar 2 - juxtapose second measure
   const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 150);
-  mm2.setRepetitionType(Repetition.type.TO_CODA, 0);
+  mm2.setRepetitionType(Repetition.type.TO_CODA, options.params.yShift);
   mm2.setMeasure(2);
   mm2.setContext(ctx).draw();
   const notesmm2 = [
@@ -439,7 +441,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
 
   // bar 3 - juxtapose third measure
   const mm3 = new Stave(mm2.getWidth() + mm2.getX(), mm1.getY(), 150);
-  mm3.setRepetitionType(Repetition.type.DS_AL_CODA, 0);
+  mm3.setRepetitionType(Repetition.type.DS_AL_CODA, options.params.yShift);
   mm3.setMeasure(3);
   mm3.setContext(ctx).draw();
   const notesmm3 = [
@@ -453,7 +455,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
 
   // bar 4 - juxtapose fourth measure
   const mm4 = new Stave(mm3.getWidth() + mm3.getX(), mm1.getY(), 150);
-  mm4.setRepetitionType(Repetition.type.CODA_LEFT, 0);
+  mm4.setRepetitionType(Repetition.type.CODA_LEFT, options.params.yShift);
   mm4.setMeasure(4);
   mm4.setContext(ctx).draw();
   const notesmm4 = [
@@ -475,7 +477,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 1
   const mm1 = new Stave(10, 50, 125);
   mm1.setBegBarType(BarlineType.REPEAT_BEGIN);
-  mm1.setRepetitionType(Repetition.type.SEGNO_LEFT, 0);
+  mm1.setRepetitionType(Repetition.type.SEGNO_LEFT);
   mm1.addClef('treble');
   mm1.addKeySignature('A');
   mm1.setMeasure(1);
@@ -487,7 +489,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   // bar 2 - juxtapose second measure
   const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 60);
-  mm2.setRepetitionType(Repetition.type.CODA_RIGHT, 0);
+  mm2.setRepetitionType(Repetition.type.CODA_RIGHT);
   mm2.setMeasure(2);
   mm2.setContext(ctx).draw();
   const notesmm2 = [new StaveNote({ keys: ['d/4'], duration: 'w' })];
@@ -544,7 +546,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 8 - juxtapose eighth measure
   const mm8 = new Stave(mm7.getWidth() + mm7.getX(), mm1.getY(), 60);
   mm8.setEndBarType(BarlineType.DOUBLE);
-  mm8.setRepetitionType(Repetition.type.DS_AL_CODA, 0);
+  mm8.setRepetitionType(Repetition.type.DS_AL_CODA);
   mm8.setMeasure(8);
   mm8.setContext(ctx).draw();
   const notesmm8 = [new StaveNote({ keys: ['c/5'], duration: 'w' })];
@@ -554,7 +556,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   // bar 9 - juxtapose ninth measure
   const mm9 = new Stave(mm8.getWidth() + mm8.getX() + 20, mm1.getY(), 125);
   mm9.setEndBarType(BarlineType.END);
-  mm9.setRepetitionType(Repetition.type.CODA_LEFT, 0);
+  mm9.setRepetitionType(Repetition.type.CODA_LEFT);
   mm9.addClef('treble');
   mm9.addKeySignature('A');
   mm9.setMeasure(9);
@@ -587,7 +589,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 2: volta begin_mid, with modifiers (clef, keysignature)
   const mm2 = new Stave(mm1.getX() + mm1.getWidth(), mm1.getY(), 175);
   mm2.setBegBarType(BarlineType.REPEAT_BEGIN);
-  mm2.setRepetitionType(Repetition.type.DS, 0);
+  mm2.setRepetitionType(Repetition.type.DS);
   mm2.setVoltaType(VoltaType.BEGIN, '2.', -5);
   mm2.addClef('treble');
   mm2.addKeySignature('A');
@@ -599,7 +601,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 3: volta mid, with modifiers (clef, keysignature)
   const mm3 = new Stave(mm2.getX() + mm2.getWidth(), mm2.getY(), 175);
   mm3.setVoltaType(VoltaType.MID, '', -5);
-  mm3.setRepetitionType(Repetition.type.DS, 0);
+  mm3.setRepetitionType(Repetition.type.DS);
   mm3.addClef('treble');
   mm3.addKeySignature('B');
   mm3.setMeasure(3);
@@ -611,7 +613,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 4: volta end, with modifiers (clef, keysignature)
   const mm4 = new Stave(mm3.getX() + mm3.getWidth(), mm3.getY(), 175);
   mm4.setVoltaType(VoltaType.END, '1.', -5);
-  mm4.setRepetitionType(Repetition.type.DS, 0);
+  mm4.setRepetitionType(Repetition.type.DS);
   mm4.addClef('treble');
   mm4.addKeySignature('A');
   mm4.setMeasure(4);
@@ -624,7 +626,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   const mm5 = new Stave(mm4.getX() + mm4.getWidth(), mm4.getY(), 175);
   // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
   mm5.setEndBarType(BarlineType.DOUBLE);
-  mm5.setRepetitionType(Repetition.type.DS, 0);
+  mm5.setRepetitionType(Repetition.type.DS);
   mm5.addClef('treble');
   mm5.addKeySignature('A');
   mm5.setMeasure(5);
@@ -636,7 +638,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   // bar 6: d.s. without modifiers
   const mm6 = new Stave(mm5.getX() + mm5.getWidth(), mm5.getY(), 175);
   // mm5.addModifier(new Repetition(Repetition.type.DS, mm4.getX() + mm4.getWidth(), 50), StaveModifierPosition.RIGHT);
-  mm6.setRepetitionType(Repetition.type.DS, 0);
+  mm6.setRepetitionType(Repetition.type.DS);
   mm6.setMeasure(6);
   mm6.setSection('E', 0);
   mm6.setContext(ctx).draw();


### PR DESCRIPTION
Fixes #1255 

There only visual differences on the two tests below (I have just placed the Gonville results). IT IS OBVIOUSLY WRONG.

Order is:
- diff
- reference
- current

**Stave Multiple_Staves_Volta**
![Stave Multiple_Staves_Volta_Test Gonville](https://user-images.githubusercontent.com/22865285/146672078-22762631-8812-461c-8058-287b5f630b27.png)
![Stave Multiple_Staves_Volta_Test Gonville_Reference](https://user-images.githubusercontent.com/22865285/146672080-fb313a4e-c779-49fc-a08f-b47af3f14dcb.png)
![Stave Multiple_Staves_Volta_Test Gonville_Current](https://user-images.githubusercontent.com/22865285/146672079-56e4882b-b8bb-48b2-913d-15b952a875fa.png)

**Stave Volta___Modifier_Measure**
![Stave Volta___Modifier_Measure_Test Gonville](https://user-images.githubusercontent.com/22865285/146672103-139513a0-6644-4346-8d97-6ca82ad23d03.png)
![Stave Volta___Modifier_Measure_Test Gonville_Reference](https://user-images.githubusercontent.com/22865285/146672106-24d2f051-925a-41d1-893f-d029b59972c2.png)
![Stave Volta___Modifier_Measure_Test Gonville_Current](https://user-images.githubusercontent.com/22865285/146672105-dbc87ed7-3149-4b99-aca7-d7daeafe84ff.png)

