### PR TITLE
Fix #1307: Accidentals overlapping

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -575,7 +575,7 @@ export abstract class Note extends Tickable {
 
   getLeftParenthesisPx(index: number): number {
     const props = this.getKeyProps()[index];
-    return props.displaced ? this.getLeftDisplacedHeadPx() : 0;
+    return props.displaced ? this.getLeftDisplacedHeadPx() - this.x_shift : -this.x_shift;
   }
 
   getFirstDotPx(): number {

--- a/src/system.ts
+++ b/src/system.ts
@@ -191,13 +191,7 @@ export class System extends Element {
     this.parts.forEach((part) => {
       y = y + part.stave.space(part.spaceAbove);
       part.stave.setY(y);
-      if (this.options.autoWidth) {
-        part.voices.forEach((voice) => {
-          formatter.joinVoices([voice]);
-        });
-      } else {
-        formatter.joinVoices(part.voices);
-      }
+      formatter.joinVoices(part.voices);
       y = y + part.stave.space(part.spaceBelow);
       y = y + part.stave.space(this.options.spaceBetweenStaves);
       if (part.debugNoteMetrics) {


### PR DESCRIPTION
Fixes #1307

This PR includes two changes:
- change in system.ts to join voices when autoWidth is set (to address #1307).
- fix the position of left parenthesis when the note is shifted (bug was made evident with the change above) 