### PR TITLE
format beginning stave modifiers

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -165,8 +165,6 @@ export class Stave extends Element {
     if (!this.formatted) this.format();
 
     this.start_x = x;
-    const begBarline = this.modifiers[0];
-    begBarline.setX(this.start_x - begBarline.getWidth());
     return this;
   }
 
@@ -842,5 +840,47 @@ export class Stave extends Element {
     this.options.line_config = lines_configuration;
 
     return this;
+  }
+
+  static formatBegModifiers(staves: Stave[]): void {
+    let maxX = 0;
+    // align note start
+    staves.forEach((stave) => {
+      if (stave.getNoteStartX() > maxX) maxX = stave.getNoteStartX();
+    });
+    staves.forEach((stave) => {
+      stave.setNoteStartX(maxX);
+    });
+
+    maxX = 0;
+    // align REPEAT_BEGIN
+    staves.forEach((stave) => {
+      const modifiers = stave.getModifiers(StaveModifierPosition.BEGIN, Category.Barline);
+      modifiers.forEach((modifier) => {
+        if ((modifier as Barline).getType() == BarlineType.REPEAT_BEGIN)
+          if (modifier.getX() > maxX) maxX = modifier.getX();
+      });
+    });
+    staves.forEach((stave) => {
+      const modifiers = stave.getModifiers(StaveModifierPosition.BEGIN, Category.Barline);
+      modifiers.forEach((modifier) => {
+        if ((modifier as Barline).getType() == BarlineType.REPEAT_BEGIN) modifier.setX(maxX);
+      });
+    });
+
+    maxX = 0;
+    // Align time signatures
+    staves.forEach((stave) => {
+      const modifiers = stave.getModifiers(StaveModifierPosition.BEGIN, Category.TimeSignature);
+      modifiers.forEach((modifier) => {
+        if (modifier.getX() > maxX) maxX = modifier.getX();
+      });
+    });
+    staves.forEach((stave) => {
+      const modifiers = stave.getModifiers(StaveModifierPosition.BEGIN, Category.TimeSignature);
+      modifiers.forEach((modifier) => {
+        modifier.setX(maxX);
+      });
+    });
   }
 }

--- a/src/system.ts
+++ b/src/system.ts
@@ -185,6 +185,7 @@ export class System extends Element {
     let y = this.options.y;
     let startX = 0;
     let allVoices: Voice[] = [];
+    let allStaves: Stave[] = [];
     const debugNoteMetricsYs: { y: number; voice: Voice }[] = [];
 
     // Join the voices for each stave.
@@ -199,6 +200,7 @@ export class System extends Element {
         y += 15;
       }
       allVoices = allVoices.concat(part.voices);
+      allStaves = allStaves.concat(part.stave);
 
       startX = Math.max(startX, part.stave.getNoteStartX());
     });
@@ -225,6 +227,7 @@ export class System extends Element {
     this.debugNoteMetricsYs = debugNoteMetricsYs;
     this.lastY = y;
     this.boundingBox = new BoundingBox(this.options.x, this.options.y, this.options.width, this.lastY - this.options.y);
+    Stave.formatBegModifiers(allStaves);
   }
 
   /** Render the system. */

--- a/tests/auto_beam_formatting_tests.ts
+++ b/tests/auto_beam_formatting_tests.ts
@@ -11,6 +11,7 @@ import { concat, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Beam } from '../src/beam';
 import { EasyScore } from '../src/easyscore';
 import { Fraction } from '../src/fraction';
+import { Stave } from '../src/stave';
 import { Stem } from '../src/stem';
 import { StemmableNote } from '../src/stemmablenote';
 
@@ -433,6 +434,7 @@ function autoOddBeamGroups(options: TestOptions): void {
   ];
 
   f.Formatter().formatToStave([voice1], stave1).formatToStave([voice2], stave2).formatToStave([voice3], stave3);
+  Stave.formatBegModifiers([stave1, stave2, stave3]);
 
   f.draw();
 
@@ -467,6 +469,7 @@ function customBeamGroups(options: TestOptions): void {
   ];
 
   f.Formatter().formatToStave([voice1], stave1).formatToStave([voice2], stave2).formatToStave([voice3], stave3);
+  Stave.formatBegModifiers([stave1, stave2, stave3]);
 
   f.draw();
 

--- a/tests/easyscore_tests.ts
+++ b/tests/easyscore_tests.ts
@@ -26,6 +26,7 @@ const EasyScoreTests = {
     test('Options', options);
     const run = VexFlowTests.runTests;
     run('Draw Basic', drawBasicTest);
+    run('Draw Different KeySignature', drawDiffKeysig);
     run('Draw Basic Muted', drawBasicMutedTest);
     run('Draw Basic Harmonic', drawBasicHarmonicTest);
     run('Draw Basic Slash', drawBasicSlashTest);
@@ -213,6 +214,36 @@ function drawBasicTest(options: TestOptions): void {
       voices: [voice(notes('c#3/q, cn3/q, bb3/q, d##3/q', { clef: 'bass' }))],
     })
     .addClef('bass');
+  system.addConnector().setType(StaveConnector.type.BRACKET);
+
+  f.draw();
+  expect(0);
+}
+
+function drawDiffKeysig(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 600, 350);
+  const score = f.EasyScore();
+  const system = f.System();
+
+  const { voice, notes } = createShortcuts(score);
+
+  system
+    .addStave({
+      voices: [
+        voice(notes('(d4 e4 g4)/q, c4/q, c4/q/r, c4/q', { stem: 'down' })),
+        voice(notes('c5/h., c5/q', { stem: 'up' })),
+      ],
+    })
+    .addClef('treble')
+    .addTimeSignature('4/4')
+    .addKeySignature('D');
+
+  system
+    .addStave({
+      voices: [voice(notes('c#3/q, cn3/q, bb3/q, d##3/q', { clef: 'bass' }))],
+    })
+    .addClef('bass')
+    .addTimeSignature('4/4');
   system.addConnector().setType(StaveConnector.type.BRACKET);
 
   f.draw();


### PR DESCRIPTION
fixes #1389
fixes #1359

Beginnig stave modifiers now formated automaticaly if `System` is used, otherwise they can be aligned as shown in `auto_beam_formated_test`.

New test added to show the results.
**EasyScore Draw_Different_KeySignature** (bravura)
![EasyScore Draw_Different_KeySignature Bravura](https://user-images.githubusercontent.com/22865285/168494806-6085cb9a-8476-4b46-a433-2e4c7bed2eb5.png)


