### PR TITLE
exclude hidden notes from formatting

### DIFF
--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -164,64 +164,41 @@ export class StaveNote extends StemmableNote {
       });
     }
 
-    let voices = notesList.length;
-    if (voices < 2) return true;
-
-    let noteU = notesList[0];
+    let voices = 0;
+    let noteU = undefined;
     let noteM = undefined;
     let noteL = undefined;
-    let draw = noteU.note.render_options.draw ? noteU.note.render_options.draw : true;
+    const draw = [false, false, false];
 
-    if (voices === 2) {
-      // 2 voices & notesList[0] hidden, return
-      if (!draw) return true;
-      noteL = notesList[1];
-      draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
-      // 2 voices & notesList[1] hidden, return
-      if (!draw) return true;
-      // 2 voices to process
-      voices = 2;
-    } else if (!draw) {
-      // notesList[0] hidden
-      noteU = notesList[1];
-      draw = noteU.note.render_options.draw ? noteU.note.render_options.draw : true;
-      // notesList[0 & 1] hidden, return
-      if (!draw) return true;
-      // only notesList[0] hidden, voices == 2
-      else {
-        noteL = notesList[2];
-        voices = 2;
-        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
-        // notesList[0 & 2] hidden, return
-        if (!draw) return true;
-        // else 2 voices to process
-      }
-    } else {
-      noteM = notesList[1];
-      draw = noteM.note.render_options.draw ? noteM.note.render_options.draw : true;
-      // notesList[1] hidden
-      if (!draw) {
-        noteL = notesList[2];
-        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
-        // notesList[1 & 2] hidden, return
-        if (!draw) return true;
-        // else 2 voices to process
-        voices = 2;
-      } else {
-        noteL = notesList[2];
-        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
-        // notesList[2] hidden, 2 voices
-        if (!draw) {
-          // 2 voices to process
-          noteL = notesList[1];
-          noteM = undefined;
-          voices = 2;
-        }
-        // three notes to process
-      }
+    for (let i = 0; i < notesList.length; i++) {
+      draw[i] = notesList[i].note.render_options.draw == false ? false : true;
     }
-    noteM = voices > 2 ? notesList[1] : undefined;
-    noteL = voices > 2 ? notesList[2] : notesList[1];
+
+    if (draw[0] && draw[1] && draw[2]) {
+      // Three visible notes
+      voices = 3;
+      noteU = notesList[0];
+      noteM = notesList[1];
+      noteL = notesList[2];
+    } else if (draw[0] && draw[1]) {
+      // Two visible notes, 0 & 1
+      voices = 2;
+      noteU = notesList[0];
+      noteL = notesList[1];
+    } else if (draw[0] && draw[2]) {
+      // Two visible notes, 0 & 2
+      voices = 2;
+      noteU = notesList[0];
+      noteL = notesList[2];
+    } else if (draw[1] && draw[2]) {
+      // Two visible notes, 1 & 2
+      voices = 2;
+      noteU = notesList[1];
+      noteL = notesList[2];
+    } else {
+      // No shift required for less than 2 visible notes
+      return true;
+    }
 
     // for two voice backward compatibility, ensure upper voice is stems up
     // for three voices, the voices must be in order (upper, middle, lower)

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -164,11 +164,64 @@ export class StaveNote extends StemmableNote {
       });
     }
 
-    const voices = notesList.length;
+    let voices = notesList.length;
+    if (voices < 2) return true;
 
     let noteU = notesList[0];
