### PR TITLE
fix #1295 by more accurately reporting articulation and annotation width

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -73,6 +73,7 @@ export class Annotation extends Modifier {
   static format(annotations: Annotation[], state: ModifierContextState): boolean {
     if (!annotations || annotations.length === 0) return false;
     let width = 0;
+    let maxGlyphWidth = 0;
     for (let i = 0; i < annotations.length; ++i) {
       const annotation = annotations[i];
       const textFormatter = TextFormatter.create(annotation.textFont);
@@ -81,6 +82,8 @@ export class Annotation extends Modifier {
       let verticalSpaceNeeded = textLines;
 
       const note = annotation.checkAttachedNote();
+      maxGlyphWidth = Math.max(note.getGlyph().getWidth(), maxGlyphWidth);
+
       const stave: Stave | undefined = note.getStave();
       const stemDirection = note.hasStem() ? note.getStemDirection() : Stem.UP;
       let stemHeight = 0;
@@ -146,8 +149,9 @@ export class Annotation extends Modifier {
         annotation.setTextLine(state.text_line);
       }
     }
-    state.left_shift += width / 2;
-    state.right_shift += width / 2;
+    const overlap = Math.min(Math.max(width - maxGlyphWidth, 0), Math.max(width - state.left_shift * 2, 0));
+    state.left_shift += overlap / 2;
+    state.right_shift += overlap / 2;
     return true;
   }
 

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -149,7 +149,10 @@ export class Annotation extends Modifier {
         annotation.setTextLine(state.text_line);
       }
     }
-    const overlap = Math.min(Math.max(width - maxGlyphWidth, 0), Math.max(width - state.left_shift * 2, 0));
+    const overlap = Math.min(
+      Math.max(width - maxGlyphWidth, 0),
+      Math.max(width - (state.left_shift + state.right_shift), 0)
+    );
     state.left_shift += overlap / 2;
     state.right_shift += overlap / 2;
     return true;

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -205,6 +205,7 @@ export class Articulation extends Modifier {
     if (!articulations || articulations.length === 0) return false;
 
     const margin = 0.5;
+    let maxGlyphWidth = 0;
 
     const getIncrement = (articulation: Articulation, line: number, position: number) =>
       roundToNearestHalf(
@@ -214,6 +215,7 @@ export class Articulation extends Modifier {
 
     articulations.forEach((articulation) => {
       const note = articulation.checkAttachedNote();
+      maxGlyphWidth = Math.max(note.getGlyph().getWidth(), maxGlyphWidth);
       let lines = 5;
       const stemDirection = note.hasStem() ? note.getStemDirection() : Stem.UP;
       let stemHeight = 0;
@@ -261,9 +263,10 @@ export class Articulation extends Modifier {
     const width = articulations
       .map((articulation) => articulation.getWidth())
       .reduce((maxWidth, articWidth) => Math.max(articWidth, maxWidth));
+    const overlap = Math.min(Math.max(width - maxGlyphWidth, 0), Math.max(width - state.left_shift * 2, 0));
 
-    state.left_shift += width / 2;
-    state.right_shift += width / 2;
+    state.left_shift += overlap / 2;
+    state.right_shift += overlap / 2;
     return true;
   }
 

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -263,7 +263,10 @@ export class Articulation extends Modifier {
     const width = articulations
       .map((articulation) => articulation.getWidth())
       .reduce((maxWidth, articWidth) => Math.max(articWidth, maxWidth));
-    const overlap = Math.min(Math.max(width - maxGlyphWidth, 0), Math.max(width - state.left_shift * 2, 0));
+    const overlap = Math.min(
+      Math.max(width - maxGlyphWidth, 0),
+      Math.max(width - (state.left_shift + state.right_shift), 0)
+    );
 
     state.left_shift += overlap / 2;
     state.right_shift += overlap / 2;

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -5,6 +5,8 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Annotation } from '../src';
+import { Accidental } from '../src/accidental';
 import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Flow } from '../src/flow';
@@ -24,6 +26,7 @@ const ArticulationTests = {
   Start(): void {
     QUnit.module('Articulation');
     const run = VexFlowTests.runTests;
+    run('Articulation - Grace Notes', graceNotes);
     run('Articulation - Vertical Placement', verticalPlacement);
     run('Articulation - Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Articulation - Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
@@ -35,6 +38,44 @@ const ArticulationTests = {
     run('TabNote Articulation', tabNotes, { sym1: 'a.', sym2: 'a.' });
   },
 };
+
+function graceNotes(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 700, 130);
+  const stave = f.Stave({ x: 10, y: 10, width: 650 });
+
+  const gracenotes = [{ keys: ['b/4'], duration: '8', slash: false }].map(f.GraceNote.bind(f));
+
+  const notes = [
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0)
+      .addModifier(new Accidental('#')),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '8', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+  ];
+  notes[0].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[1].addModifier(new Articulation('a-').setPosition(3), 0).addModifier(new Annotation('words'));
+  notes[2].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[2].addModifier(new Articulation('a>').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a>').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a@a').setPosition(3), 0);
+
+  const voice = f.Voice().setStrict(false).addTickables(notes);
+
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  ok(true, 'GraceNoteBasic');
+}
 // Helper function for creating StaveNotes.
 function drawArticulations(options: TestOptions): void {
   const sym1 = options.params.sym1;

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -5,8 +5,6 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Annotation } from '../src';
-import { Accidental } from '../src/accidental';
 import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Flow } from '../src/flow';
@@ -26,7 +24,6 @@ const ArticulationTests = {
   Start(): void {
     QUnit.module('Articulation');
     const run = VexFlowTests.runTests;
-    run('Articulation - Grace Notes', graceNotes);
     run('Articulation - Vertical Placement', verticalPlacement);
     run('Articulation - Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Articulation - Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
@@ -39,43 +36,6 @@ const ArticulationTests = {
   },
 };
 
-function graceNotes(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 700, 130);
-  const stave = f.Stave({ x: 10, y: 10, width: 650 });
-
-  const gracenotes = [{ keys: ['b/4'], duration: '8', slash: false }].map(f.GraceNote.bind(f));
-
-  const notes = [
-    f
-      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0)
-      .addModifier(new Accidental('#')),
-    f
-      .StaveNote({ keys: ['c/5'], duration: '8', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
-    f
-      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
-    f
-      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
-  ];
-  notes[0].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[1].addModifier(new Articulation('a-').setPosition(3), 0).addModifier(new Annotation('words'));
-  notes[2].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[2].addModifier(new Articulation('a>').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a>').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a@a').setPosition(3), 0);
-
-  const voice = f.Voice().setStrict(false).addTickables(notes);
-
-  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
-
-  f.draw();
-
-  ok(true, 'GraceNoteBasic');
-}
 // Helper function for creating StaveNotes.
 function drawArticulations(options: TestOptions): void {
   const sym1 = options.params.sym1;

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -7,6 +7,9 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Accidental } from '../src/accidental';
+import { Annotation } from '../src/annotation';
+import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Dot } from '../src/dot';
 import { Factory } from '../src/factory';
@@ -19,6 +22,7 @@ const GraceNoteTests = {
     QUnit.module('Grace Notes');
     const run = VexFlowTests.runTests;
     run('Grace Note Basic', basic);
+    run('With Articulation and Annotation on Parent Note', graceNoteModifiers);
     run('Grace Note Basic with Slurs', basicSlurred);
     run('Grace Note Stem', stem);
     run('Grace Note Stem with Beams 1', stemWithBeamed, {
@@ -106,7 +110,43 @@ function basic(options: TestOptions): void {
 
   ok(true, 'GraceNoteBasic');
 }
+function graceNoteModifiers(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 700, 130);
+  const stave = f.Stave({ x: 10, y: 10, width: 650 });
 
+  const gracenotes = [{ keys: ['b/4'], duration: '8', slash: false }].map(f.GraceNote.bind(f));
+
+  const notes = [
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0)
+      .addModifier(new Accidental('#')),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '8', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+  ];
+  notes[0].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[1].addModifier(new Articulation('a-').setPosition(3), 0).addModifier(new Annotation('words'));
+  notes[2].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a-').setPosition(3), 0);
+  notes[2].addModifier(new Articulation('a>').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a>').setPosition(3), 0);
+  notes[3].addModifier(new Articulation('a@a').setPosition(3), 0);
+
+  const voice = f.Voice().setStrict(false).addTickables(notes);
+
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  ok(true, 'GraceNoteBasic');
+}
 function basicSlurred(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 700, 130);
   const stave = f.Stave({ x: 10, y: 10, width: 650 });

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -119,25 +119,33 @@ function graceNoteModifiers(options: TestOptions): void {
   const notes = [
     f
       .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0)
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0)
+      .addModifier(new Articulation('a-').setPosition(3), 0),
+    f
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0)
+      .addModifier(new Articulation('a-').setPosition(3), 0)
       .addModifier(new Accidental('#')),
     f
-      .StaveNote({ keys: ['c/5'], duration: '8', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+      .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0)
+      .addModifier(new Articulation('a-').setPosition(3), 0)
+      .addModifier(new Annotation('words')),
     f
       .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0)
+      .addModifier(new Articulation('a-').setPosition(3), 0)
+      .addModifier(new Articulation('a>').setPosition(3), 0),
     f
       .StaveNote({ keys: ['c/5'], duration: '4', auto_stem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes }).beamNotes(), 0),
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes }), 0)
+      .addModifier(new Articulation('a-').setPosition(3), 0)
+      .addModifier(new Articulation('a>').setPosition(3), 0)
+      .addModifier(new Articulation('a@a').setPosition(3), 0),
   ];
