### PR TITLE
stringnumber: radius protected, circle configurable. 

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -464,10 +464,11 @@ export class Factory {
     return fingering;
   }
 
-  StringNumber(params: { number: string; position: string }): StringNumber {
+  StringNumber(params: { number: string; position: string; radius?: number }): StringNumber {
     const stringNumber = new StringNumber(params.number);
     stringNumber.setPosition(params.position);
     stringNumber.setContext(this.context);
+    if (params.radius != undefined) stringNumber.radius = params.radius;
     return stringNumber;
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -464,11 +464,11 @@ export class Factory {
     return fingering;
   }
 
-  StringNumber(params: { number: string; position: string; drawCircle?: boolean }): StringNumber {
+  StringNumber(params: { number: string; position: string }, drawCircle = true): StringNumber {
     const stringNumber = new StringNumber(params.number);
     stringNumber.setPosition(params.position);
     stringNumber.setContext(this.context);
-    if (params.drawCircle != undefined) stringNumber.setDrawCircle(params.drawCircle);
+    stringNumber.setDrawCircle(drawCircle);
     return stringNumber;
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -464,11 +464,11 @@ export class Factory {
     return fingering;
   }
 
-  StringNumber(params: { number: string; position: string; radius?: number }): StringNumber {
+  StringNumber(params: { number: string; position: string; drawCircle?: boolean }): StringNumber {
     const stringNumber = new StringNumber(params.number);
     stringNumber.setPosition(params.position);
     stringNumber.setContext(this.context);
-    if (params.radius != undefined) stringNumber.radius = params.radius;
+    if (params.drawCircle != undefined) stringNumber.setDrawCircle(params.drawCircle);
     return stringNumber;
   }
 

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -57,7 +57,7 @@ export class StringNumber extends Modifier {
       const index = num.checkIndex();
       const props = note.getKeyProps()[index];
       const mc = note.getModifierContext();
-      const verticalSpaceNeeded = (num.radius * 2) / Tables.STAVE_LINE_DISTANCE + 0.5;
+      const verticalSpaceNeeded = (num.getMinRadius() * 2) / Tables.STAVE_LINE_DISTANCE + 0.5;
 
       if (mc) {
         if (pos === ModifierPosition.ABOVE) {
@@ -160,6 +160,10 @@ export class StringNumber extends Modifier {
     this.resetFont();
   }
 
+  protected getMinRadius(): number {
+    return Math.max(this.radius, 8);
+  }
+
   setLineEndType(leg: number): this {
     if (leg >= Renderer.LineEndType.NONE && leg <= Renderer.LineEndType.DOWN) {
       this.leg = leg;
@@ -214,7 +218,8 @@ export class StringNumber extends Modifier {
           if (note.hasStem() && stemDirection == Stem.UP) {
             dot_y = stem_ext.topY + StringNumber.metrics.stemPadding;
           }
-          dot_y -= this.radius + StringNumber.metrics.verticalPadding + this.text_line * Tables.STAVE_LINE_DISTANCE;
+          dot_y -=
+            this.getMinRadius() + StringNumber.metrics.verticalPadding + this.text_line * Tables.STAVE_LINE_DISTANCE;
         }
         break;
       case Modifier.Position.BELOW:
@@ -224,14 +229,15 @@ export class StringNumber extends Modifier {
           if (note.hasStem() && stemDirection == Stem.DOWN) {
             dot_y = stem_ext.topY - StringNumber.metrics.stemPadding;
           }
-          dot_y += this.radius + StringNumber.metrics.verticalPadding + this.text_line * Tables.STAVE_LINE_DISTANCE;
+          dot_y +=
+            this.getMinRadius() + StringNumber.metrics.verticalPadding + this.text_line * Tables.STAVE_LINE_DISTANCE;
         }
         break;
       case Modifier.Position.LEFT:
-        dot_x -= this.radius / 2 + StringNumber.metrics.leftPadding;
+        dot_x -= this.getMinRadius() / 2 + StringNumber.metrics.leftPadding;
         break;
       case Modifier.Position.RIGHT:
-        dot_x += this.radius / 2 + StringNumber.metrics.rightPadding;
+        dot_x += this.getMinRadius() / 2 + StringNumber.metrics.rightPadding;
         break;
       default:
         throw new RuntimeError('InvalidPosition', `The position ${this.position} is invalid`);

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -34,40 +34,31 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes1 = score.notes('(c4 e4 g4)/4., (c5 e5 g5)/8, (c4 f4 g4)/4, (c4 f4 g4)/4', { stem: 'down' });
 
   notes1[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left', drawCircle: options.params?.drawCircle }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right' }, options.params?.drawCircle), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left' }, options.params?.drawCircle), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right' }, options.params?.drawCircle), 2);
 
   notes1[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below' }, options.params?.drawCircle), 0)
     .addModifier(f.Accidental({ type: '#' }).setAsCautionary(), 1)
     .addModifier(
       f
-        .StringNumber({ number: '3', position: 'above', drawCircle: options.params?.drawCircle })
+        .StringNumber({ number: '3', position: 'above' }, options.params?.drawCircle)
         .setLastNote(notes1[3])
         .setLineEndType(Renderer.LineEndType.DOWN),
       2
     );
 
   notes1[2]
-    .addModifier(f.StringNumber({ number: '5', position: 'left', drawCircle: options.params?.drawCircle }), 0)
-    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
+    .addModifier(f.StringNumber({ number: '5', position: 'left' }, options.params?.drawCircle), 0)
+    .addModifier(f.StringNumber({ number: '3', position: 'left' }, options.params?.drawCircle), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes1[3]
-    .addModifier(
-      f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(7),
-      0
-    )
-    .addModifier(
-      f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(6),
-      1
-    )
-    .addModifier(
-      f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(-6),
-      2
-    );
+    .addModifier(f.StringNumber({ number: '5', position: 'right' }, options.params?.drawCircle).setOffsetY(7), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right' }, options.params?.drawCircle).setOffsetY(6), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right' }, options.params?.drawCircle).setOffsetY(-6), 2);
 
   const voice1 = score.voice(notes1);
 
@@ -81,39 +72,30 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes2 = score.notes('(c4 e4 g4)/4, (c5 e5 g5), (c4 f4 g4), (c4 f4 g4)', { stem: 'up' });
 
   notes2[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left', drawCircle: options.params?.drawCircle }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right' }, options.params?.drawCircle), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left' }, options.params?.drawCircle), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right' }, options.params?.drawCircle), 2);
 
   notes2[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below' }, options.params?.drawCircle), 0)
     .addModifier(f.Accidental({ type: '#' }), 1)
     .addModifier(
       f
-        .StringNumber({ number: '3', position: 'above', drawCircle: options.params?.drawCircle })
+        .StringNumber({ number: '3', position: 'above' }, options.params?.drawCircle)
         .setLastNote(notes2[3])
         .setDashed(false),
       2
     );
 
   notes2[2]
-    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
+    .addModifier(f.StringNumber({ number: '3', position: 'left' }, options.params?.drawCircle), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes2[3]
-    .addModifier(
-      f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(7),
-      0
-    )
-    .addModifier(
-      f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(6),
-      1
-    )
-    .addModifier(
-      f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(-6),
-      2
-    );
+    .addModifier(f.StringNumber({ number: '5', position: 'right' }, options.params?.drawCircle).setOffsetY(7), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right' }, options.params?.drawCircle).setOffsetY(6), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right' }, options.params?.drawCircle).setOffsetY(-6), 2);
 
   const voice2 = score.voice(notes2);
 
@@ -127,10 +109,10 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notesBar3 = score.notes('(c4 e4 g4 a4)/1.');
 
   notesBar3[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
-    .addModifier(f.StringNumber({ number: '2', position: 'above', drawCircle: options.params?.drawCircle }), 3);
+    .addModifier(f.StringNumber({ number: '5', position: 'below' }, options.params?.drawCircle), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right' }, options.params?.drawCircle), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'left' }, options.params?.drawCircle), 2)
+    .addModifier(f.StringNumber({ number: '2', position: 'above' }, options.params?.drawCircle), 3);
 
   const voice3 = score.voice(notesBar3, { time: '6/4' });
 

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -17,6 +17,8 @@ const StringNumberTests = {
 
     const run = VexFlowTests.runTests;
     run('String Number In Notation', drawMultipleMeasures);
+    run('String Number In Notation - radius 0', drawMultipleMeasures, { radius: 0 });
+    run('String Number In Notation - radius 7', drawMultipleMeasures, { radius: 7 });
     run('Fret Hand Finger In Notation', drawFretHandFingers);
     run('Multi Voice With Strokes, String & Finger Numbers', multi);
     run('Complex Measure With String & Finger Numbers', drawAccidentals);
@@ -33,31 +35,31 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes1 = score.notes('(c4 e4 g4)/4., (c5 e5 g5)/8, (c4 f4 g4)/4, (c4 f4 g4)/4', { stem: 'down' });
 
   notes1[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right' }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left' }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right' }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left', radius: options.params?.radius }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }), 2);
 
   notes1[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below' }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
     .addModifier(f.Accidental({ type: '#' }).setAsCautionary(), 1)
     .addModifier(
       f
-        .StringNumber({ number: '3', position: 'above' })
+        .StringNumber({ number: '3', position: 'above', radius: options.params?.radius })
         .setLastNote(notes1[3])
         .setLineEndType(Renderer.LineEndType.DOWN),
       2
     );
 
   notes1[2]
-    .addModifier(f.StringNumber({ number: '5', position: 'left' }), 0)
-    .addModifier(f.StringNumber({ number: '3', position: 'left' }), 2)
+    .addModifier(f.StringNumber({ number: '5', position: 'left', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes1[3]
-    .addModifier(f.StringNumber({ number: '5', position: 'right' }).setOffsetY(7), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right' }).setOffsetY(6), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right' }).setOffsetY(-6), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }).setOffsetY(7), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }).setOffsetY(6), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }).setOffsetY(-6), 2);
 
   const voice1 = score.voice(notes1);
 
