### PR TITLE
Rename Justification to TextJustification.

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -75,7 +75,7 @@ import { TabTie } from './tabtie';
 import { TextBracket, TextBracketPosition } from './textbracket';
 import { TextDynamics } from './textdynamics';
 import { TextFormatter } from './textformatter';
-import { Justification, TextNote } from './textnote';
+import { TextJustification, TextNote } from './textnote';
 import { TickContext } from './tickcontext';
 import { TimeSignature } from './timesignature';
 import { TimeSigNote } from './timesignote';
@@ -198,7 +198,7 @@ export class Flow {
   static StaveModifierPosition = StaveModifierPosition;
   static VoltaType = VoltaType;
   static TextBracketPosition = TextBracketPosition;
-  static Justification = Justification;
+  static TextJustification = TextJustification;
   static VoiceMode = VoiceMode;
 
   /**

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -13,6 +13,7 @@ import { FontInfo } from './font';
 import { RenderContext } from './rendercontext';
 import { StaveNote } from './stavenote';
 import { Tables } from './tables';
+import { TextJustification } from './textnote';
 import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
@@ -62,11 +63,7 @@ export class StaveLine extends Element {
     BOTTOM: 2,
   };
 
-  static readonly TextJustification = {
-    LEFT: 1,
-    CENTER: 2,
-    RIGHT: 3,
-  };
+  static readonly TextJustification = TextJustification;
 
   public render_options: {
     padding_left: number;

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -4,7 +4,7 @@
 import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
-import { Justification, TextNote } from './textnote';
+import { TextJustification, TextNote } from './textnote';
 import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
@@ -94,9 +94,9 @@ export class StaveText extends StaveModifier {
       case StaveModifierPosition.ABOVE:
       case StaveModifierPosition.BELOW:
         x = stave.getX() + this.options.shift_x;
-        if (this.options.justification === Justification.CENTER) {
+        if (this.options.justification === TextJustification.CENTER) {
           x += stave.getWidth() / 2 - text_width / 2;
-        } else if (this.options.justification === Justification.RIGHT) {
+        } else if (this.options.justification === TextJustification.RIGHT) {
           x += stave.getWidth() - text_width;
         }
 

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -7,7 +7,7 @@ import { Note, NoteStruct } from './note';
 import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
-export enum Justification {
+export enum TextJustification {
   LEFT = 1,
   CENTER = 2,
   RIGHT = 3,
@@ -41,9 +41,7 @@ export class TextNote extends Note {
     style: FontStyle.NORMAL,
   };
 
-  static get Justification(): typeof Justification {
-    return Justification;
-  }
+  static readonly Justification = TextJustification;
 
   /** Glyph data. */
   static get GLYPHS(): Record<string, { code: string }> {
@@ -112,7 +110,7 @@ export class TextNote extends Note {
   protected superscript?: string;
   protected subscript?: string;
   protected smooth: boolean;
-  protected justification: Justification;
+  protected justification: TextJustification;
   protected line: number;
 
   constructor(noteStruct: TextNoteStruct) {
@@ -125,7 +123,7 @@ export class TextNote extends Note {
     this.line = noteStruct.line || 0;
     this.smooth = noteStruct.smooth || false;
     this.ignore_ticks = noteStruct.ignore_ticks || false;
-    this.justification = Justification.LEFT;
+    this.justification = TextJustification.LEFT;
 
     // Determine and set initial note width. Note that the text width is
     // an approximation and isn't very accurate. The only way to accurately
@@ -142,7 +140,7 @@ export class TextNote extends Note {
   }
 
   /** Set the horizontal justification of the TextNote. */
-  setJustification(just: Justification): this {
+  setJustification(just: TextJustification): this {
     this.justification = just;
     return this;
   }
@@ -170,9 +168,9 @@ export class TextNote extends Note {
       }
     }
 
-    if (this.justification === Justification.CENTER) {
+    if (this.justification === TextJustification.CENTER) {
       this.leftDisplacedHeadPx = this.width / 2;
-    } else if (this.justification === Justification.RIGHT) {
+    } else if (this.justification === TextJustification.RIGHT) {
       this.leftDisplacedHeadPx = this.width;
     }
 
@@ -198,9 +196,9 @@ export class TextNote extends Note {
     // Align based on tick-context width.
     const width = this.getWidth();
 
-    if (this.justification === Justification.CENTER) {
+    if (this.justification === TextJustification.CENTER) {
       x -= width / 2;
-    } else if (this.justification === Justification.RIGHT) {
+    } else if (this.justification === TextJustification.RIGHT) {
       x -= width;
     }
 

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -22,7 +22,7 @@ import { StaveNote } from '../src/stavenote';
 import { Repetition } from '../src/staverepetition';
 import { StaveTempoOptions } from '../src/stavetempo';
 import { VoltaType } from '../src/stavevolta';
-import { Justification } from '../src/textnote';
+import { TextJustification } from '../src/textnote';
 import { TimeSignature } from '../src/timesignature';
 
 const StaveTests = {
@@ -765,8 +765,8 @@ function drawStaveTextMultiLine(options: TestOptions, contextBuilder: ContextBui
   stave.setText('2nd line', Modifier.Position.RIGHT, { shift_y: 10 });
   stave.setText('Above Text', Modifier.Position.ABOVE, { shift_y: -10 });
   stave.setText('2nd line', Modifier.Position.ABOVE, { shift_y: 10 });
-  stave.setText('Left Below Text', Modifier.Position.BELOW, { shift_y: -10, justification: Justification.LEFT });
-  stave.setText('Right Below Text', Modifier.Position.BELOW, { shift_y: 10, justification: Justification.RIGHT });
+  stave.setText('Left Below Text', Modifier.Position.BELOW, { shift_y: -10, justification: TextJustification.LEFT });
+  stave.setText('Right Below Text', Modifier.Position.BELOW, { shift_y: 10, justification: TextJustification.RIGHT });
   stave.setContext(ctx).draw();
 
   ok(true, 'all pass');


### PR DESCRIPTION
While working on the most recent CJS/ESM PR, I noticed that we were exporting a generically named enum called `Justification` from the TextNote file: 
https://github.com/0xfe/vexflow/blob/b23bb465b2e52f2e4c50af269b79225d395f3f5b/src/textnote.ts#L10-L14

StaveLine also has an identical "enum": https://github.com/0xfe/vexflow/blob/b23bb465b2e52f2e4c50af269b79225d395f3f5b/src/staveline.ts#L65-L69

In this PR, I renamed Justification to TextJustification so that it is more clear what the enum is used for. This is similar to the convention used in other classes, like:

https://github.com/0xfe/vexflow/blob/b23bb465b2e52f2e4c50af269b79225d395f3f5b/src/annotation.ts#L20-L32

`AnnotationVerticalJustify` and `AnnotationHorizontalJustify` are long names, but it is clear what they are for.


Summary:
* Renamed `Justification` => `TextJustification` in the textnote.ts file.
* staveline.ts now imports and uses the `TextJustification` enum, to reduce duplication.


## A comment on naming:

The word "justification" can be a bit unclear. In the text formatting world, justify usually means that a block of text is aligned to both the left margin and the right margin at the same time. So the spacing between words is automatically adjusted (via a "formatter" hehe) so that every line has the same width.

We use "justification" in many places inside VexFlow. I think in most cases, the word "align" would be clearer. For example: 
* HorizontalAlign
* VerticalAlign

Anyways, that's a much bigger breaking change, so I'm going to leave it for a future discussion. 