### PR TITLE
Restore v3.0.9 URLs and Fix JSFiddle examples.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -771,7 +771,7 @@ module.exports = (grunt) => {
       },
       git: {
         commitMessage: 'Release VexFlow ${version}',
-        changelog: false, // After 4.0: set to true to start publishing recent git commit history as a mini changelog.
+        changelog: true,
         requireCleanWorkingDir: false,
         commit: true,
         tag: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -836,12 +836,13 @@ module.exports = (grunt) => {
     });
   });
 
-  // VexFlow examples on JSFiddles and other websites broke because VexFlow 4 removed these URLs:
+  // VexFlow examples on JSFiddle and other websites broke because VexFlow 4 removed these URLs:
   //   https://unpkg.com/vexflow/releases/vexflow-debug.js
   //   https://unpkg.com/vexflow/releases/vexflow-min.js
-  // This command restores version 3.0.9 to the correct location, but adds a console.log() to the JS file to alert developers
+  // This command restores version 3.0.9 to those locations, but adds a console.warn(...) to the JS file to alert developers
   // that a new version has been released.
-  // For now, use this command during the release script, so that we can publish version 3.0.9 to npm alongside version 4.x.
+  //
+  // Use this command during the release script, so we can publish legacy version 3.0.9 to npm alongside version 4.x.
   //
   // grunt v309:add
   // grunt v309:remove

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -768,8 +768,8 @@ module.exports = (grunt) => {
         'after:git:release': [],
         'after:github:release': [],
         'after:release': [
-          'echo Successfully released ${name} ${version} to https://github.com/${repo.repository}',
           'grunt v309:remove',
+          'echo Successfully released ${name} ${version} to https://github.com/${repo.repository}',
         ],
       },
       git: {
@@ -842,26 +842,29 @@ module.exports = (grunt) => {
   // This command restores version 3.0.9 to those locations, but adds a console.warn(...) to the JS file to alert developers
   // that a new version has been released.
   //
-  // Use this command during the release script, so we can publish legacy version 3.0.9 to npm alongside version 4.x.
-  //
-  // grunt v309:add
-  // grunt v309:remove
-  grunt.registerTask('v309', '', function (command) {
+  // Use this command during the release script to publish version 3.0.9 to npm alongside version 4.x.
+  //   grunt v309:add
+  //   grunt v309:remove
+  grunt.registerTask('v309', 'Include the legacy version when publishing to npm.', function (command) {
+    const minifiedFile = 'releases/vexflow-min.js';
+    const debugFile = 'releases/vexflow-debug.js';
+
     if (command === 'add') {
-      const message =
-        '\n' +
-        'console.warn("VexFlow 4 has been released.\\nSee: https://github.com/0xfe/vexflow for more information.\\n' +
-        'This page is running version 3.0.9, which is no longer supported.");';
-
       // Commit ID 00ec15c67ff333ea49f4d3defbd9e22374c03684 is version 3.0.9.
-      runCommand('git', 'checkout', '00ec15c67ff333ea49f4d3defbd9e22374c03684', 'releases/vexflow-min.js');
-      fs.appendFileSync('releases/vexflow-min.js', message);
+      const commitID = '00ec15c67ff333ea49f4d3defbd9e22374c03684';
+      runCommand('git', 'checkout', commitID, minifiedFile);
+      runCommand('git', 'checkout', commitID, debugFile);
 
-      runCommand('git', 'checkout', '00ec15c67ff333ea49f4d3defbd9e22374c03684', 'releases/vexflow-debug.js');
-      fs.appendFileSync('releases/vexflow-debug.js', message);
+      const message =
+        '\nconsole.warn("Please upgrade to the newest release of VexFlow.\\n' +
+        'See: https://github.com/0xfe/vexflow for more information.\\nThis page uses version 3.0.9, which is no longer supported.");\n\n' +
+        '// YOU ARE LOOKING AT VEXFLOW LEGACY VERSION 3.0.9.\n' +
+        '// SEE THE `build/` FOLDER FOR THE NEWEST RELEASE.\n';
+      fs.appendFileSync(minifiedFile, message);
+      fs.appendFileSync(debugFile, message);
     } else {
-      runCommand('git', 'rm', '-f', 'releases/vexflow-min.js');
-      runCommand('git', 'rm', '-f', 'releases/vexflow-debug.js');
+      runCommand('git', 'rm', '-f', minifiedFile);
+      runCommand('git', 'rm', '-f', debugFile);
     }
   });
 };

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ system
 vf.draw();
 ```
 
-[See a running example of EasyScore here.](https://jsfiddle.net/t1672wza/)
+[See a running example of EasyScore here.](https://jsfiddle.net/xure9svb/)
 
 [Learn more about EasyScore here.](https://github.com/0xfe/vexflow/wiki/Using-EasyScore)
 
 ## Native API
 
-If you need more control, you can use the low-level VexFlow API. Below, we render a stave using SVG. [See a running example of the low-level API here.](https://jsfiddle.net/vbu1nto7/)
+If you need more control, you can use the low-level VexFlow API. Below, we render a stave using SVG. [See a running example of the low-level API here.](https://jsfiddle.net/5zgf03un/)
 
 ```javascript
 const { Renderer, Stave } = Vex.Flow;

--- a/demos/jsfiddle/gracenotes.html
+++ b/demos/jsfiddle/gracenotes.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    canvas {
+      border: 1px solid gray;
+    }
+  </style>
+  <!-- This example is available at: https://jsfiddle.net/smyht3q5/ -->
+  <body>
+    <canvas id="output"></canvas>
+    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <script>
+      const canvas = document.getElementById('output');
+
+      const { Renderer, Stave, StaveNote, Accidental, GraceNote, GraceNoteGroup, Voice, Formatter, Beam, Stem } =
+        Vex.Flow;
+
+      const renderer = new Renderer(canvas, Renderer.Backends.CANVAS);
+      const context = renderer.getContext();
+      renderer.resize(520, 210);
+
+      const TIME4_4 = {
+        num_beats: 4,
+        beat_value: 4,
+        resolution: Vex.Flow.RESOLUTION,
+      };
+
+      // Create and draw the tablature stave
+      const stave = new Stave(10, 40, 500);
+      stave.setContext(context).draw();
+
+      function note(params) {
+        return new StaveNote(params);
+      }
+
+      const notesA = [
+        note({
+          keys: ['f/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['f/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['d/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['c/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['c/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['d/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['f/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+        note({
+          keys: ['e/5'],
+          stem_direction: Stem.UP,
+          duration: '16',
+        }),
+      ];
+
+      const notesB = [
+        note({
+          keys: ['f/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['e/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['d/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['c/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['c/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['d/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['f/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+        note({
+          keys: ['e/4'],
+          stem_direction: Stem.DOWN,
+          duration: '16',
+        }),
+      ];
+
+      const graceNotes1 = [
+        new GraceNote({
+          keys: ['b/4'],
+          duration: '8',
+          slash: true,
+        }),
+      ];
+      const graceNotes2 = [
+        new GraceNote({
+          keys: ['f/4'],
+          duration: '8',
+          slash: true,
+        }),
+      ];
+      const graceNotes3 = [
+        new GraceNote({
+          keys: ['f/4'],
+          duration: '32',
+          stem_direction: Stem.DOWN,
+        }),
+        new GraceNote({
+          keys: ['e/4'],
+          duration: '32',
+          stem_direction: Stem.DOWN,
+        }),
+      ];
+
+      graceNotes2[0].setStemDirection(-1);
+      graceNotes2[0].addModifier(new Accidental('#'));
+
+      notesA[3].addModifier(new GraceNoteGroup(graceNotes1));
+      notesB[1].addModifier(new GraceNoteGroup(graceNotes2).beamNotes());
+      notesB[5].addModifier(new GraceNoteGroup(graceNotes3).beamNotes());
+
+      const voiceA = new Voice(TIME4_4).setStrict(false);
+      const voiceB = new Voice(TIME4_4).setStrict(false);
+      voiceA.addTickables(notesA);
+      voiceB.addTickables(notesB);
+
+      const formatter = new Formatter().joinVoices([voiceA, voiceB]).formatToStave([voiceA, voiceB], stave);
+      const beam1_1 = new Beam(notesA.slice(0, 4));
+      const beam1_2 = new Beam(notesA.slice(4, 8));
+
+      const beam2_1 = new Beam(notesB.slice(0, 4));
+      const beam2_2 = new Beam(notesB.slice(4, 8));
+
+      voiceA.draw(context, stave);
+      voiceB.draw(context, stave);
+      beam1_1.setContext(context).draw();
+      beam1_2.setContext(context).draw();
+
+      beam2_1.setContext(context).draw();
+      beam2_2.setContext(context).draw();
+    </script>
+  </body>
+</html>

--- a/demos/jsfiddle/sandbox.html
+++ b/demos/jsfiddle/sandbox.html
@@ -1,0 +1,38 @@
+<!DOCTYPE >
+<!-- 
+  This example is available at:
+  https://jsfiddle.net/wjm3t5su/ -->
+<html>
+  <style>
+    body {
+      font-family: Arial, 'sans-serif';
+    }
+  </style>
+  <body>
+    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <script>
+      const { Renderer, Stave } = Vex.Flow;
+
+      // Vex.Flow.setMusicFont('Bravura');
+      // Vex.Flow.setMusicFont('Gonville');
+      Vex.Flow.setMusicFont('Petaluma');
+
+      // Create an SVG renderer and attach it to the DIV element with id="output".
+      const div = document.getElementById('output');
+      const renderer = new Renderer(div, Renderer.Backends.SVG);
+
+      // Configure the rendering context.
+      renderer.resize(800, 500);
+      const context = renderer.getContext();
+
+      // Create a stave of width 400 at position 10, 40 on the canvas.
+      const stave = new Stave(10, 40, 400);
+
+      // Add a clef and time signature.
+      stave.addClef('treble').addTimeSignature('4/4');
+
+      // Connect it to the rendering context and draw!
+      stave.setContext(context).draw();
+    </script>
+  </body>
+</html>

--- a/demos/jsfiddle/sandbox.html
+++ b/demos/jsfiddle/sandbox.html
@@ -9,6 +9,7 @@
     }
   </style>
   <body>
+    <div id="output"></div>
     <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
     <script>
       const { Renderer, Stave } = Vex.Flow;

--- a/demos/jsfiddle/tutorial/step1_basics.html
+++ b/demos/jsfiddle/tutorial/step1_basics.html
@@ -1,0 +1,39 @@
+<!DOCTYPE >
+<!-- 
+This example is available at: https://jsfiddle.net/cwnsrep9/
+It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
+-->
+<html>
+  <style>
+    body {
+      font-family: Arial, 'sans-serif';
+    }
+  </style>
+  <body>
+    <!--
+    On JSFiddle.net, we pin the dependency to an exact version number,
+    to prevent a future release from accidentally breaking the example. 
+    -->
+    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <script>
+      const { Renderer, Stave } = Vex.Flow;
+
+      // Create an SVG renderer and attach it to the DIV element named "boo".
+      const div = document.getElementById('output');
+      const renderer = new Renderer(div, Renderer.Backends.SVG);
+
+      // Configure the rendering context.
+      renderer.resize(500, 500);
+      const context = renderer.getContext();
+
+      // Create a stave of width 400 at position 10, 40 on the canvas.
+      const stave = new Stave(10, 40, 400);
+
+      // Add a clef and time signature.
+      stave.addClef('treble').addTimeSignature('4/4');
+
+      // Connect it to the rendering context and draw!
+      stave.setContext(context).draw();
+    </script>
+  </body>
+</html>

--- a/demos/jsfiddle/tutorial/step1_basics.html
+++ b/demos/jsfiddle/tutorial/step1_basics.html
@@ -10,6 +10,7 @@ It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tut
     }
   </style>
   <body>
+    <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 

--- a/demos/jsfiddle/tutorial/step2_addnotes.html
+++ b/demos/jsfiddle/tutorial/step2_addnotes.html
@@ -1,0 +1,80 @@
+<!DOCTYPE >
+<!-- 
+This example is available at: https://jsfiddle.net/c36p8eo2/
+It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
+-->
+<html>
+  <style>
+    body {
+      font-family: Arial, 'sans-serif';
+    }
+  </style>
+  <body>
+    <!--
+    On JSFiddle.net, we pin the dependency to an exact version number,
+    to prevent a future release from accidentally breaking the example. 
+    -->
+    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <script>
+      const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
+
+      // Create an SVG renderer and attach it to the DIV element named "boo".
+      const div = document.getElementById('output');
+      const renderer = new Renderer(div, Renderer.Backends.SVG);
+
+      // Configure the rendering context.
+      renderer.resize(500, 500);
+      const context = renderer.getContext();
+
+      // Create a stave of width 400 at position 10, 40 on the canvas.
+      const stave = new Stave(10, 40, 400);
+
+      // Add a clef and time signature.
+      stave.addClef('treble').addTimeSignature('4/4');
+
+      // Connect it to the rendering context and draw!
+      stave.setContext(context).draw();
+
+      // Create the notes
+      const notes = [
+        // A quarter-note C.
+        new StaveNote({
+          keys: ['c/4'],
+          duration: 'q',
+        }),
+
+        // A quarter-note D.
+        new StaveNote({
+          keys: ['d/4'],
+          duration: 'q',
+        }),
+
+        // A quarter-note rest. Note that the key (b/4) specifies the vertical
+        // position of the rest.
+        new StaveNote({
+          keys: ['b/4'],
+          duration: 'qr',
+        }),
+
+        // A C-Major chord.
+        new StaveNote({
+          keys: ['c/4', 'e/4', 'g/4'],
+          duration: 'q',
+        }),
+      ];
+
+      // Create a voice in 4/4 and add above notes
+      const voice = new Voice({
+        num_beats: 4,
+        beat_value: 4,
+      });
+      voice.addTickables(notes);
+
+      // Format and justify the notes to 400 pixels.
+      new Formatter().joinVoices([voice]).format([voice], 350);
+
+      // Render voice
+      voice.draw(context, stave);
+    </script>
+  </body>
+</html>

--- a/demos/jsfiddle/tutorial/step2_addnotes.html
+++ b/demos/jsfiddle/tutorial/step2_addnotes.html
@@ -10,6 +10,7 @@ It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tut
     }
   </style>
   <body>
+    <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 

--- a/demos/jsfiddle/tutorial/step2_secondvoice.html
+++ b/demos/jsfiddle/tutorial/step2_secondvoice.html
@@ -10,6 +10,7 @@ It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tut
     }
   </style>
   <body>
+    <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 

--- a/demos/jsfiddle/tutorial/step2_secondvoice.html
+++ b/demos/jsfiddle/tutorial/step2_secondvoice.html
@@ -1,0 +1,86 @@
+<!DOCTYPE >
+<!-- 
+This example is available at: https://jsfiddle.net/awe4vdms/
+It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
+-->
+<html>
+  <style>
+    body {
+      font-family: Arial, 'sans-serif';
+    }
+  </style>
+  <body>
+    <!--
+    On JSFiddle.net, we pin the dependency to an exact version number,
+    to prevent a future release from accidentally breaking the example. 
+    -->
+    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <script>
+      const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
+
+      // Create an SVG renderer and attach it to the DIV element named "boo".
+      const div = document.getElementById('output');
+      const renderer = new Renderer(div, Renderer.Backends.SVG);
+
+      // Configure the rendering context.
+      renderer.resize(500, 500);
+      const context = renderer.getContext();
+
+      // Create a stave of width 400 at position 10, 40 on the canvas.
+      const stave = new Stave(10, 40, 400);
+
+      // Add a clef and time signature.
+      stave.addClef('treble').addTimeSignature('4/4');
+
+      // Connect it to the rendering context and draw!
+      stave.setContext(context).draw();
+
+      // Create the notes
+      const notes = [
+        new StaveNote({
+          keys: ['c/5'],
+          duration: 'q',
+        }),
+        new StaveNote({
+          keys: ['d/4'],
+          duration: 'q',
+        }),
+        new StaveNote({
+          keys: ['b/4'],
+          duration: 'qr',
+        }),
+        new StaveNote({
+          keys: ['c/4', 'e/4', 'g/4'],
+          duration: 'q',
+        }),
+      ];
+
+      const notes2 = [
+        new StaveNote({
+          keys: ['c/4'],
+          duration: 'w',
+        }),
+      ];
+
+      // Create a voice in 4/4 and add above notes
+      const voices = [
+        new Voice({
+          num_beats: 4,
+          beat_value: 4,
+        }).addTickables(notes),
+        new Voice({
+          num_beats: 4,
+          beat_value: 4,
+        }).addTickables(notes2),
+      ];
+
+      // Format and justify the notes to 400 pixels.
+      new Formatter().joinVoices(voices).format(voices, 350);
+
+      // Render voices.
+      voices.forEach(function (v) {
+        v.draw(context, stave);
+      });
+    </script>
+  </body>
+</html>

--- a/docs/sandbox.html
+++ b/docs/sandbox.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The VexFlow Sandbox</title>
-  <meta http-equiv="refresh" content="0; url=https://jsfiddle.net/nL0cn3vL/44/" />
-</head>
+  <head>
+    <title>The VexFlow Sandbox</title>
+    <meta http-equiv="refresh" content="0; url=https://jsfiddle.net/wjm3t5su/" />
+  </head>
 </html>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "tests/flow.html",
     "tests/flow.css",
     "tests/support",
+    "releases/vexflow-min.js",
+    "releases/vexflow-debug.js",
     "AUTHORS.md"
   ],
   "bugs": {


### PR DESCRIPTION
Work in progress:
- Adds a step to the release script where we patch version 3.0.9 with a console.warn() message to upgrade to VexFlow 4. We publish this version at the old URL to fix any live deployments that reference the old URL.
- As part of my work in updating the wiki and fixing JSFiddles, I am starting to include the JSFiddle examples in the repository itself. This will make it easier to maintain going forward. If any changes are needed (e.g., if VexFlow 5 breaks something), we can make the changes in the repo and copy the code directly into the JSFiddles, instead of editing the code on the JSFiddle editor.