### PR TITLE
Add last note padding test case using softmax

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -97,7 +97,7 @@ export class Annotation extends Modifier {
         maxLeftGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
         leftWidth = Math.max(leftWidth, textWidth) + Annotation.minAnnotationPadding;
       } else if (annotation.horizontalJustification === AnnotationHorizontalJustify.RIGHT) {
-        maxRightGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
+        maxRightGlyphWidth = Math.max(glyphWidth, maxRightGlyphWidth);
         rightWidth = Math.max(rightWidth, textWidth);
       } else {
         leftWidth = Math.max(leftWidth, textWidth / 2) + Annotation.minAnnotationPadding;

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -13,10 +13,11 @@ import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
+import { Note } from './note';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { TextFormatter } from './textformatter';
-import { Category } from './typeguard';
+import { Category, isStemmableNote } from './typeguard';
 import { log } from './util';
 
 // To enable logging for this class. Set `Vex.Flow.ChordSymbol.DEBUG` to `true`.
@@ -247,6 +248,10 @@ export class ChordSymbol extends Modifier {
     return block.symbolModifier !== undefined && block.symbolModifier === SymbolModifiers.SUBSCRIPT;
   }
 
+  static get minPadding(): number {
+    const musicFont = Tables.currentMusicFont();
+    return musicFont.lookupMetric('glyphs.noteHead.minPadding');
+  }
   /**
    * Estimate the width of the whole chord symbol, based on the sum of the widths of the individual blocks.
    * Estimate how many lines above/below the staff we need.
@@ -256,12 +261,17 @@ export class ChordSymbol extends Modifier {
 
     let width = 0;
     let nonSuperWidth = 0;
-    const reportedWidths = [];
+    let leftWidth = 0;
+    let rightWidth = 0;
+    let maxLeftGlyphWidth = 0;
+    let maxRightGlyphWidth = 0;
 
     for (const symbol of symbols) {
       const fontSize = Font.convertSizeToPointValue(symbol.textFont?.size);
       const fontAdj = Font.scaleSize(fontSize, 0.05);
       const glyphAdj = fontAdj * 2;
+      const note: Note = symbol.checkAttachedNote();
+      let symbolWidth = 0;
       let lineSpaces = 1;
       let vAlign = false;
 
@@ -323,6 +333,7 @@ export class ChordSymbol extends Modifier {
         }
         block.vAlign = vAlign;
         width += block.width;
+        symbolWidth = width;
       }
 
       // make kerning adjustments after computing super/subscripts
@@ -336,17 +347,30 @@ export class ChordSymbol extends Modifier {
         symbol.setTextLine(state.text_line + 1);
         state.text_line += lineSpaces + 1;
       }
-      if (symbol.getReportWidth()) {
-        reportedWidths.push(width);
-      } else {
-        reportedWidths.push(0);
+      if (symbol.getReportWidth() && isStemmableNote(note)) {
+        const glyphWidth = note.getGlyph().getWidth();
+        if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.LEFT) {
+          maxLeftGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
+          leftWidth = Math.max(leftWidth, symbolWidth) + ChordSymbol.minPadding;
+        } else if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.RIGHT) {
+          maxRightGlyphWidth = Math.max(glyphWidth, maxRightGlyphWidth);
+          rightWidth = Math.max(rightWidth, symbolWidth);
+        } else {
+          leftWidth = Math.max(leftWidth, symbolWidth / 2) + ChordSymbol.minPadding;
+          rightWidth = Math.max(rightWidth, symbolWidth / 2);
+          maxLeftGlyphWidth = Math.max(glyphWidth / 2, maxLeftGlyphWidth);
+          maxRightGlyphWidth = Math.max(glyphWidth / 2, maxRightGlyphWidth);
+        }
       }
     }
+    const rightOverlap = Math.min(
+      Math.max(rightWidth - maxRightGlyphWidth, 0),
+      Math.max(rightWidth - state.right_shift, 0)
+    );
+    const leftOverlap = Math.min(Math.max(leftWidth - maxLeftGlyphWidth, 0), Math.max(leftWidth - state.left_shift, 0));
 
-    width = reportedWidths.reduce((a, b) => a + b, 0);
-
-    state.left_shift += width / 2;
-    state.right_shift += width / 2;
+    state.left_shift += leftOverlap;
+    state.right_shift += rightOverlap;
     return true;
   }
 

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -8,14 +8,18 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Accidental } from '../src/accidental';
 import { ChordSymbol } from '../src/chordsymbol';
 import { Factory } from '../src/factory';
+import { Font, FontGlyph } from '../src/font';
 import { Formatter } from '../src/formatter';
+import { Ornament } from '../src/ornament';
 import { Stave } from '../src/stave';
 import { StaveNote } from '../src/stavenote';
+import { Tables } from '../src/tables';
 
 const ChordSymbolTests = {
   Start(): void {
     QUnit.module('ChordSymbol');
     const run = VexFlowTests.runTests;
+    run('Chord Symbol With Modifiers', withModifiers);
     run('Chord Symbol Font Size Tests', fontSize);
     run('Chord Symbol Kerning Tests', kern);
     run('Top Chord Symbols', top);
@@ -33,6 +37,114 @@ const subscript = { symbolModifier: ChordSymbol.symbolModifiers.SUBSCRIPT };
 // Helper function for creating StaveNotes.
 const note = (factory: Factory, keys: string[], duration: string, chordSymbol: ChordSymbol) =>
   factory.StaveNote({ keys, duration }).addModifier(chordSymbol, 0);
+
+/** Calculate the glyph's width in the current music font. */
+// How is this different from Glyph.getWidth()? The numbers don't match up.
+function getGlyphWidth(glyphName: string): number {
+  // `38` seems to be the `font_scale` specified in many classes, such as
+  // Accidental, Articulation, Ornament, Strokes. Does this mean `38pt`???
+  //
+  // However, tables.ts specifies:
+  //   NOTATION_FONT_SCALE: 39,
+  //   TABLATURE_FONT_SCALE: 39,
+  const musicFont = Tables.currentMusicFont();
+  const glyph: FontGlyph = musicFont.getGlyphs()[glyphName];
+  const widthInEm = (glyph.x_max - glyph.x_min) / musicFont.getResolution();
+  return widthInEm * 38 * Font.scaleToPxFrom.pt;
+}
+function withModifiers(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 750, 580);
+  const ctx = f.getContext();
+  ctx.scale(1.5, 1.5);
+  ctx.fillStyle = '#221';
+  ctx.strokeStyle = '#221';
+
+  function draw(chords: ChordSymbol[], y: number) {
+    const notes = [
+      note(f, ['c/4'], 'q', chords[0]).addModifier(new Ornament('doit')),
+      note(f, ['c/4'], 'q', chords[1]),
+      note(f, ['c/4'], 'q', chords[2]).addModifier(new Ornament('fall')),
+      note(f, ['c/4'], 'q', chords[3]),
+    ];
+    const score = f.EasyScore();
+    const voice = score.voice(notes, { time: '4/4' });
+    const formatter = f.Formatter();
+    formatter.joinVoices([voice]);
+    const voiceW = formatter.preCalculateMinTotalWidth([voice]);
+    const staffW = voiceW + Stave.defaultPadding + getGlyphWidth('gClef');
+    formatter.format([voice], voiceW);
+    const staff = f.Stave({ x: 10, y, width: staffW }).addClef('treble').draw();
+    voice.draw(ctx, staff);
+  }
+
+  let chords = [];
+  chords.push(
+    f
+      .ChordSymbol({ fontSize: 10 })
+      .addText('F7')
+      .addGlyph('leftParenTall')
+      .addGlyphOrText('b9', superscript)
+      .addGlyphOrText('#11', subscript)
+      .addGlyph('rightParenTall')
+  );
+  chords.push(
+    f.ChordSymbol({ fontSize: 12 }).addText('F7').addGlyphOrText('b9', superscript).addGlyphOrText('#11', subscript)
+  );
+  chords.push(
+    f
+      .ChordSymbol({ fontSize: 14 })
+      .addText('F7')
+      .addGlyph('leftParenTall')
+      .addGlyphOrText('add 3', superscript)
+      .addGlyphOrText('omit 9', subscript)
+      .addGlyph('rightParenTall')
+  );
+  chords.push(
+    f
+      .ChordSymbol({ fontSize: 16 })
+      .addText('F7')
+      .addGlyph('leftParenTall')
+      .addGlyphOrText('b9', superscript)
+      .addGlyphOrText('#11', subscript)
+      .addGlyph('rightParenTall')
+  );
+  draw(chords, 40);
+
+  chords = [];
+  chords.push(
+    f
+      .ChordSymbol({ fontSize: 10 })
+      .setFontSize(10)
+      .addText('F7')
+      .addGlyphOrText('#11', superscript)
+      .addGlyphOrText('b9', subscript)
+  );
+  chords.push(
+    f.ChordSymbol({ fontSize: 12 }).addText('F7').addGlyphOrText('#11', superscript).addGlyphOrText('b9', subscript)
+  );
+  chords.push(
+    f.ChordSymbol({ fontSize: 14 }).addText('F7').addGlyphOrText('#11', superscript).addGlyphOrText('b9', subscript)
+  );
+  chords.push(
+    f
+      .ChordSymbol({ fontSize: 16 })
+      .setFontSize(16)
+      .addText('F7')
+      .addGlyphOrText('#11', superscript)
+      .addGlyphOrText('b9', subscript)
+  );
+  draw(chords, 140);
+
+  chords = [
+    f.ChordSymbol({ fontSize: 10 }).addGlyphOrText('Ab').addGlyphOrText('7(#11b9)', superscript),
+    f.ChordSymbol({ fontSize: 14 }).addGlyphOrText('C#').addGlyphOrText('7(#11b9)', superscript),
+    f.ChordSymbol({ fontSize: 16 }).addGlyphOrText('Ab').addGlyphOrText('7(#11b9)', superscript),
+    f.ChordSymbol({ fontSize: 18 }).addGlyphOrText('C#').addGlyphOrText('7(#11b9)', superscript),
+  ];
+  draw(chords, 240);
+
+  ok(true, 'Font Size Chord Symbol');
+}
 
 function fontSize(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 750, 580);

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -152,6 +152,7 @@ function rightJustify(options: TestOptions): void {
 function penultimateNote(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 500, 550);
   const score = f.EasyScore();
+  const staffWidth = 310;
   let system: System | undefined = undefined;
   let voices: Voice[] = [];
   let notes: StemmableNote[] = [];
@@ -159,7 +160,12 @@ function penultimateNote(options: TestOptions): void {
   let stave: Stave | undefined = undefined;
   let y = 10;
   const draw = (softmax: number) => {
-    system = f.System({ width: 309.87, y, formatOptions: { align_rests: true }, details: { softmaxFactor: softmax } });
+    system = f.System({
+      width: staffWidth,
+      y,
+      formatOptions: { align_rests: true },
+      details: { softmaxFactor: softmax },
+    });
     notes = [];
     voices = [];
     note = score.notes('C4/8/r', { clef: 'bass' })[0];
@@ -181,6 +187,7 @@ function penultimateNote(options: TestOptions): void {
     stave.addTimeSignature('2/4');
     voices = [];
     f.draw();
+    f.getContext().fillText(`softmax: ${softmax.toString()}`, staffWidth + 20, y + 50);
     y += 100;
   };
   draw(100);
@@ -649,6 +656,7 @@ function proportional(options: TestOptions): void {
 
 function softMax(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 550, 500);
+  const textX = 450 / 0.8;
   f.getContext().scale(0.8, 0.8);
 
   function draw(y: number, factor: number): void {
@@ -676,6 +684,7 @@ function softMax(options: TestOptions): void {
       .addTimeSignature('5/4');
 
     f.draw();
+    f.getContext().fillText(`softmax: ${factor.toString()}`, textX, y + 50);
     ok(true);
   }
 

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -24,7 +24,6 @@ import { StaveNote } from '../src/stavenote';
 import { Stem } from '../src/stem';
 import { StemmableNote } from '../src/stemmablenote';
 import { StringNumber } from '../src/stringnumber';
-import { System } from '../src/system';
 import { Tables } from '../src/tables';
 import { Tuplet } from '../src/tuplet';
 import { Voice, VoiceTime } from '../src/voice';
@@ -36,7 +35,6 @@ const FormatterTests = {
     test('TickContext Building', buildTickContexts);
 
     const run = VexFlowTests.runTests;
-    run('Penultimate Note Padding', penultimateNote);
     run('Whitespace and justify', rightJustify);
     run('Notehead padding', noteHeadPadding);
     run('Justification and alignment with accidentals', accidentalJustification);
@@ -121,7 +119,7 @@ function buildTickContexts(): void {
 }
 
 function rightJustify(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 1200, 150);
+  const f = VexFlowTests.makeFactory(options, 1200, 300);
   const getTickables = (time: VoiceTime, n: number, duration: string, duration2: string): Voice => {
     const tickar: StaveNote[] = [];
     let i = 0;
@@ -134,7 +132,7 @@ function rightJustify(options: TestOptions): void {
   const renderTest = (time: VoiceTime, n: number, duration: string, duration2: string, x: number, width: number) => {
     const formatter = f.Formatter();
 
-    const stave = f.Stave({ x, y: 20, width });
+    const stave = f.Stave({ x, y: 40, width });
     // stave.addClef('treble').addTimeSignature('4/4');
 
     const voice = getTickables(time, n, duration, duration2);
@@ -146,55 +144,6 @@ function rightJustify(options: TestOptions): void {
   renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 1, 'w', 'w', 310, 300);
   renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 3, '4', '4', 610, 300);
   renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 6, '8', '8', 910, 300);
-  ok(true);
-}
-
-function penultimateNote(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 500, 550);
-  const score = f.EasyScore();
-  const staffWidth = 310;
-  let system: System | undefined = undefined;
-  let voices: Voice[] = [];
-  let notes: StemmableNote[] = [];
-  let note: StemmableNote | undefined = undefined;
-  let stave: Stave | undefined = undefined;
-  let y = 10;
-  const draw = (softmax: number) => {
-    system = f.System({
-      width: staffWidth,
-      y,
-      formatOptions: { align_rests: true },
-      details: { softmaxFactor: softmax },
-    });
-    notes = [];
-    voices = [];
-    note = score.notes('C4/8/r', { clef: 'bass' })[0];
-    notes.push(note);
-    note = score.notes('A3/8', { stem: 'up', clef: 'bass' })[0];
-    notes.push(note);
-    note = score.notes('C4/4', { stem: 'up', clef: 'bass' })[0];
-    notes.push(note);
-    voices.push(score.voice(notes).setMode(2));
-    notes = [];
-    note = score.notes('( F3 A3 )/4', { stem: 'down', clef: 'bass' })[0];
-    notes.push(note);
-    note = score.notes('B4/4/r', {})[0];
-    notes.push(note);
-    voices.push(score.voice(notes).setMode(2));
-    notes = [];
-    stave = system.addStave({ voices: voices });
-    stave.addClef('bass');
-    stave.addTimeSignature('2/4');
-    voices = [];
-    f.draw();
-    f.getContext().fillText(`softmax: ${softmax.toString()}`, staffWidth + 20, y + 50);
-    y += 100;
-  };
-  draw(100);
-  draw(10);
-  draw(5);
-  draw(2);
-  draw(1.5);
   ok(true);
 }
 
@@ -656,7 +605,6 @@ function proportional(options: TestOptions): void {
 
 function softMax(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 550, 500);
-  const textX = 450 / 0.8;
   f.getContext().scale(0.8, 0.8);
 
   function draw(y: number, factor: number): void {
@@ -684,7 +632,6 @@ function softMax(options: TestOptions): void {
       .addTimeSignature('5/4');
 
     f.draw();
-    f.getContext().fillText(`softmax: ${factor.toString()}`, textX, y + 50);
     ok(true);
   }
 

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -24,6 +24,7 @@ import { StaveNote } from '../src/stavenote';
 import { Stem } from '../src/stem';
 import { StemmableNote } from '../src/stemmablenote';
 import { StringNumber } from '../src/stringnumber';
+import { System } from '../src/system';
 import { Tables } from '../src/tables';
 import { Tuplet } from '../src/tuplet';
 import { Voice, VoiceTime } from '../src/voice';
@@ -35,6 +36,7 @@ const FormatterTests = {
     test('TickContext Building', buildTickContexts);
 
     const run = VexFlowTests.runTests;
+    run('Penultimate Note Padding', penultimateNote);
     run('Whitespace and justify', rightJustify);
     run('Notehead padding', noteHeadPadding);
     run('Justification and alignment with accidentals', accidentalJustification);
@@ -119,7 +121,7 @@ function buildTickContexts(): void {
 }
 
 function rightJustify(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 1200, 300);
+  const f = VexFlowTests.makeFactory(options, 1200, 150);
   const getTickables = (time: VoiceTime, n: number, duration: string, duration2: string): Voice => {
     const tickar: StaveNote[] = [];
     let i = 0;
@@ -132,7 +134,7 @@ function rightJustify(options: TestOptions): void {
   const renderTest = (time: VoiceTime, n: number, duration: string, duration2: string, x: number, width: number) => {
     const formatter = f.Formatter();
 
-    const stave = f.Stave({ x, y: 40, width });
+    const stave = f.Stave({ x, y: 20, width });
     // stave.addClef('treble').addTimeSignature('4/4');
 
     const voice = getTickables(time, n, duration, duration2);
@@ -144,6 +146,48 @@ function rightJustify(options: TestOptions): void {
   renderTest({ num_beats: 4, beat_value: 4, resolution: 4 * 4096 }, 1, 'w', 'w', 310, 300);
   renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 3, '4', '4', 610, 300);
   renderTest({ num_beats: 3, beat_value: 4, resolution: 4 * 4096 }, 6, '8', '8', 910, 300);
+  ok(true);
+}
+
+function penultimateNote(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 500, 550);
+  const score = f.EasyScore();
+  let system: System | undefined = undefined;
+  let voices: Voice[] = [];
+  let notes: StemmableNote[] = [];
+  let note: StemmableNote | undefined = undefined;
+  let stave: Stave | undefined = undefined;
+  let y = 10;
+  const draw = (softmax: number) => {
+    system = f.System({ width: 309.87, y, formatOptions: { align_rests: true }, details: { softmaxFactor: softmax } });
+    notes = [];
+    voices = [];
+    note = score.notes('C4/8/r', { clef: 'bass' })[0];
+    notes.push(note);
+    note = score.notes('A3/8', { stem: 'up', clef: 'bass' })[0];
+    notes.push(note);
+    note = score.notes('C4/4', { stem: 'up', clef: 'bass' })[0];
+    notes.push(note);
+    voices.push(score.voice(notes).setMode(2));
+    notes = [];
+    note = score.notes('( F3 A3 )/4', { stem: 'down', clef: 'bass' })[0];
+    notes.push(note);
+    note = score.notes('B4/4/r', {})[0];
+    notes.push(note);
+    voices.push(score.voice(notes).setMode(2));
+    notes = [];
+    stave = system.addStave({ voices: voices });
+    stave.addClef('bass');
+    stave.addTimeSignature('2/4');
+    voices = [];
+    f.draw();
+    y += 100;
+  };
+  draw(100);
+  draw(10);
+  draw(5);
+  draw(2);
+  draw(1.5);
   ok(true);
 }
 


### PR DESCRIPTION
This addresses issue 1370.  Added a test case to formatter test cases to demonstrate softmax and how it affects measures with extra whitespace.  I don't think there is any other action we need to take, but this seems to come up a lot.

![image](https://user-images.githubusercontent.com/5438280/163632468-66e05651-2131-462f-8575-680a68d81837.png)
