### PR TITLE
feat(annotation): Apply styles from setStyle when rendering

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -231,6 +231,10 @@ export class Annotation extends Modifier {
 
     // We're changing context parameters. Save current state.
     ctx.save();
+    // Apply style might not save context, if this.style is undefined, so we
+    // still need to save context state just before this, since we will be
+    // changing ctx parameters below.
+    this.applyStyle();
     const classString = Object.keys(this.getAttribute('classes')).join(' ');
     ctx.openGroup(classString, this.getAttribute('id'));
     ctx.setFont(this.textFont);
@@ -290,6 +294,7 @@ export class Annotation extends Modifier {
     L('Rendering annotation: ', this.text, x, y);
     ctx.fillText(this.text, x, y);
     ctx.closeGroup();
+    this.restoreStyle();
     ctx.restore();
   }
 }

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -13,6 +13,7 @@ import { Annotation, AnnotationVerticalJustify } from '../src/annotation';
 import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Bend } from '../src/bend';
+import { ElementStyle } from '../src/element';
 import { Flow } from '../src/flow';
 import { Font, FontStyle, FontWeight } from '../src/font';
 import { Formatter } from '../src/formatter';
@@ -35,6 +36,7 @@ const AnnotationTests = {
     run('Placement', placement);
     run('Lyrics', lyrics);
     run('Simple Annotation', simple);
+    run('Styled Annotation', styling);
     run('Standard Notation Annotation', standard);
     run('Harmonics', harmonic);
     run('Fingerpicking', picking);
@@ -139,6 +141,26 @@ function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
   const notes = [
     staveNote({ keys: ['c/4', 'e/4'], duration: 'h' }).addModifier(annotation('quiet'), 0),
     staveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'h' }).addModifier(annotation('Allegro'), 2),
+  ];
+
+  Formatter.FormatAndDraw(ctx, stave, notes);
+  ok(true, 'Standard Notation Annotation');
+}
+
+function styling(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 500, 240);
+  ctx.scale(1.5, 1.5);
+  const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
+
+  const annotation = (text: string, style: ElementStyle) =>
+    new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic').setStyle(style);
+
+  const notes = [
+    staveNote({ keys: ['c/4', 'e/4'], duration: 'h' }).addModifier(annotation('quiet', { fillStyle: '#0F0' }), 0),
+    staveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'h' }).addModifier(
+      annotation('Allegro', { fillStyle: '#00F' }),
+      2
+    ),
   ];
 
   Formatter.FormatAndDraw(ctx, stave, notes);


### PR DESCRIPTION
This PR enables rendering styles applied using the base `Element` class's `setStyle()` method when drawing annotations.