### PR TITLE
Fix Circular Dependency Issue (using getCategory)

### DIFF
--- a/src/dot.ts
+++ b/src/dot.ts
@@ -8,7 +8,6 @@ import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
 import { isStaveNote } from './stavenote';
-import { isTabNote } from './tabnote';
 import { isCategory } from './typeguard';
 import { RuntimeError } from './util';
 
@@ -42,7 +41,7 @@ export class Dot extends Modifier {
         const index = dot.checkIndex();
         props = note.getKeyProps()[index];
         shift = note.getRightDisplacedHeadPx();
-      } else if (isTabNote(note)) {
+      } else if (note.getCategory() === 'TabNote') {
         props = { line: 0.5 }; // Shim key props for dot placement
         shift = 0;
       } else {
@@ -145,7 +144,7 @@ export class Dot extends Modifier {
     const start = note.getModifierStartXY(this.position, this.index, { forceFlagRight: true });
 
     // Set the starting y coordinate to the base of the stem for TabNotes.
-    if (isTabNote(note)) {
+    if (note.getCategory() === 'TabNote') {
       start.y = note.getStemExtents().baseY;
     }
 


### PR DESCRIPTION
fixes #1274

I figured out wich circular dependency was producing the crash. This PR fixes this particular one.

I have learned that:
- methods like `note.isTabNote()` contribute to circular dependencies
- `note instanceof TabNote` produces the same error (also contributes to circular dependencies`

We should probably avoid the methods above. 