### PR TITLE
rect configurable in sections

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -306,8 +306,8 @@ export class Stave extends Element {
   }
 
   // Section functions
-  setSection(section: string, y: number, xOffset = 0, fontSize?: number) {
-    const staveSection = new StaveSection(section, this.x + xOffset, y);
+  setSection(section: string, y: number, xOffset = 0, fontSize?: number, drawRect = true) {
+    const staveSection = new StaveSection(section, this.x + xOffset, y, drawRect);
     if (fontSize) staveSection.setFontSize(fontSize);
     this.modifiers.push(staveSection);
     return this;

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -21,8 +21,9 @@ export class StaveSection extends StaveModifier {
   protected section: string;
   protected shift_x: number;
   protected shift_y: number;
+  protected drawRect: boolean;
 
-  constructor(section: string, x: number, shift_y: number) {
+  constructor(section: string, x: number, shift_y: number, drawRect = true) {
     super();
 
     this.setWidth(16);
@@ -30,6 +31,7 @@ export class StaveSection extends StaveModifier {
     this.x = x;
     this.shift_x = 0;
     this.shift_y = shift_y;
+    this.drawRect = drawRect;
     this.resetFont();
   }
 
@@ -66,12 +68,14 @@ export class StaveSection extends StaveModifier {
     const height = textHeight + 2 * paddingY; // add top & bottom padding
 
     //  Seems to be a good default y
-    const y = stave.getYForTopText(2) + this.shift_y;
+    const y = stave.getYForTopText(1.5) + this.shift_y;
     const x = this.x + shift_x;
-    ctx.beginPath();
-    ctx.setLineWidth(rectWidth);
-    ctx.rect(x, y + textMeasurements.y - paddingY, width, height);
-    ctx.stroke();
+    if (this.drawRect) {
+      ctx.beginPath();
+      ctx.setLineWidth(rectWidth);
+      ctx.rect(x, y + textMeasurements.y - paddingY, width, height);
+      ctx.stroke();
+    }
     ctx.fillText(this.section, x + paddingX, y);
     ctx.restore();
     return this;

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -151,7 +151,7 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
   const staveBar1 = new Stave(10, 50, 200);
   staveBar1.setBegBarType(BarlineType.REPEAT_BEGIN);
   staveBar1.setEndBarType(BarlineType.DOUBLE);
-  staveBar1.setSection('A', 0, 0, options.params?.fontSize);
+  staveBar1.setSection('A', 0, 0, options.params?.fontSize, false);
   staveBar1.addClef('treble').setContext(ctx).draw();
   const notesBar1 = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),


### PR DESCRIPTION
fixes #1366

On the refactoring of `StaveSection` the text was put half a line higher. It also allows to make the rectangle around the text configurable as requested by @sschmidTU.

Only one Visual Difference (test case changed to disable the rectangle in the first section)
![Stave Multiple_Stave_Barline_Test__14pt_Section_ Bravura](https://user-images.githubusercontent.com/22865285/163576250-d672a44c-221c-4cfe-8a4d-bab5e6395703.png)