-    const noteM = voices > 2 ? notesList[1] : undefined;
-    let noteL = voices > 2 ? notesList[2] : notesList[1];
+    let noteM = undefined;
+    let noteL = undefined;
+    let draw = noteU.note.render_options.draw ? noteU.note.render_options.draw : true;
+
+    if (voices === 2) {
+      // 2 voices & notesList[0] hidden, return
+      if (!draw) return true;
+      noteL = notesList[1];
+      draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
+      // 2 voices & notesList[1] hidden, return
+      if (!draw) return true;
+      // 2 voices to process
+      voices = 2;
+    } else if (!draw) {
+      // notesList[0] hidden
+      noteU = notesList[1];
+      draw = noteU.note.render_options.draw ? noteU.note.render_options.draw : true;
+      // notesList[0 & 1] hidden, return
+      if (!draw) return true;
+      // only notesList[0] hidden, voices == 2
+      else {
+        noteL = notesList[2];
+        voices = 2;
+        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
+        // notesList[0 & 2] hidden, return
+        if (!draw) return true;
+        // else 2 voices to process
+      }
+    } else {
+      noteM = notesList[1];
+      draw = noteM.note.render_options.draw ? noteM.note.render_options.draw : true;
+      // notesList[1] hidden
+      if (!draw) {
+        noteL = notesList[2];
+        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
+        // notesList[1 & 2] hidden, return
+        if (!draw) return true;
+        // else 2 voices to process
+        voices = 2;
+      } else {
+        noteL = notesList[2];
+        draw = noteL.note.render_options.draw ? noteL.note.render_options.draw : true;
+        // notesList[2] hidden, 2 voices
+        if (!draw) {
+          // 2 voices to process
+          noteL = notesList[1];
+          noteM = undefined;
+          voices = 2;
+        }
+        // three notes to process
+      }
+    }
+    noteM = voices > 2 ? notesList[1] : undefined;
+    noteL = voices > 2 ? notesList[2] : notesList[1];
 
     // for two voice backward compatibility, ensure upper voice is stems up
     // for three voices, the voices must be in order (upper, middle, lower)

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -62,6 +62,7 @@ const StaveNoteTests = {
     run('Beam and Dot Placement - Stem Up', dotsAndBeamsUp);
     run('Beam and Dot Placement - Stem Down', dotsAndBeamsDown);
     run('Note Heads Placement - Simple', noteHeadsSimple);
+    run('Note Heads Placement - Hidden Notes', noteHeadsHidden);
     run('Center Aligned Note', centerAlignedRest);
     run('Center Aligned Note with Articulation', centerAlignedRestFermata);
     run('Center Aligned Note with Annotation', centerAlignedRestAnnotation);
@@ -1027,6 +1028,47 @@ function noteHeadsSimple(options: TestOptions): void {
       score.voice(score.notes('e4/q, e4/q/r, e4/h/r')),
       score.voice(score.notes('e4/8, e4/8/r, e4/q/r, e4/h/r')),
     ],
+  });
+
+  vf.draw();
+  expect(0);
+}
+
+function noteHeadsHidden(options: TestOptions): void {
+  const vf = VexFlowTests.makeFactory(options, 800, 250);
+  const score = vf.EasyScore();
+
+  const system1 = vf.System({ y: 100, x: 50, width: 200 });
+  const notes1 = score.notes('g4/w');
+  notes1[0].render_options.draw = false;
+  system1
+    .addStave({
+      voices: [
+        score.voice([...score.beam(score.notes('a4/8, b4/8', { stem: 'up' })), ...score.notes('a4/q/r, a4/h/r')]),
+        score.voice(notes1),
+      ],
+    })
+    .addClef('treble')
+    .addTimeSignature('4/4');
+
+  const system2 = vf.System({ y: 100, x: 250, width: 150 });
+  const notes2 = score.notes('b4/w');
+  notes2[0].render_options.draw = false;
+  system2.addStave({
+    voices: [score.voice(score.notes('b4/h, b4/h/r')), score.voice(notes2)],
+  });
+
+  const system3 = vf.System({ y: 100, x: 400, width: 150 });
+  system3.addStave({
+    voices: [score.voice(score.notes('d5/h, d5/h/r')), score.voice(score.notes('e4/w'))],
+  });
+
+  const system4 = vf.System({ y: 100, x: 550, width: 150 });
+  const notes4 = score.notes('e4/q, e4/q/r, e4/h/r');
+  notes4[0].render_options.draw = false;
+  notes4[2].render_options.draw = false;
+  system4.addStave({
+    voices: [score.voice(notes4), score.voice(score.notes('e4/8, e4/8/r, e4/q/r, e4/h/r'))],
   });
 
   vf.draw();


### PR DESCRIPTION
fixes #1369

The notes which are hidden are not to be considered in the formatting calculations.

No visual differences.