### PR TITLE
fix #1316: consider shifted notes

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -97,7 +97,7 @@ export class Accidental extends Modifier {
       if (note !== prevNote) {
         // Iterate through all notes to get the displaced pixels
         for (let n = 0; n < note.keys.length; ++n) {
-          shiftL = Math.max(note.getLeftDisplacedHeadPx(), shiftL);
+          shiftL = Math.max(note.getLeftDisplacedHeadPx() - note.getXShift(), shiftL);
         }
         prevNote = note;
       }


### PR DESCRIPTION
fixes #1316 

Only one visual difference on all fonts (below Bravura):
![Accidental Multi_Voice Bravura](https://user-images.githubusercontent.com/22865285/152246279-655c8e58-5a75-4eac-8c67-d83c3e7d58f0.png)
**Current**
![Accidental Multi_Voice Bravura_current](https://user-images.githubusercontent.com/22865285/152246295-e320312f-3732-454c-8b44-49e8ed3a3797.png)
**Reference**
![Accidental Multi_Voice Bravura_reference](https://user-images.githubusercontent.com/22865285/152246307-b6866e1b-6626-4b02-928e-732689842e85.png)

