### PR TITLE
minor style fixes

### DIFF
--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -85,11 +85,11 @@ export class BarNote extends Note {
   draw(): void {
     const ctx = this.checkContext();
     L('Rendering bar line at: ', this.getAbsoluteX());
-    if (this.style) this.applyStyle(ctx);
+    this.applyStyle(ctx);
     const barline = new Barline(this.type);
     barline.setX(this.getAbsoluteX());
     barline.draw(this.checkStave());
-    if (this.style) this.restoreStyle(ctx);
+    this.restoreStyle(ctx);
     this.setRendered();
   }
 }

--- a/src/element.ts
+++ b/src/element.ts
@@ -143,7 +143,7 @@ export abstract class Element {
    * element.drawWithStyle();
    * ```
    */
-  setStyle(style: ElementStyle): this {
+  setStyle(style: ElementStyle | undefined): this {
     this.style = style;
     return this;
   }

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -146,7 +146,7 @@ export class NoteHead extends Note {
       this.stem_down_x_offset = noteStruct.stem_down_x_offset || 0;
     }
 
-    this.style = noteStruct.style;
+    this.setStyle(noteStruct.style);
     this.slashed = noteStruct.slashed || false;
 
     this.render_options = {
@@ -275,9 +275,7 @@ export class NoteHead extends Note {
     const stem_direction = this.stem_direction;
     const glyph_font_scale = this.render_options.glyph_font_scale;
 
-    if (this.style) {
-      this.applyStyle(ctx);
-    }
+    this.applyStyle(ctx);
 
     const categorySuffix = `${this.glyph_code}Stem${stem_direction === Stem.UP ? 'Up' : 'Down'}`;
     if (this.noteType === 's') {
@@ -289,8 +287,6 @@ export class NoteHead extends Note {
       });
     }
 
-    if (this.style) {
-      this.restoreStyle(ctx);
-    }
+    this.restoreStyle(ctx);
   }
 }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -251,7 +251,7 @@ export class Stave extends Element {
       fillStyle: this.options.fill_style,
       strokeStyle: this.options.fill_style, // yes, this is correct for legacy compatibility
       lineWidth: Tables.STAVE_LINE_THICKNESS,
-      ...this.style,
+      ...super.getStyle(),
     };
   }
 

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -405,7 +405,6 @@ export class StaveNote extends StemmableNote {
   protected dot_shiftY: number;
   protected use_default_head_x: boolean;
   protected ledgerLineStyle: ElementStyle;
-  protected flagStyle?: ElementStyle;
   private _noteHeads: NoteHead[];
   // Sorted variant of keyProps used internally
   private sortedKeyProps: { keyProps: KeyProps; index: number }[] = [];
@@ -868,10 +867,10 @@ export class StaveNote extends StemmableNote {
   }
 
   setFlagStyle(style: ElementStyle): void {
-    this.flagStyle = style;
+    this.flag?.setStyle(style);
   }
   getFlagStyle(): ElementStyle | undefined {
-    return this.flagStyle;
+    return this.flag?.getStyle();
   }
 
   // Sets the notehead at `index` to the provided coloring `style`.
@@ -1155,9 +1154,7 @@ export class StaveNote extends StemmableNote {
             (this.flag?.getMetrics().y_shift ?? 0) * (1 - this.getStaveNoteScale());
 
       // Draw the Flag
-      this.applyStyle(ctx, this.getFlagStyle());
       this.flag?.render(ctx, flagX, flagY);
-      this.restoreStyle(ctx, this.getFlagStyle());
     }
   }
 


### PR DESCRIPTION
- Remove unneccesary check of `this.style!=undefined` before calling `applyStyle` / `restoreStyle` this already checked within these functions.
- Allow ´setStyle´ to also accept `undefined`
- Access `this.style` through `set/getStyle`function
- `flagStyle` not required, `flag` contains its own `ElementStyle`