@@ -71,24 +73,30 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes2 = score.notes('(c4 e4 g4)/4, (c5 e5 g5), (c4 f4 g4), (c4 f4 g4)', { stem: 'up' });
 
   notes2[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right' }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left' }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right' }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left', radius: options.params?.radius }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }), 2);
 
   notes2[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below' }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
     .addModifier(f.Accidental({ type: '#' }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'above' }).setLastNote(notes2[3]).setDashed(false), 2);
+    .addModifier(
+      f
+        .StringNumber({ number: '3', position: 'above', radius: options.params?.radius })
+        .setLastNote(notes2[3])
+        .setDashed(false),
+      2
+    );
 
   notes2[2]
-    .addModifier(f.StringNumber({ number: '3', position: 'left' }), 2)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes2[3]
-    .addModifier(f.StringNumber({ number: '5', position: 'right' }).setOffsetY(7), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right' }).setOffsetY(6), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right' }).setOffsetY(-6), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }).setOffsetY(7), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }).setOffsetY(6), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }).setOffsetY(-6), 2);
 
   const voice2 = score.voice(notes2);
 
@@ -102,10 +110,10 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notesBar3 = score.notes('(c4 e4 g4 a4)/1.');
 
   notesBar3[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'below' }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right' }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'left' }), 2)
