### PR TITLE
easyscore tests: render notes in keys(...)

### DIFF
--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -555,11 +555,16 @@ function drawFingeringsTest(options: TestOptions): void {
 }
 
 function keys(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 500, 200);
+  const f = VexFlowTests.makeFactory(options, 700, 200);
   const score = f.EasyScore();
+  const system = f.System();
   const notes = score.notes(
-    'c#3/q, c##3, cb3, cbb3, cn3, c3, cbbs3, cbss3, cbs3, cdb3, cd3, c++-3, c++3, c+-3, c+3, co3, ck3'
+    'c#3/q, c##3, cb3, cbb3, cn3, c3, cbbs3, cbss3, cbs3, cdb3, cd3, c++-3, c++3, c+-3, c+3, co3, ck3',
+    { clef: 'bass' }
   );
+
+  system.addStave({ voices: [f.Voice().setStrict(false).addTickables(notes)] }).addClef('bass');
+  f.draw();
 
   equal(notes[0].keys, 'c#/3');
   equal(notes[1].keys, 'c##/3');


### PR DESCRIPTION
Reviewing the tests' output I realised that the test `keys(...)` was producing no output. Bellow the bravura version:

**EasyScore Keys Bravura**
![EasyScore Keys Bravura](https://user-images.githubusercontent.com/22865285/155566549-513bc5b5-1ef6-49fe-a617-14ed5cd34d26.png)
**current**
![EasyScore Keys Bravura_current](https://user-images.githubusercontent.com/22865285/155566551-79d401dc-4c48-417a-a84b-7cfc0636b76f.png)
**reference**
![EasyScore Keys Bravura_reference](https://user-images.githubusercontent.com/22865285/155566553-8da0b301-5b77-4dc1-9250-56f095e5cfba.png)
