### PR TITLE
fix openGroup optional parameters

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -103,7 +103,7 @@ export class CanvasContext extends RenderContext {
   }
 
   // eslint-disable-next-line
-  openGroup(cls: string, id?: string, attrs?: GroupAttributes): any {
+  openGroup(cls?: string, id?: string, attrs?: GroupAttributes): any {
     // Containers not implemented.
   }
 

--- a/src/rendercontext.ts
+++ b/src/rendercontext.ts
@@ -50,7 +50,7 @@ export abstract class RenderContext {
   abstract save(): this;
   abstract restore(): this;
   // eslint-disable-next-line
-  abstract openGroup(cls: string, id?: string, attrs?: GroupAttributes): any;
+  abstract openGroup(cls?: string, id?: string, attrs?: GroupAttributes): any;
   abstract closeGroup(): void;
   // eslint-disable-next-line
   abstract add(child: any): void;

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -496,7 +496,7 @@ export class SVGContext extends RenderContext {
     return `filter: drop-shadow(0 0 ${sa.width / 1.5}px ${sa.color})`;
   }
 
-  fill(attributes: Attributes): this {
+  fill(attributes?: Attributes): this {
     const path = this.create('path');
     if (typeof attributes === 'undefined') {
       attributes = { ...this.attributes, stroke: 'none' };

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -185,7 +185,7 @@ export class SVGContext extends RenderContext {
   }
 
   // Allow grouping elements in containers for interactivity.
-  openGroup(cls: string, id?: string, attrs?: GroupAttributes): SVGGElement {
+  openGroup(cls?: string, id?: string, attrs?: GroupAttributes): SVGGElement {
     const group = this.create('g');
     this.groups.push(group);
     this.parent.appendChild(group);


### PR DESCRIPTION
Minor fix: the first parameter should be optional. This parameter is expected to be undefined or a string within the function.

@sschmidTU thanks to find this out!

No visual differences.