-    .addModifier(f.StringNumber({ number: '2', position: 'above' }), 3);
+    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
+    .addModifier(f.StringNumber({ number: '2', position: 'above', radius: options.params?.radius }), 3);
 
   const voice3 = score.voice(notesBar3, { time: '6/4' });
 

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -17,8 +17,7 @@ const StringNumberTests = {
 
     const run = VexFlowTests.runTests;
     run('String Number In Notation', drawMultipleMeasures);
-    run('String Number In Notation - radius 0', drawMultipleMeasures, { radius: 0 });
-    run('String Number In Notation - radius 7', drawMultipleMeasures, { radius: 7 });
+    run('String Number In Notation - no circle', drawMultipleMeasures, { drawCircle: false });
     run('Fret Hand Finger In Notation', drawFretHandFingers);
     run('Multi Voice With Strokes, String & Finger Numbers', multi);
     run('Complex Measure With String & Finger Numbers', drawAccidentals);
@@ -35,31 +34,40 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes1 = score.notes('(c4 e4 g4)/4., (c5 e5 g5)/8, (c4 f4 g4)/4, (c4 f4 g4)/4', { stem: 'down' });
 
   notes1[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left', radius: options.params?.radius }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left', drawCircle: options.params?.drawCircle }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }), 2);
 
   notes1[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
     .addModifier(f.Accidental({ type: '#' }).setAsCautionary(), 1)
     .addModifier(
       f
-        .StringNumber({ number: '3', position: 'above', radius: options.params?.radius })
+        .StringNumber({ number: '3', position: 'above', drawCircle: options.params?.drawCircle })
         .setLastNote(notes1[3])
         .setLineEndType(Renderer.LineEndType.DOWN),
       2
     );
 
   notes1[2]
-    .addModifier(f.StringNumber({ number: '5', position: 'left', radius: options.params?.radius }), 0)
-    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
+    .addModifier(f.StringNumber({ number: '5', position: 'left', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes1[3]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }).setOffsetY(7), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }).setOffsetY(6), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }).setOffsetY(-6), 2);
+    .addModifier(
+      f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(7),
+      0
+    )
+    .addModifier(
+      f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(6),
+      1
+    )
+    .addModifier(
+      f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(-6),
+      2
+    );
 
   const voice1 = score.voice(notes1);
 
