### PR TITLE
fix #1314: remove duplicated line

### DIFF
--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -217,7 +217,6 @@ function drawOrnamentsWithAccidentals(options: TestOptions, contextBuilder: Cont
 
   notes[0].addModifier(new Ornament('mordent').setUpperAccidental('#').setLowerAccidental('#'), 0);
   notes[1].addModifier(new Ornament('turn_inverted').setLowerAccidental('b').setUpperAccidental('b'), 0);
-  notes[1].addModifier(new Ornament('turn_inverted').setLowerAccidental('b').setUpperAccidental('b'), 0);
   notes[2].addModifier(new Ornament('turn').setUpperAccidental('##').setLowerAccidental('##'), 0);
   notes[3].addModifier(new Ornament('mordent_inverted').setLowerAccidental('db').setUpperAccidental('db'), 0);
   notes[4].addModifier(new Ornament('turn_inverted').setUpperAccidental('++').setLowerAccidental('++'), 0);


### PR DESCRIPTION
fixes #1314 

@AaronDavidNewman thanks!

The test system shows no visual difference although there is one indeed:
**Current**
![Ornament With_Upper_Lower_Accidentals Bravura](https://user-images.githubusercontent.com/22865285/152301982-c4ede3c4-fe64-438a-b57b-be819997099a.png)
**Reference**
![Ornament With_Upper_Lower_Accidentals Bravura](https://user-images.githubusercontent.com/22865285/152302025-9bdde2d9-9edc-4f14-96f8-fcf6331c92f7.png)

