### PR TITLE
simplify format function in Stave Note

### DIFF
--- a/src/dot.ts
+++ b/src/dot.ts
@@ -67,8 +67,7 @@ export class Dot extends Modifier {
         const index = dot.checkIndex();
         props = note.getKeyProps()[index];
         // consider right displaced head with no previous modifier
-        if (note.checkModifierContext().getMembers('Parenthesis').length === 0) shift = note.getRightDisplacedHeadPx();
-        else shift = right_shift;
+        shift = note.getFirstDotPx();
       } else if (note.getCategory() === 'TabNote') {
         props = { line: 0.5 }; // Shim key props for dot placement
         shift = right_shift;

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -67,7 +67,7 @@ export class Dot extends Modifier {
         const index = dot.checkIndex();
         props = note.getKeyProps()[index];
         // consider right displaced head with no previous modifier
-        if (right_shift === 0) shift = note.getRightDisplacedHeadPx();
+        if (note.checkModifierContext().getMembers('Parenthesis').length === 0) shift = note.getRightDisplacedHeadPx();
         else shift = right_shift;
       } else if (note.getCategory() === 'TabNote') {
         props = { line: 0.5 }; // Shim key props for dot placement

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -132,7 +132,7 @@ export class ModifierContext {
   }
 
   getMembers(category: string): ModifierContextMember[] {
-    return this.members[category];
+    return this.members[category] ?? [];
   }
 
   getWidth(): number {

--- a/src/note.ts
+++ b/src/note.ts
@@ -577,6 +577,24 @@ export abstract class Note extends Tickable {
     };
   }
 
+  getRightParenthesisPx(index: number): number {
+    const props = this.getKeyProps()[index];
+    return props.displaced ? this.getRightDisplacedHeadPx() : 0;
+  }
+
+  getLeftParenthesisPx(index: number): number {
+    const props = this.getKeyProps()[index];
+    return props.displaced ? this.getLeftDisplacedHeadPx() : 0;
+  }
+
+  getFirstDotPx(): number {
+    let px = this.getRightDisplacedHeadPx();
+
+    if (this.checkModifierContext().getMembers('Parenthesis').length !== 0)
+      px += Tables.currentMusicFont().lookupMetric('parenthesis.default.width');
+    return px;
+  }
+
   /** Get the metrics for this note. */
   getMetrics(): NoteMetrics {
     if (!this.preFormatted) {

--- a/src/parenthesis.ts
+++ b/src/parenthesis.ts
@@ -28,8 +28,6 @@ export class Parenthesis extends Modifier {
 
   /** Arrange parentheses inside a ModifierContext. */
   static format(parentheses: Parenthesis[], state: ModifierContextState): boolean {
-    const { right_shift, left_shift } = state;
-
     if (!parentheses || parentheses.length === 0) return false;
 
     let x_widthL = 0;
@@ -40,17 +38,16 @@ export class Parenthesis extends Modifier {
       const note = parenthesis.getNote();
       const pos = parenthesis.getPosition();
       const index = parenthesis.checkIndex();
-      const props = note.getKeyProps()[index];
 
       let shift = 0;
 
       if (pos === ModifierPosition.RIGHT) {
-        shift = (props.displaced ? note.getRightDisplacedHeadPx() : 0) + right_shift;
-        x_widthR += shift + parenthesis.width;
+        shift = note.getRightParenthesisPx(index);
+        x_widthR = x_widthR > shift + parenthesis.width ? x_widthR : shift + parenthesis.width;
       }
       if (pos === ModifierPosition.LEFT) {
-        shift = (props.displaced ? note.getLeftDisplacedHeadPx() : 0) + left_shift;
-        x_widthL += shift + parenthesis.width;
+        shift = note.getLeftParenthesisPx(index);
+        x_widthL = x_widthL > shift + parenthesis.width ? x_widthL : shift + parenthesis.width;
       }
       parenthesis.setXShift(shift);
     }

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -99,9 +99,6 @@ function centerRest(rest: StaveNoteFormatSettings, noteU: StaveNoteFormatSetting
 }
 
 export class StaveNote extends StemmableNote {
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  // STATIC MEMBERS
-
   static DEBUG: boolean = false;
 
   static get CATEGORY(): string {
@@ -134,23 +131,6 @@ export class StaveNote extends StemmableNote {
   /** Format notes inside a ModifierContext. */
   static format(notes: StaveNote[], state: ModifierContextState): boolean {
     if (!notes || notes.length < 2) return false;
-
-    // FIXME: VexFlow will soon require that a stave be set before formatting.
-    // Which, according to the below condition, means that following branch will
-    // always be taken and the rest of this function is dead code.
-    //
-    // Problematically, `Formatter#formatByY` was not designed to work for more
-    // than 2 voices (although, doesn't throw on this condition, just tries
-    // to power through).
-    //
-    // Based on the above:
-    //   * 2 voices can be formatted *with or without* a stave being set but
-    //     the output will be different
-    //   * 3 voices can only be formatted *without* a stave
-    if (notes[0].getStave()) {
-      StaveNote.formatByY(notes, state);
-      return true;
-    }
 
     const notesList: StaveNoteFormatSettings[] = [];
 
@@ -201,164 +181,38 @@ export class StaveNote extends StemmableNote {
 
     const voiceXShift = Math.max(noteU.voice_shift, noteL.voice_shift);
     let xShift = 0;
-    let stemDelta;
 
     // Test for two voice note intersection
     if (voices === 2) {
       const lineSpacing = noteU.stemDirection === noteL.stemDirection ? 0.0 : 0.5;
-      // if top voice is a middle voice, check stem intersection with lower voice
-      if (noteU.stemDirection === noteL.stemDirection && noteU.minLine <= noteL.maxLine) {
-        if (!noteU.isrest) {
-          stemDelta = Math.abs(noteU.line - (noteL.maxLine + 0.5));
-          stemDelta = Math.max(stemDelta, noteU.stemMin);
-          noteU.minLine = noteU.line - stemDelta;
-          noteU.note.setStemLength(stemDelta * 10);
-        }
-      }
       if (noteU.minLine <= noteL.maxLine + lineSpacing) {
-        if (noteU.isrest) {
-          // shift rest up
-          shiftRestVertical(noteU, noteL, 1);
-        } else if (noteL.isrest) {
-          // shift rest down
-          shiftRestVertical(noteL, noteU, -1);
+        if (noteU.stemDirection === noteL.stemDirection) {
+          // upper voice is middle voice, so shift it right
+          xShift = voiceXShift + 2;
+          noteU.note.setXShift(xShift);
         } else {
-          xShift = voiceXShift;
-          if (noteU.stemDirection === noteL.stemDirection) {
-            // upper voice is middle voice, so shift it right
-            noteU.note.setXShift(xShift + 3);
-          } else {
-            // shift lower voice right
-            noteL.note.setXShift(xShift);
-          }
+          // shift lower voice right
+          xShift = voiceXShift + 2;
+          noteL.note.setXShift(xShift);
         }
       }
 
       // format complete
+      state.right_shift += xShift;
       return true;
     }
 
     if (!noteM) throw new RuntimeError('InvalidState', 'noteM not defined.');
 
-    // Check middle voice stem intersection with lower voice
-    if (noteM.minLine < noteL.maxLine + 0.5) {
-      if (!noteM.isrest) {
-        stemDelta = Math.abs(noteM.line - (noteL.maxLine + 0.5));
-        stemDelta = Math.max(stemDelta, noteM.stemMin);
-        noteM.minLine = noteM.line - stemDelta;
-        noteM.note.setStemLength(stemDelta * 10);
-      }
-    }
-
-    // For three voices, test if rests can be repositioned
-    //
-    // Special case 1 :: middle voice rest between two notes
-    //
-    if (noteM.isrest && !noteU.isrest && !noteL.isrest) {
-      if (noteU.minLine <= noteM.maxLine || noteM.minLine <= noteL.maxLine) {
-        const restHeight = noteM.maxLine - noteM.minLine;
-        const space = noteU.minLine - noteL.maxLine;
-        if (restHeight < space) {
-          // center middle voice rest between the upper and lower voices
-          centerRest(noteM, noteU, noteL);
-        } else {
-          xShift = voiceXShift + 3; // shift middle rest right
-          noteM.note.setXShift(xShift);
-        }
-        // format complete
-        return true;
-      }
-    }
-
-    // Special case 2 :: all voices are rests
-    if (noteU.isrest && noteM.isrest && noteL.isrest) {
-      // Shift upper voice rest up
-      shiftRestVertical(noteU, noteM, 1);
-      // Shift lower voice rest down
-      shiftRestVertical(noteL, noteM, -1);
-      // format complete
-      return true;
-    }
-
-    // Test if any other rests can be repositioned
-    if (noteM.isrest && noteU.isrest && noteM.minLine <= noteL.maxLine) {
-      // Shift middle voice rest up
-      shiftRestVertical(noteM, noteL, 1);
-    }
-    if (noteM.isrest && noteL.isrest && noteU.minLine <= noteM.maxLine) {
-      // Shift middle voice rest down
-      shiftRestVertical(noteM, noteU, -1);
-    }
-    if (noteU.isrest && noteU.minLine <= noteM.maxLine) {
-      // shift upper voice rest up;
-      shiftRestVertical(noteU, noteM, 1);
-    }
-    if (noteL.isrest && noteM.minLine <= noteL.maxLine) {
-      // shift lower voice rest down
-      shiftRestVertical(noteL, noteM, -1);
-    }
-
     // If middle voice intersects upper or lower voice
-    if (
-      (!noteU.isrest && !noteM.isrest && noteU.minLine <= noteM.maxLine + 0.5) ||
-      (!noteM.isrest && !noteL.isrest && noteM.minLine <= noteL.maxLine)
-    ) {
-      xShift = voiceXShift + 3; // shift middle note right
+    if (noteU.minLine <= noteM.maxLine + 0.5 || noteM.minLine <= noteL.maxLine) {
+      // shift middle note right
+      xShift = voiceXShift + 2;
       noteM.note.setXShift(xShift);
     }
 
-    return true;
-  }
-
-  static formatByY(notes: StaveNote[], state: ModifierContextState): void {
-    // NOTE: this function does not support more than two voices per stave. Use with care.
-
-    let hasStave = true;
-    for (let i = 0; i < notes.length; i++) {
-      hasStave = hasStave && notes[i].getStave() != undefined;
-    }
-    if (!hasStave) {
-      throw new RuntimeError('NoStave', 'All notes must have a stave.');
-    }
-
-    let xShift = 0;
-
-    for (let i = 0; i < notes.length - 1; i++) {
-      let topNote = notes[i];
-      let bottomNote = notes[i + 1];
-
-      if (topNote.getStemDirection() === Stem.DOWN) {
-        topNote = notes[i + 1];
-        bottomNote = notes[i];
-      }
-
-      const topKeys = topNote.getKeyProps();
-      const bottomKeys = bottomNote.getKeyProps();
-
-      const HALF_NOTEHEAD_HEIGHT = 0.5;
-
-      // `keyProps` and `stave.getYForLine` have different notions of a `line`
-      // so we have to convert the keyProps value by subtracting 5.
-      // See https://github.com/0xfe/vexflow/wiki/Development-Gotchas
-      //
-      // We also extend the y for each note by a half notehead because the
-      // notehead's origin is centered
-      const topStave = topNote.checkStave();
-      const topNoteBottomY = topStave.getYForLine(5 - topKeys[0].line + HALF_NOTEHEAD_HEIGHT);
-
-      const bottomStave = bottomNote.checkStave();
-      const bottomNoteTopY = bottomStave.getYForLine(5 - bottomKeys[bottomKeys.length - 1].line - HALF_NOTEHEAD_HEIGHT);
-
-      const areNotesColliding =
-        bottomNoteTopY != undefined && topNoteBottomY != undefined ? bottomNoteTopY - topNoteBottomY < 0 : false;
-
-      if (areNotesColliding) {
-        xShift = topNote.getVoiceShiftWidth() + 2;
-        bottomNote.setXShift(xShift);
-      }
-    }
-
     state.right_shift += xShift;
+    return true;
   }
 
   static postFormat(notes: Note[]): boolean {


### PR DESCRIPTION
Fixes #1283

After realising that the code in `StaveNote.forma()` in #1263 was dead code. I decided to bring it back to life as simple as possible.

The visual differences (Bravura version) are:

**StaveNote Center_Aligned_Note___Multi_Voice Bravura**
![StaveNote Center_Aligned_Note___Multi_Voice Bravura](https://user-images.githubusercontent.com/22865285/147835882-0d47309e-3819-4ea1-9b0c-d6ed768fe032.png)
**Current**
![StaveNote Center_Aligned_Note___Multi_Voice Bravura_Current](https://user-images.githubusercontent.com/22865285/147835883-a6992bcd-7433-4083-9f9a-24d706c157b8.png)
**Reference**
![StaveNote Center_Aligned_Note___Multi_Voice Bravura_Reference](https://user-images.githubusercontent.com/22865285/147835884-b55225ff-0193-40b4-b25e-64f0100b44d7.png)
**Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura](https://user-images.githubusercontent.com/22865285/147835894-0c7bfe40-68f6-43e8-bb0c-26330a301aa3.png)
**Current**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura_Current](https://user-images.githubusercontent.com/22865285/147835895-ebd5d33a-83a5-4db5-8862-28ea6cfb1f45.png)
**Reference**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura_Reference](https://user-images.githubusercontent.com/22865285/147835896-b6fbf894-b70c-474c-800d-3c06bce3071e.png)
**Three_Voice_Rests Auto_Adjust_Rest_Positions___Two_Voices Bravura**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Two_Voices Bravura](https://user-images.githubusercontent.com/22865285/147835903-669eff54-1e8d-4e7d-a78e-3a284cdb098f.png)
**Current**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Two_Voices Bravura_Current](https://user-images.githubusercontent.com/22865285/147835904-bd61fb46-1612-4950-ab50-0a8e60e52e60.png)
**Reference**
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Two_Voices Bravura_Reference](https://user-images.githubusercontent.com/22865285/147835905-ff24180d-0a02-47c1-bf79-5c9a749fe81c.png)

