### PR TITLE
Dependency graphs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ releases
 build
 demos/node/output
 node_modules
+graphs
 .eslintcache
 .DS_Store
 *.lock

--- a/tools/dependency_graph.js
+++ b/tools/dependency_graph.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+// VexFlow does NOT include the necessary dependencies. To run this script, install the following:
+//   npm i -g dependency-cruiser
+//   npm i -g graphviz-cli
+
+// Set the NODE_PATH environment variable to point to your global node_modules directory.
+// Run this script from the vexflow/ directory:
+//   NODE_PATH=/usr/local/lib/node_modules/ ./tools/dependency_graph.js
+
+// If your global node_modules folder is /usr/local/lib/node_modules/
+// You can skip setting the NODE_PATH, because we do so in the line below:
+module.paths.push('/usr/local/lib/node_modules/');
+// Just run the script with no arguments, and we will output the graphs to the vexflow/graphs/ directory.
+//   ./tools/dependency_graph.js
+
+const fs = require('fs');
+const { cruise } = require('dependency-cruiser');
+const { renderGraphFromSource } = require('graphviz-cli');
+
+fs.mkdirSync('graphs', { recursive: true });
+
+function generateGraphForFolder(folderName, excludePattern, collapsePattern = undefined) {
+  try {
+    const options = {
+      outputType: 'dot',
+      exclude: { path: excludePattern },
+    };
+    if (collapsePattern) {
+      options.collapse = collapsePattern;
+    }
+    const cruiseResult = cruise([folderName], options);
+    renderGraphFromSource({ input: cruiseResult.output }, { format: 'svg' }).then((svg) => {
+      const svgWithLinks = svg.replace(
+        /xlink:href="(.*?)"/g,
+        `href="https://github.com/0xfe/vexflow/tree/master/$1" target="_blank"`
+      );
+      const htmlOutput = getHTMLOutput(`VexFlow ${folderName}/`, svgWithLinks);
+      fs.writeFileSync(`graphs/${folderName}.html`, htmlOutput);
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function getHTMLOutput(title, svg) {
+  return `
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>
+      .node:active path,
+      .node:hover path,
+      .node.current path,
+      .node:active polygon,
+      .node:hover polygon,
+      .node.current polygon {
+        stroke: fuchsia;
+        stroke-width: 2;
+      }
+      .edge:active path,
+      .edge:hover path,
+      .edge.current path,
+      .edge:active ellipse,
+      .edge:hover ellipse,
+      .edge.current ellipse {
+        stroke: fuchsia;
+        stroke-width: 3;
+        stroke-opacity: 1;
+      }
+      .edge:active polygon,
+      .edge:hover polygon,
+      .edge.current polygon {
+        stroke: fuchsia;
+        stroke-width: 3;
+        fill: fuchsia;
+        stroke-opacity: 1;
+        fill-opacity: 1;
+      }
+      .edge:active text,
+      .edge:hover text {
+        fill: fuchsia;
+      }
+      .cluster path {
+        stroke-width: 3;
+      }
+      .cluster:active path,
+      .cluster:hover path {
+        fill: #ffff0011;
+      }
+    </style>
+  </head>
+  <body>
+    ${svg}
+    <script>
+      document.body.onmouseover = getHighlightHandler();
+      document.body.onclick = getClickHandler();
+
+      function getHighlightHandler() {
+        /** @type {string} */
+        var currentHighlightedTitle;
+
+        /** @type {NodeListOf<SVGGElement>} */
+        var nodes = document.querySelectorAll('.node');
+        /** @type {NodeListOf<SVGGElement>} */
+        var edges = document.querySelectorAll('.edge');
+        var title2ElementMap = new Title2ElementMap(edges, nodes);
+
+        /** @param {MouseEvent} pMouseEvent */
+        return function highlightHandler(pMouseEvent) {
+          var closestNodeOrEdge = pMouseEvent.target.closest('.edge, .node');
+          var closestTitleText = getTitleText(closestNodeOrEdge);
+
+          if (!(currentHighlightedTitle === closestTitleText)) {
+            title2ElementMap.get(currentHighlightedTitle).forEach(removeHighlight);
+            title2ElementMap.get(closestTitleText).forEach(addHighlight);
+            currentHighlightedTitle = closestTitleText;
+          }
+        };
+      }
+
+      function getClickHandler() {
+        return function highlightHandler(pMouseEvent) {
+          var closestNodeOrEdge = pMouseEvent.target.closest('.edge, .node');
+          console.log('Clicked', closestNodeOrEdge);
+        };
+      }
+
+      /**
+       *
+       * @param {SVGGelement[]} pEdges
+       * @param {SVGGElement[]} pNodes
+       * @return {{get: (pTitleText:string) => SVGGElement[]}}
+       */
+      function Title2ElementMap(pEdges, pNodes) {
+        /* {{[key: string]: SVGGElement[]}} */
+        var elementMap = buildMap(pEdges, pNodes);
+
+        /**
+         * @param {NodeListOf<SVGGElement>} pEdges
+         * @param {NodeListOf<SVGGElement>} pNodes
+         * @return {{[key: string]: SVGGElement[]}}
+         */
+        function buildMap(pEdges, pNodes) {
+          var title2NodeMap = buildTitle2NodeMap(pNodes);
+
+          return nodeListToArray(pEdges).reduce(addEdgeToMap(title2NodeMap), {});
+        }
+        /**
+         * @param {NodeListOf<SVGGElement>} pNodes
+         * @return {{[key: string]: SVGGElement}}
+         */
+        function buildTitle2NodeMap(pNodes) {
+          return nodeListToArray(pNodes).reduce(addNodeToMap, {});
+        }
+
+        function addNodeToMap(pMap, pNode) {
+          var titleText = getTitleText(pNode);
+
+          if (titleText) {
+            pMap[titleText] = pNode;
+          }
+          return pMap;
+        }
+
+        function addEdgeToMap(pNodeMap) {
+          return function (pEdgeMap, pEdge) {
+            /** @type {string} */
+            var titleText = getTitleText(pEdge);
+
+            if (titleText) {
+              var edge = pryEdgeFromTitle(titleText);
+
+              pEdgeMap[titleText] = [pNodeMap[edge.from], pNodeMap[edge.to]];
+              (pEdgeMap[edge.from] || (pEdgeMap[edge.from] = [])).push(pEdge);
+              (pEdgeMap[edge.to] || (pEdgeMap[edge.to] = [])).push(pEdge);
+            }
+            return pEdgeMap;
+          };
+        }
+
+        /**
+         *
+         * @param {string} pString
+         * @return {{from?: string; to?:string;}}
+         */
+        function pryEdgeFromTitle(pString) {
+          var nodeNames = pString.split(/\s*->\s*/);
+
+          return {
+            from: nodeNames.shift(),
+            to: nodeNames.shift(),
+          };
+        }
+        /**
+         *
+         * @param {string} pTitleText
+         * @return {SVGGElement[]}
+         */
+        function get(pTitleText) {
+          return (pTitleText && elementMap[pTitleText]) || [];
+        }
+        return {
+          get: get,
+        };
+      }
+
+      /**
+       * @param {SVGGElement} pGElement
+       * @return {string?}
+       */
+      function getTitleText(pGElement) {
+        /** @type {SVGTitleElement} */
+        var title = pGElement && pGElement.querySelector('title');
+        /** @type {string} */
+        var titleText = title && title.textContent;
+
+        if (titleText) {
+          titleText = titleText.trim();
+        }
+        return titleText;
+      }
+
+      /**
+       * @param {NodeListOf<Element>} pNodeList
+       * @return {Element[]}
+       */
+      function nodeListToArray(pNodeList) {
+        var lReturnValue = [];
+
+        pNodeList.forEach(function (pElement) {
+          lReturnValue.push(pElement);
+        });
+
+        return lReturnValue;
+      }
+
+      /**
+       * @param {SVGGElement} pGElement
+       */
+      function removeHighlight(pGElement) {
+        if (pGElement && pGElement.classList) {
+          pGElement.classList.remove('current');
+        }
+      }
+
+      /**
+       * @param {SVGGElement} pGroup
+       */
+      function addHighlight(pGroup) {
+        if (pGroup && pGroup.classList) {
+          pGroup.classList.add('current');
+        }
+      }
+    </script>
+  </body>
+</html>
+`;
+}
+
+const IGNORE = '(index|vex|flow|util|tables|typeguard|version).ts';
+
+generateGraphForFolder('src', IGNORE);
+generateGraphForFolder('entry', IGNORE);
+generateGraphForFolder('tests', `(formatter|support|types|${IGNORE})`, '^src/');

--- a/tools/dependency_graph.rb
+++ b/tools/dependency_graph.rb
@@ -1,16 +1,20 @@
 #!/usr/bin/env ruby
 #
-# Draw dependency graph of VexFlow classes.
-#
-# $ brew install graphviz
-# $ ./dependency_graph.rb | dot -Tpdf -o graph.pdf
+# Draw dependency graphs of VexFlow classes.
+#   brew install graphviz
+#   ./dependency_graph.rb | dot -T pdf -o graph.pdf
+#   ./dependency_graph.rb --dependencies | dot -T svg -o graph_dependencies.svg
+#   ./dependency_graph.rb --inheritance  | dot -T png -o graph_inheritance.png
 
+# If you have dependency cruiser installed, you can make a graph that highlights edges on mouse hover:
+#   npm install -g dependency-cruiser
+#   ./dependency_graph.rb | dot -T svg | depcruise-wrap-stream-in-html > graph.html
 require 'optparse'
 require 'pp'
 
 $options = {
-    inheritance: true,
-    dependencies: true,
+  inheritance: true,
+  dependencies: true,
 }
 
 OptionParser.new do |opts|
@@ -25,50 +29,60 @@ end.parse!
 
 # pp $options
 
+
+folder_name = "../src/"
+# Uncomment the following line to start from the VexFlow entry files.
+# folder_name = "../entry/"
+
+files = folder_name + "*.ts"
+
 puts "digraph G {"
-puts "  node[fontname=Arial,fontsize=10]"
 puts "  graph[rankdir=LR]"
-Dir.glob("../src/*.js").each do |file|
-    f = File.open(file, "r")
-    
-    uses = []
-    inherits = ""
-    parent = file
-    next if file =~ /index.js$/;
-    next if file =~ /tables.js$/;
-    next if file =~ /vex.js$/;
-    next if file =~ /smufl.js$/;
+# puts "  graph[splines=spline]"
+puts "  graph[splines=polyline]"
+puts "  node[fontname=Arial, fontsize=12, shape=oval]"
+Dir.glob(files).each do |file|
+  f = File.open(file, "r")
+  
+  uses = []
+  inherits = ""
+  parent = file.gsub(folder_name, "")
 
-    f.each_line do |line|
-        if line =~ /export\s+class\s+(\S+)\s*{/
-            puts "  #{$1} [color = burlywood3, fontcolor = coral3];"
-            parent = $1
-        end
-        if line =~ /export\s+class\s+(\S+)\s+extends\s+(\S+)\s*{/
-            puts "  #{$1} [color = burlywood3, fontcolor = coral3];"
-            parent = $1
-            inherits = $2
-        end
-        if line =~ /import\s+{\s*(\S+)\s*} from/
-            next if $1 == "Vex"
-            next if $1 == "Flow"
-            uses << $1
-        end
+  # Skip these files.
+  next if file =~ /index.ts$/;
+  next if file =~ /tables.ts$/;
+  next if file =~ /flow.ts$/;
+  next if file =~ /vex.ts$/;
+  next if file =~ /typeguard.ts$/;
 
-        # Old JS syntax: remove after all files cleaned up
-        if line =~ /export\s+var\s+(\S+)\s*=\s*\(\s*function/
-            puts "  #{$1} [color = burlywood3, fontcolor = coral3];"
-            parent = $1
-        end
-        if line =~ /Vex.Inherit\s*\(([^,]+),\s*([^\s,]+)/
-            inherits = $2
-        end
+  f.each_line do |line|
+    if line =~ /export\s+.*?class\s+(\S+)/
+      puts "  #{$1} [color = burlywood3, fontcolor = coral3];"
+      parent = $1
     end
-
-    uses.each do |child|
-        puts "  #{parent} -> #{child} [color = cadetblue];" if (child != inherits) && $options[:dependencies]
+    if line =~ /\s+extends\s+(\S+)\s*{/
+      puts "  #{$1} [color = burlywood3, fontcolor = coral3];"
+      inherits = $1
     end
+    # import { A, B, C } from './hello';
+    # import { X } from './goodbye';
+    if line =~ /^import\s+{\s*(.+?)\s*} from/
+      classes_imported = $1.split(/\s*,\s*/)
+      classes_imported.each do |c|
+        next if c == "Category" # Skip Category because it is a const enum that is erased during compilation.
+        next if c == "Tables"
+        next if c == "RuntimeError" 
+        next if c[0] == c[0].downcase # Ignore function imports (which start with a lowercase letter).
+        uses << c
+      end
+    end
+  end
 
-    puts "  #{parent} -> #{inherits} [color = burlywood3];" if (inherits != "")  && $options[:inheritance] 
+  # draw the lines / edges of the graph
+  uses.each do |child|
+      puts "  \"#{parent}\" -> #{child} [color = cadetblue];" if (child != inherits) && $options[:dependencies]
+  end
+
+  puts "  \"#{parent}\" -> #{inherits} [color = burlywood3, penwidth=2];" if (inherits != "")  && $options[:inheritance] 
 end
 puts "}"


### PR DESCRIPTION
I've been updating docs for https://github.com/0xfe/vexflow/issues/1271

I ran across the dependency graphs wiki page and realized the script no longer worked.

I fixed the ruby script, and then got side tracked a bit...and discovered a npm package that can produce interactive graphs. I wrote up a script, and here are the graphs I produced:

[src/ folder](https://vexflow-dependency-graphs.surge.sh/src.html)

[entry/ folder](https://vexflow-dependency-graphs.surge.sh/entry.html)

[tests/ folder](https://vexflow-dependency-graphs.surge.sh/tests.html)

You can hover over edges to show a tooltip. Click on a node to open the GitHub page for that file.


The updated docs are here: https://github.com/0xfe/vexflow/wiki/VexFlow-Class-Diagrams

I verified that the example commands now work once again.