-  notes[0].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[1].addModifier(new Articulation('a-').setPosition(3), 0).addModifier(new Annotation('words'));
-  notes[2].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a-').setPosition(3), 0);
-  notes[2].addModifier(new Articulation('a>').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a>').setPosition(3), 0);
-  notes[3].addModifier(new Articulation('a@a').setPosition(3), 0);
 
   const voice = f.Voice().setStrict(false).addTickables(notes);
 
@@ -145,7 +153,7 @@ function graceNoteModifiers(options: TestOptions): void {
 
   f.draw();
 
-  ok(true, 'GraceNoteBasic');
+  ok(true, 'GraceNoteModifiers');
 }
 function basicSlurred(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 700, 130);


### PR DESCRIPTION
Prevent grace notes from being pushed too far away from the note by annotations and articulations, because those modifiers reported incorrect width (too high).  For centered, vertically stacked modifiers, subtract the note width from the modifier width and report the overlap.

old:
![image](https://user-images.githubusercontent.com/5438280/153775005-268eb959-91e4-4672-92dc-d634341a72a3.png)

new:
![image](https://user-images.githubusercontent.com/5438280/153774964-8888578a-89cf-4781-bc19-40d458c996b4.png)

This causes 298 visual differences.  Most of them are not visible to me, if I didn't see the diff.  Our perceptive hash is super sensitive to text changes.  

![image](https://user-images.githubusercontent.com/5438280/153775054-5e08a8c0-e56e-45ad-a1d6-a0f1bb364285.png)

Some new test cases take up less room, but I didn't see any collisions.  This is an example:
old:
![image](https://user-images.githubusercontent.com/5438280/153774899-bc9ec547-b5fb-4861-a072-99d0ca4d9bb8.png)
new:
![image](https://user-images.githubusercontent.com/5438280/153774931-3c619388-f909-4d80-8a79-2911964cfb20.png)