@@ -73,30 +81,39 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notes2 = score.notes('(c4 e4 g4)/4, (c5 e5 g5), (c4 f4 g4), (c4 f4 g4)', { stem: 'up' });
 
   notes2[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'left', radius: options.params?.radius }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }), 2);
+    .addModifier(f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'left', drawCircle: options.params?.drawCircle }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }), 2);
 
   notes2[1]
     .addModifier(f.Accidental({ type: '#' }), 0)
-    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
+    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
     .addModifier(f.Accidental({ type: '#' }), 1)
     .addModifier(
       f
-        .StringNumber({ number: '3', position: 'above', radius: options.params?.radius })
+        .StringNumber({ number: '3', position: 'above', drawCircle: options.params?.drawCircle })
         .setLastNote(notes2[3])
         .setDashed(false),
       2
     );
 
   notes2[2]
-    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
     .addModifier(f.Accidental({ type: '#' }), 1);
 
   notes2[3]
-    .addModifier(f.StringNumber({ number: '5', position: 'right', radius: options.params?.radius }).setOffsetY(7), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }).setOffsetY(6), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'right', radius: options.params?.radius }).setOffsetY(-6), 2);
+    .addModifier(
+      f.StringNumber({ number: '5', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(7),
+      0
+    )
+    .addModifier(
+      f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(6),
+      1
+    )
+    .addModifier(
+      f.StringNumber({ number: '3', position: 'right', drawCircle: options.params?.drawCircle }).setOffsetY(-6),
+      2
+    );
 
   const voice2 = score.voice(notes2);
 
@@ -110,10 +127,10 @@ function drawMultipleMeasures(options: TestOptions): void {
   const notesBar3 = score.notes('(c4 e4 g4 a4)/1.');
 
   notesBar3[0]
-    .addModifier(f.StringNumber({ number: '5', position: 'below', radius: options.params?.radius }), 0)
-    .addModifier(f.StringNumber({ number: '4', position: 'right', radius: options.params?.radius }), 1)
-    .addModifier(f.StringNumber({ number: '3', position: 'left', radius: options.params?.radius }), 2)
-    .addModifier(f.StringNumber({ number: '2', position: 'above', radius: options.params?.radius }), 3);
+    .addModifier(f.StringNumber({ number: '5', position: 'below', drawCircle: options.params?.drawCircle }), 0)
+    .addModifier(f.StringNumber({ number: '4', position: 'right', drawCircle: options.params?.drawCircle }), 1)
+    .addModifier(f.StringNumber({ number: '3', position: 'left', drawCircle: options.params?.drawCircle }), 2)
+    .addModifier(f.StringNumber({ number: '2', position: 'above', drawCircle: options.params?.drawCircle }), 3);
 
   const voice3 = score.voice(notesBar3, { time: '6/4' });
 


### PR DESCRIPTION
fixes #1364

I added one test without circle (this one collides as described in #1364 without the changes in this PR).
![StringNumber String_Number_In_Notation___radius_0 Bravura](https://user-images.githubusercontent.com/22865285/166133321-e02c489a-9c1d-48d0-abf7-292adced8bae.png)

which is a variant of the standard with radius 8
![StringNumber String_Number_In_Notation Bravura](https://user-images.githubusercontent.com/22865285/166133318-b4f401d0-510b-4a07-b95e-75e5184dd98b.png)

