### PR TITLE
Fix issues of vertical placement: tuplet

### DIFF
--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -515,5 +515,11 @@ export const BravuraMetrics = {
         reportedWidth: 5,
       },
     },
+    tuplet: {
+      noteHeadOffset: 20,
+      stemOffset: 10,
+      bottomLine: 4,
+      topModifierOffset: 15,
+    },
   },
 };

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -409,5 +409,11 @@ export const GonvilleMetrics = {
         reportedWidth: 5,
       },
     },
+    tuplet: {
+      noteHeadOffset: 20,
+      stemOffset: 10,
+      bottomLine: 4,
+      topModifierOffset: 15,
+    },
   },
 };

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -543,5 +543,11 @@ export const PetalumaMetrics = {
         reportedWidth: 5,
       },
     },
+    tuplet: {
+      noteHeadOffset: 20,
+      stemOffset: 10,
+      bottomLine: 4,
+      topModifierOffset: 20,
+    },
   },
 };

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -273,13 +273,23 @@ export class Tuplet extends Element {
       // y_pos = first_note.getStemExtents().topY - 10;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        const top_y =
-          this.notes[i].getStemDirection() === Stem.UP
-            ? this.notes[i].getStemExtents().topY - 10
-            : this.notes[i].getStemExtents().baseY - 20;
-
-        if (top_y < y_pos) {
-          y_pos = top_y;
+        const note = this.notes[i];
+        let modLines = 0;
+        const mc = note.getModifierContext();
+        if (mc) {
+          modLines = Math.max(modLines, mc.getState().top_text_line);
+        }
+        const modY = note.getYForTopText(modLines) - 20;
+        if (note.hasStem() || note.isRest()) {
+          const top_y =
+            note.getStemDirection() === Stem.UP ? note.getStemExtents().topY - 10 : note.getStemExtents().baseY - 20;
+          y_pos = Math.min(top_y, y_pos);
+          if (modLines > 0) {
+            y_pos = Math.min(modY, y_pos);
+          }
+          if (top_y < y_pos) {
+            y_pos = top_y;
+          }
         }
       }
     } else {
@@ -294,12 +304,14 @@ export class Tuplet extends Element {
       y_pos = first_note.checkStave().getYForLine(lineCheck) + 20;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        const bottom_y =
-          this.notes[i].getStemDirection() === Stem.UP
-            ? this.notes[i].getStemExtents().baseY + 20
-            : this.notes[i].getStemExtents().topY + 10;
-        if (bottom_y > y_pos) {
-          y_pos = bottom_y;
+        if (this.notes[i].hasStem() || this.notes[i].isRest()) {
+          const bottom_y =
+            this.notes[i].getStemDirection() === Stem.UP
+              ? this.notes[i].getStemExtents().baseY + 20
+              : this.notes[i].getStemExtents().topY + 10;
+          if (bottom_y > y_pos) {
+            y_pos = bottom_y;
+          }
         }
       }
     }

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -287,9 +287,6 @@ export class Tuplet extends Element {
           if (modLines > 0) {
             y_pos = Math.min(modY, y_pos);
           }
-          if (top_y < y_pos) {
-            y_pos = top_y;
-          }
         }
       }
     } else {

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -273,29 +273,33 @@ export class Tuplet extends Element {
       // y_pos = first_note.getStemExtents().topY - 10;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        if (this.notes[i].hasStem() || this.notes[i].isRest()) {
-          const top_y =
-            this.notes[i].getStemDirection() === Stem.UP
-              ? this.notes[i].getStemExtents().topY - 10
-              : this.notes[i].getStemExtents().baseY - 20;
+        const top_y =
+          this.notes[i].getStemDirection() === Stem.UP
+            ? this.notes[i].getStemExtents().topY - 10
+            : this.notes[i].getStemExtents().baseY - 20;
 
-          if (top_y < y_pos) {
-            y_pos = top_y;
-          }
+        if (top_y < y_pos) {
+          y_pos = top_y;
         }
       }
     } else {
-      y_pos = first_note.checkStave().getYForLine(4) + 20;
+      let lineCheck = 4; // tuplet default on line 4
+      // check modifiers below note for correct Y position
+      this.notes.forEach((nn) => {
+        const mc = nn.getModifierContext();
+        if (mc) {
+          lineCheck = Math.max(lineCheck, mc.getState().text_line + 1);
+        }
+      });
+      y_pos = first_note.checkStave().getYForLine(lineCheck) + 20;
 
       for (let i = 0; i < this.notes.length; ++i) {
-        if (this.notes[i].hasStem() || this.notes[i].isRest()) {
-          const bottom_y =
-            this.notes[i].getStemDirection() === Stem.UP
-              ? this.notes[i].getStemExtents().baseY + 20
-              : this.notes[i].getStemExtents().topY + 10;
-          if (bottom_y > y_pos) {
-            y_pos = bottom_y;
-          }
+        const bottom_y =
+          this.notes[i].getStemDirection() === Stem.UP
+            ? this.notes[i].getStemExtents().baseY + 20
+            : this.notes[i].getStemExtents().topY + 10;
+        if (bottom_y > y_pos) {
+          y_pos = bottom_y;
         }
       }
     }

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -96,6 +96,8 @@ export class Tuplet extends Element {
   static get NESTING_OFFSET(): number {
     return 15;
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static get metrics(): any {
     return Tables.currentMusicFont().getMetrics().glyphs.tuplet;
   }


### PR DESCRIPTION
With tuplet, annotation, and accidental CS all merged it will look like this:

![image](https://user-images.githubusercontent.com/5438280/148582564-018585d5-2131-4ef4-88a9-573edd3cd8b8.png)

I ran visual regression tests (which I figured out finally after 3 years how to do!) and there were no changes.  The logic here only kicks in if there are modifiers that take up vertical space on one of the notes the tuplet covers, and currently none of our other test cases do this.
