### PR TITLE
Formatter Whitespace_and_justify: keep num_beats constant

### DIFF
--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -141,8 +141,8 @@ function rightJustify(options: TestOptions): void {
   };
   renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 2, '2', 10, 300);
   renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 1, 'w', 310, 300);
-  renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 3, '4', 610, 300);
-  renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 6, '8', 910, 300);
+  renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 4, '4', 610, 300);
+  renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 8, '8', 910, 300);
   ok(true);
 }
 


### PR DESCRIPTION
Reviewing the tests' output I thought that in the test below there was a rendering error: Some notes were missing. 
The problem is that the test did not keep num_beats contant. 
I suggest this change to avoid that someone else also thinks that the rendering is wrong. Bellow the Bravura version:

 **Formatter Whitespace_and_justify Bravura**
![Formatter Whitespace_and_justify Bravura](https://user-images.githubusercontent.com/22865285/155418420-525837f4-1423-4402-9751-bb9f45c8d58a.png)
**current**
![Formatter Whitespace_and_justify Bravura_current](https://user-images.githubusercontent.com/22865285/155418427-ead14dc4-b8d2-44b5-9a52-2f6e5b1d7793.png)
**reference(master)**
![Formatter Whitespace_and_justify Bravura_reference](https://user-images.githubusercontent.com/22865285/155418428-3da6e0a5-4adb-406b-ab37-397a18ed34c1.png)
