### PR TITLE
Issue1267 artic y pos

### DIFF
--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -8,6 +8,7 @@ import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
 import { StaveNote } from './stavenote';
+import { Stave } from './stave';
 import { Stem } from './stem';
 import { Tables } from './tables';
 import { isGraceNote, isStaveNote, isTabNote } from './typeguard';
@@ -203,23 +204,42 @@ export class Articulation extends Modifier {
   static format(articulations: Articulation[], state: ModifierContextState): boolean {
     if (!articulations || articulations.length === 0) return false;
 
-    const isAbove = (artic: Articulation) => artic.getPosition() === ABOVE;
-    const isBelow = (artic: Articulation) => artic.getPosition() === BELOW;
     const margin = 0.5;
+
     const getIncrement = (articulation: Articulation, line: number, position: number) =>
       roundToNearestHalf(
         getRoundingFunction(line, position),
         defined(articulation.glyph.getMetrics().height) / 10 + margin
       );
 
-    articulations.filter(isAbove).forEach((articulation) => {
-      articulation.setTextLine(state.top_text_line);
-      state.top_text_line += getIncrement(articulation, state.top_text_line, ABOVE);
-    });
-
-    articulations.filter(isBelow).forEach((articulation) => {
-      articulation.setTextLine(state.text_line);
-      state.text_line += getIncrement(articulation, state.text_line, BELOW);
+    articulations.forEach((articulation) => {
+      const note = articulation.checkAttachedNote();
+      let lines = 5;
+      const stave: Stave | undefined = note.getStave();
+      if (stave) {
+        lines = stave.getNumLines();
+      }
+      if (articulation.getPosition() === ABOVE) {
+        const noteLine = note.getLineNumber(true);
+        let increment = getIncrement(articulation, state.top_text_line, ABOVE);
+        const curTop = noteLine + state.text_line;
+        // If articulation must be above stave, add lines between note and stave top
+        if (!articulation.articulation.between_lines && curTop < lines) {
+          increment += lines - curTop;
+        }
+        articulation.setTextLine(state.top_text_line);
+        state.top_text_line += increment;
+      } else if (articulation.getPosition() === BELOW) {
+        const noteLine = note.getLineNumber();
+        let increment = getIncrement(articulation, state.text_line, BELOW);
+        const curBottom = (lines - noteLine) + state.text_line;
+        // if articulation must be below stave, add lines from note to stave bottom
+        if (!articulation.articulation.between_lines && curBottom < lines) {
+          increment += lines - curBottom;
+        }
+        articulation.setTextLine(state.text_line);
+        state.text_line += increment;
+      }
     });
 
     const width = articulations

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -9,11 +9,13 @@ import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Flow } from '../src/flow';
 import { Font } from '../src/font';
+import { Stem } from '../src/stem';
 import { Formatter } from '../src/formatter';
 import { ContextBuilder } from '../src/renderer';
+import { ModifierPosition } from '../src/modifier';
 import { Stave } from '../src/stave';
 import { Barline } from '../src/stavebarline';
-import { StaveNote } from '../src/stavenote';
+import { StaveNote, StaveNoteStruct } from '../src/stavenote';
 import { TabNote } from '../src/tabnote';
 import { TabStave } from '../src/tabstave';
 import { Voice } from '../src/voice';
@@ -22,6 +24,7 @@ const ArticulationTests = {
   Start(): void {
     QUnit.module('Articulation');
     const run = VexFlowTests.runTests;
+    run('Articulation - Vertical Placement', verticalPlacement);
     run('Articulation - Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Articulation - Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Articulation - Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -172,6 +175,45 @@ function drawFermata(options: TestOptions): void {
   // Helper function to justify and draw a 4/4 voice
   formatAndDrawToWidth(x, y, width, notesBar2, Barline.type.DOUBLE);
 }
+
+function verticalPlacement(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 750, 300);
+  ctx.fillStyle = '#221';
+  ctx.strokeStyle = '#221';
+  const staveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
+  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
+
+  const notes = [
+    staveNote({ keys: ['a/5'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['f/5'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['f/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('am').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['f/5'], duration: 'q' })
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['f/5'], duration: 'q' })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['f/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('am').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+    ];
+
+  Formatter.FormatAndDraw(ctx, stave, notes);
+  ok(true, ' Annotation Placement');
+}
+
 
 function drawArticulations2(options: TestOptions): void {
   expect(0);

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -184,30 +184,54 @@ function verticalPlacement(options: TestOptions, contextBuilder: ContextBuilder)
   const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
 
   const notes = [
+    staveNote({ keys: ['f/4'], duration: 'q' })
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['g/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['c/5'], duration: 'q' })
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['f/4'], duration: 'q' })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['g/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW)),
+    staveNote({ keys: ['c/5'], duration: 'q' })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW))
+      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW)),
     staveNote({ keys: ['a/5'], duration: 'q', stem_direction: Stem.DOWN })
       .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE))
       .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
       .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
-    staveNote({ keys: ['f/5'], duration: 'q', stem_direction: Stem.DOWN })
+    staveNote({ keys: ['f/5'], duration: 'q' })
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['b/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['a/5'], duration: 'q', stem_direction: Stem.DOWN })
       .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
       .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE))
       .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE)),
-    staveNote({ keys: ['f/4'], duration: 'q', stem_direction: Stem.DOWN })
-      .addArticulation(0, new Articulation('am').setPosition(ModifierPosition.ABOVE))
+    staveNote({ keys: ['f/5'], duration: 'q' })
       .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
-      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE)),
-    staveNote({ keys: ['f/5'], duration: 'q' })
-      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
-    staveNote({ keys: ['f/5'], duration: 'q' })
-      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a@u').setPosition(ModifierPosition.BELOW)),
-    staveNote({ keys: ['f/4'], duration: 'q', stem_direction: Stem.DOWN })
-      .addArticulation(0, new Articulation('am').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.BELOW))
-      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.BELOW)),
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE)),
+    staveNote({ keys: ['b/4'], duration: 'q', stem_direction: Stem.DOWN })
+      .addArticulation(0, new Articulation('a.').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a-').setPosition(ModifierPosition.ABOVE))
+      .addArticulation(0, new Articulation('a@a').setPosition(ModifierPosition.ABOVE)),
     ];
 
   Formatter.FormatAndDraw(ctx, stave, notes);


### PR DESCRIPTION
#fixes 1267

prevent accidentals from colliding when some accidentals must be placed above/below the staff and others don't.

before:
![image](https://user-images.githubusercontent.com/5438280/147153933-862712d6-fc85-4ec2-9263-b6b46f4e4490.png)

after:
![image](https://user-images.githubusercontent.com/5438280/147153988-492d45ea-3365-4c2d-98fd-99f2a9e40c29.png)
