### PR TITLE
setGroupStyle

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -67,7 +67,6 @@ export abstract class Element {
     return Category.Element;
   }
 
-  protected parent?: Element;
   protected children: Element[] = [];
   protected static ID: number = 1000;
   protected static newID(): string {
@@ -113,14 +112,8 @@ export abstract class Element {
     Registry.getDefaultRegistry()?.register(this);
   }
 
-  setParent(parent?: Element): this {
-    if (parent) {
-      this.parent = parent;
-      this.parent.children.push(this);
-    } else if (this.parent) {
-      this.parent.children.splice(this.parent.children.indexOf(this));
-      this.parent = undefined;
-    }
+  addChildElement(child: Element): this {
+    this.children.push(child);
     return this;
   }
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -67,6 +67,8 @@ export abstract class Element {
     return Category.Element;
   }
 
+  protected parent?: Element;
+  protected children: Element[] = [];
   protected static ID: number = 1000;
   protected static newID(): string {
     return `auto${Element.ID++}`;
@@ -111,7 +113,17 @@ export abstract class Element {
     Registry.getDefaultRegistry()?.register(this);
   }
 
-  /** Get element category string. */
+  setParent(parent?: Element): this {
+    if (parent) {
+      this.parent = parent;
+      this.parent.children.push(this);
+    } else if (this.parent) {
+      this.parent.children.splice(this.parent.children.indexOf(this));
+      this.parent = undefined;
+    }
+    return this;
+  }
+
   getCategory(): string {
     return (<typeof Element>this.constructor).CATEGORY;
   }
@@ -140,6 +152,13 @@ export abstract class Element {
    */
   setStyle(style: ElementStyle): this {
     this.style = style;
+    return this;
+  }
+
+  /** Set the element & associated children style used for rendering. */
+  setGroupStyle(style: ElementStyle): this {
+    this.style = style;
+    this.children.forEach((child) => child.setGroupStyle(style));
     return this;
   }
 

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -540,7 +540,7 @@ export class StaveNote extends StemmableNote {
         stem_up_x_offset: noteProps.stem_up_x_offset,
         stem_down_x_offset: noteProps.stem_down_x_offset,
         line: noteProps.line,
-      });
+      }).setParent(this);
 
       this._noteHeads[i] = notehead;
     }
@@ -844,10 +844,7 @@ export class StaveNote extends StemmableNote {
   // Sets the style of the complete StaveNote, including all keys
   // and the stem.
   setStyle(style: ElementStyle): this {
-    super.setStyle(style);
-    this._noteHeads.forEach((notehead) => notehead.setStyle(style));
-    if (this.stem) this.stem.setStyle(style);
-    return this;
+    return super.setGroupStyle(style);
   }
 
   setStemStyle(style: ElementStyle): this {

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -540,8 +540,9 @@ export class StaveNote extends StemmableNote {
         stem_up_x_offset: noteProps.stem_up_x_offset,
         stem_down_x_offset: noteProps.stem_down_x_offset,
         line: noteProps.line,
-      }).setParent(this);
+      });
 
+      this.addChildElement(notehead);
       this._noteHeads[i] = notehead;
     }
   }

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -39,7 +39,7 @@ export abstract class StemmableNote extends Note {
   }
 
   setStem(stem: Stem): this {
-    this.stem = stem;
+    this.stem = stem.setParent(this);
     return this;
   }
 

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -39,7 +39,8 @@ export abstract class StemmableNote extends Note {
   }
 
   setStem(stem: Stem): this {
-    this.stem = stem.setParent(this);
+    this.stem = stem;
+    this.addChildElement(stem);
     return this;
   }
 


### PR DESCRIPTION
> @0xfe @gristow would it make sense to arrange elements genericaly in a tree?
> with that we could find childs for example by className we would have a root element without parent (probably the score), childs of the scores would be the measures, child of the measures would be the notes and then we could define a setGroupStyle() that would apply to the referenced element and all its childs.
>@ronyeh @AaronDavidNewman what do you think?

POC to show the idea I described in #285 quoted above.
I have also realised that if we set a `Registry` see below,
https://github.com/0xfe/vexflow/blob/46af63bb5eb52c66d3a30d978b3a08d04eecf5c6/src/element.ts#L111
we can use the registry member fuctions to look for elements and appy styles. 
