### PR TITLE
reduce jsdom_jobs on platform with many cpus.

### DIFF
--- a/tools/generate_images.js
+++ b/tools/generate_images.js
@@ -150,7 +150,7 @@ const appMain = async () => {
       getArgs: () => {
         return [`../${ver}`, imageDir].concat(args);
       },
-      jobs: numTestes ? parallel : 1,
+      jobs: numTestes ? Math.min(pptrJobs, parallel) : 1,
     },
     pptr: {
       path: './tools/generate_images_pptr.js',


### PR DESCRIPTION
@0xfe san

thank you for merge #1268 and sorry to bother you.

this PR reduce the jsdom_jobs on platform with many cpus.
for example my MBP has 12 logical cpus. 

It seems that 12 is a bit much for jodom_jobs, so limiting it to pptr_jobs will speed up the process by a few seconds.
