### PR TITLE
Bug on  "npm run test:reference" visual regression.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,7 +258,7 @@ module.exports = (grunt) => {
           {
             expand: true,
             cwd: BUILD_DIR,
-            src: ['*.js', '*.map'],
+            src: ['**/*.js', '**/*.map'],
             dest: REFERENCE_DIR,
           },
         ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,7 +258,7 @@ module.exports = (grunt) => {
           {
             expand: true,
             cwd: BUILD_DIR,
-            src: ['**/*.js', '**/*.map'],
+            src: ['cjs/*.js', 'cjs/*.map'],
             dest: REFERENCE_DIR,
           },
         ],

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "build:esm": "grunt buildESM",
     "qunit": "grunt test",
     "generate:current": "node   ./tools/generate_png_images.js ../build/cjs ./build/images/current   ${VF_GENERATE_OPTIONS}",
-    "generate:reference": "node ./tools/generate_png_images.js ../reference ./build/images/reference ${VF_GENERATE_OPTIONS}",
+    "generate:reference": "node ./tools/generate_png_images.js ../reference/cjs ./build/images/reference ${VF_GENERATE_OPTIONS}",
     "diff:reference": "./tools/visual_regression.sh reference",
     "get:releases": "node ./tools/get_releases.mjs",
     "test": "npm run lint && npm run qunit && npm run generate:current",


### PR DESCRIPTION
The new location in build/cjs broke the tests against a reference.

This is a minor change to take into account the location of the files.