### PR TITLE
Fix #1331: shared rest notes

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -224,6 +224,7 @@ export abstract class Note extends Tickable {
   protected stave?: Stave;
   public render_options: {
     draw_stem_through_stave?: boolean;
+    draw?: boolean;
     draw_dots?: boolean;
     draw_stem?: boolean;
     y_shift: number;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -184,7 +184,9 @@ export class StaveNote extends StemmableNote {
     if (voices === 2) {
       const lineSpacing =
         noteU.note.hasStem() && noteL.note.hasStem() && noteU.stemDirection === noteL.stemDirection ? 0.0 : 0.5;
-      if (noteU.minLine <= noteL.maxLine + lineSpacing) {
+      if (noteL.isrest && noteU.isrest && noteU.note.duration === noteL.note.duration) {
+        noteL.note.render_options.draw = false;
+      } else if (noteU.minLine <= noteL.maxLine + lineSpacing) {
         if (noteU.isrest) {
           // shift rest up
           shiftRestVertical(noteU, noteL, 1);
@@ -299,10 +301,10 @@ export class StaveNote extends StemmableNote {
 
     // Special case 2 :: all voices are rests
     if (noteU.isrest && noteM.isrest && noteL.isrest) {
-      // Shift upper voice rest up
-      shiftRestVertical(noteU, noteM, 1);
-      // Shift lower voice rest down
-      shiftRestVertical(noteL, noteM, -1);
+      // Hide upper voice rest
+      noteU.note.render_options.draw = false;
+      // Hide lower voice rest
+      noteL.note.render_options.draw = false;
       // format complete
       state.right_shift += xShift;
       return true;
@@ -310,12 +312,12 @@ export class StaveNote extends StemmableNote {
 
     // Test if any other rests can be repositioned
     if (noteM.isrest && noteU.isrest && noteM.minLine <= noteL.maxLine) {
-      // Shift middle voice rest up
-      shiftRestVertical(noteM, noteL, 1);
+      // Hide middle voice rest
+      noteM.note.render_options.draw = false;
     }
     if (noteM.isrest && noteL.isrest && noteU.minLine <= noteM.maxLine) {
-      // Shift middle voice rest down
-      shiftRestVertical(noteM, noteU, -1);
+      // Hide middle voice rest
+      noteM.note.render_options.draw = false;
     }
     if (noteU.isrest && noteU.minLine <= noteM.maxLine) {
       // shift upper voice rest up;
@@ -1206,6 +1208,8 @@ export class StaveNote extends StemmableNote {
 
   // Draws all the `StaveNote` parts. This is the main drawing method.
   draw(): void {
+    if (this.render_options.draw === false) return;
+
     if (this.ys.length === 0) {
       throw new RuntimeError('NoYValues', "Can't draw note without Y values.");
     }


### PR DESCRIPTION
Fixes #1331

Follows proposal from @mscuthbert on how to combine rest notes.

Visual differences (Bravura) diff/current/reference
![StaveNote Note_Heads_Placement___Simple Bravura](https://user-images.githubusercontent.com/22865285/156634420-876f0dc1-f826-44a4-9621-925d3140f668.png)
![StaveNote Note_Heads_Placement___Simple Bravura_current](https://user-images.githubusercontent.com/22865285/156634425-157fb74b-3b69-4569-9d47-77f4cfac39dd.png)
![StaveNote Note_Heads_Placement___Simple Bravura_reference](https://user-images.githubusercontent.com/22865285/156634426-799c1527-852a-4b4b-994a-d9f1ccaaeb4a.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__1 Bravura](https://user-images.githubusercontent.com/22865285/156634460-de553fe8-fb1c-46b3-9c96-6d94b88c6f05.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__1 Bravura_current](https://user-images.githubusercontent.com/22865285/156634466-56c5efde-f1ca-494e-bb78-5ba71d0829af.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__1 Bravura_reference](https://user-images.githubusercontent.com/22865285/156634467-511b91f2-26d8-41e3-8be1-3a225ee8f312.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura](https://user-images.githubusercontent.com/22865285/156634518-32db890d-c79c-4d8b-a2b0-fe5ad482d663.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura_current](https://user-images.githubusercontent.com/22865285/156634520-0698db00-aea2-45bb-a5ba-81449251cdf1.png)
![Three_Voice_Rests Auto_Adjust_Rest_Positions___Three_Voices__2 Bravura_reference](https://user-images.githubusercontent.com/22865285/156634521-c7711fed-4f48-498a-a01c-e780de4504cf.png)

