### PR TITLE
Add SVG classes (+ ids partly) to beams, stems within beams, staveties (OSMD VexflowPatch)

### DIFF
--- a/src/beam.ts
+++ b/src/beam.ts
@@ -851,7 +851,9 @@ export class Beam extends Element {
     this.notes.forEach((note) => {
       const stem = note.getStem();
       if (stem) {
+        ctx.openGroup('stem', note.getAttribute('id') + '-stem');
         stem.setContext(ctx).draw();
+        ctx.closeGroup();
       }
     }, this);
   }

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -879,6 +879,7 @@ export class Beam extends Element {
         if (lastBeamX) {
           const lastBeamY = this.getSlopeY(lastBeamX, firstStemX, beamY, this.slope);
 
+          this.setAttribute('el', ctx.openGroup('beam'));
           ctx.beginPath();
           ctx.moveTo(startBeamX, startBeamY);
           ctx.lineTo(startBeamX, startBeamY + beamThickness);
@@ -886,6 +887,7 @@ export class Beam extends Element {
           ctx.lineTo(lastBeamX + 1, lastBeamY);
           ctx.closePath();
           ctx.fill();
+          ctx.closeGroup();
         } else {
           throw new RuntimeError('NoLastBeamX', 'lastBeamX undefined.');
         }

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -152,12 +152,20 @@ export class StaveTie extends Element {
       const top_cp_y = (first_y_px + last_y_px) / 2 + cp1 * params.direction;
       const bottom_cp_y = (first_y_px + last_y_px) / 2 + cp2 * params.direction;
 
+      // id probably unnecessary if we save the group to 'el' via setAttribute
+      // let id: string = "";
+      // if (this.notes.first_note) {
+      //   id = this.notes.first_note.getAttribute('id') + '-tie';
+      // }
+      // this.setAttribute('el', ctx.openGroup('stavetie', id));
+      this.setAttribute('el', ctx.openGroup('stavetie'));
       ctx.beginPath();
       ctx.moveTo(params.first_x_px + first_x_shift, first_y_px);
       ctx.quadraticCurveTo(cp_x, top_cp_y, params.last_x_px + last_x_shift, last_y_px);
       ctx.quadraticCurveTo(cp_x, bottom_cp_y, params.first_x_px + first_x_shift, first_y_px);
       ctx.closePath();
       ctx.fill();
+      ctx.closeGroup();
     }
   }
 


### PR DESCRIPTION
Without this PR, staveties, beams and stems within beams are just random `<path>` elements in the SVG Dom, not inside a `<g>` node with a class (and sometimes id), which non-beamed stems and most other elements like key signatures and clefs are at this point:
![image](https://user-images.githubusercontent.com/33069673/153474857-518e0557-eefd-4364-bc20-a80dece3d41f.png)
Instead, these 3 path nodes will be within `<g class='vf-stem/beam'>`  groups too now.

There are a few differences in how the SVG classes are created.
For staveties, we just save the SVG node as an attribute 'el' to the stavetie, so the SVG node doesn't need an ID -> you can get it by `stavetie.getAttribute('el')`.
  (alternatively, we could set the id by taking the ID of the start note + `-tie` if you want to get the info from the SVG alone)
Same for beams.
For stems within beams, the id of the note is added to the stem id, because there can be multiple stems within the beam, so we need a way to correlate them to their note, to say which stem belongs to which note.

Merging this would basically complete OSMD's Vexflowpatch integration, at least when #1263 is merged (and a few more bugs are fixed).

------

I couldn't run tests, but there should be no visual or functional changes other than adding the SVG classes.

My `grunt`, `grunt test` and `grunt reference` processes keep getting killed for some reason.

![image](https://user-images.githubusercontent.com/33069673/153474084-7f9d2e60-fb80-4a33-83ad-55ac353d52fa.png)
(I don't think my Ctrl+C is sticky)
Maybe it's running out of RAM? But then it should use Swap or something. I've configured the VM to have 1.5GB of RAM, which I thought should be enough for a Linux machine running a console running npm/grunt tasks.

`grunt test` aborted with this error (likely just a result of getting killed):
```console
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

RpcIpcMessagePortClosedError: Cannot send the message - the message port has been closed for the process 2749.
    at /home/simon/vexflow/vexflow-patch/node_modules/fork-ts-checker-webpack-plugin/lib/rpc/rpc-ipc/RpcIpcMessagePort.js:47:47
```
ran on Linux Mint 20.2 in a VM (VirtualBox on Windows host).
Looks like the process is getting killed, which also happened when running `grunt` the first time, though that succeeded the second time.