### PR TITLE
SVG paths with 3 decimal places of precision.

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -250,6 +250,14 @@ export class Flow {
     return fonts.map((font) => font.getName());
   }
 
+  static get GLYPH_PRECISION(): number {
+    return Tables.GLYPH_PRECISION;
+  }
+
+  static set GLYPH_PRECISION(precision: number) {
+    Tables.GLYPH_PRECISION = precision;
+  }
+
   static get SOFTMAX_FACTOR(): number {
     return Tables.SOFTMAX_FACTOR;
   }

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -250,12 +250,12 @@ export class Flow {
     return fonts.map((font) => font.getName());
   }
 
-  static get GLYPH_PRECISION(): number {
-    return Tables.GLYPH_PRECISION;
+  static get RENDER_PRECISION_PLACES(): number {
+    return Tables.RENDER_PRECISION_PLACES;
   }
 
-  static set GLYPH_PRECISION(precision: number) {
-    Tables.GLYPH_PRECISION = precision;
+  static set RENDER_PRECISION_PLACES(precision: number) {
+    Tables.RENDER_PRECISION_PLACES = precision;
   }
 
   static get SOFTMAX_FACTOR(): number {

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -102,26 +102,24 @@ class GlyphCache {
 
 class GlyphOutline {
   private i: number = 0;
+  private precision = 1;
 
   constructor(private outline: number[], private originX: number, private originY: number, private scale: number) {
     // Automatically assign private properties: this.outline, this.originX, this.originY, and this.scale.
+    this.precision = Math.pow(10, Tables.RENDER_PRECISION_PLACES);
   }
 
   done(): boolean {
     return this.i >= this.outline.length;
   }
   next(): number {
-    return Math.round((this.outline[this.i++] * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION);
+    return Math.round((this.outline[this.i++] * this.precision) / this.precision);
   }
   nextX(): number {
-    return (
-      Math.round((this.originX + this.outline[this.i++] * this.scale) * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION
-    );
+    return Math.round((this.originX + this.outline[this.i++] * this.scale) * this.precision) / this.precision;
   }
   nextY(): number {
-    return (
-      Math.round((this.originY - this.outline[this.i++] * this.scale) * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION
-    );
+    return Math.round((this.originY - this.outline[this.i++] * this.scale) * this.precision) / this.precision;
   }
 
   static parse(str: string): number[] {

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -8,6 +8,7 @@ import { Font, FontGlyph } from './font';
 import { RenderContext } from './rendercontext';
 import { Stave } from './stave';
 import { Stem } from './stem';
+import { Tables } from './tables';
 import { Category } from './typeguard';
 import { defined, RuntimeError } from './util';
 
@@ -110,13 +111,17 @@ class GlyphOutline {
     return this.i >= this.outline.length;
   }
   next(): number {
-    return Math.round((this.outline[this.i++] * 100) / 100);
+    return Math.round((this.outline[this.i++] * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION);
   }
   nextX(): number {
-    return Math.round((this.originX + this.outline[this.i++] * this.scale) * 100) / 100;
+    return (
+      Math.round((this.originX + this.outline[this.i++] * this.scale) * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION
+    );
   }
   nextY(): number {
-    return Math.round((this.originY - this.outline[this.i++] * this.scale) * 100) / 100;
+    return (
+      Math.round((this.originY - this.outline[this.i++] * this.scale) * Tables.GLYPH_PRECISION) / Tables.GLYPH_PRECISION
+    );
   }
 
   static parse(str: string): number[] {

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -110,13 +110,13 @@ class GlyphOutline {
     return this.i >= this.outline.length;
   }
   next(): number {
-    return this.outline[this.i++];
+    return Math.round((this.outline[this.i++] * 100) / 100);
   }
   nextX(): number {
-    return this.originX + this.outline[this.i++] * this.scale;
+    return Math.round((this.originX + this.outline[this.i++] * this.scale) * 100) / 100;
   }
   nextY(): number {
-    return this.originY - this.outline[this.i++] * this.scale;
+    return Math.round((this.originY - this.outline[this.i++] * this.scale) * 100) / 100;
   }
 
   static parse(str: string): number[] {

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -559,11 +559,11 @@ const ornaments: Record<string, { code: string }> = {
 };
 
 export class Tables {
-  static GLYPH_PRECISION = 100;
   static SOFTMAX_FACTOR = 100;
   static STEM_WIDTH = 1.5;
   static STEM_HEIGHT = 35;
   static STAVE_LINE_THICKNESS = 1;
+  static RENDER_PRECISION_PLACES = 3;
   static RESOLUTION = RESOLUTION;
 
   /**

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -559,6 +559,7 @@ const ornaments: Record<string, { code: string }> = {
 };
 
 export class Tables {
+  static GLYPH_PRECISION = 100;
   static SOFTMAX_FACTOR = 100;
   static STEM_WIDTH = 1.5;
   static STEM_HEIGHT = 35;


### PR DESCRIPTION
fixes #1152 

SVG paths with 2 decimals, all the tests have minimal visual differences, see example below.

![Articulation Articulation___Vertical_Placement Bravura](https://user-images.githubusercontent.com/22865285/170721849-a2069c7b-3c98-453e-a7f7-a2769b6b5cbd.png)
![Articulation Articulation___Vertical_Placement Bravura_current](https://user-images.githubusercontent.com/22865285/170721854-f14a1c21-c46b-4439-9a0d-2787be3a2141.png)
![Articulation Articulation___Vertical_Placement Bravura_reference](https://user-images.githubusercontent.com/22865285/170721855-b50737cd-34e3-4050-99e7-a43b52282ebf.png)
s