### PR TITLE
Refactor/sofmaxfactor

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -487,12 +487,12 @@ export class Factory {
     return multiMeasureRest;
   }
 
-  Voice(params?: { time?: VoiceTime | string; options?: { softmaxFactor: number } }): Voice {
+  Voice(params?: { time?: VoiceTime | string }): Voice {
     const p = {
       time: '4/4',
       ...params,
     };
-    const voice = new Voice(p.time, p.options);
+    const voice = new Voice(p.time);
     this.voices.push(voice);
     return voice;
   }


### PR DESCRIPTION
The first commit refactors softmaxFactor leaving it in `Formatter` only,  no longer duplicated in `Voice`. This first commits has an impact on the interfaces but produces no visual difference.

The second commit changes the default from 100 to 5. This value was suggested as a good one by @AaronDavidNewman this produces a lot of visual differences and I believe that the results are better.

Ready to review. 