### PR TITLE
Question: Remove assignment of `fillStyle` and `strokeStyle` in tests?

### DIFF
--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -106,8 +106,7 @@ function lyrics(options: TestOptions): void {
 function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial, sans-serif';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -132,8 +131,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
 function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string) => new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic');
@@ -170,8 +168,7 @@ function styling(options: TestOptions, contextBuilder: ContextBuilder): void {
 function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -197,8 +194,7 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
 
 function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
+
   ctx.setFont(Font.SANS_SERIF, FONT_SIZE);
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -239,8 +235,7 @@ function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
 }
 function placement(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 750, 300);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string, fontSize: number, vj: number) =>
@@ -304,8 +299,7 @@ function placement(options: TestOptions, contextBuilder: ContextBuilder): void {
 function bottom(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string) =>
@@ -325,8 +319,7 @@ function bottom(options: TestOptions, contextBuilder: ContextBuilder): void {
 function bottomWithBeam(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
 
   const notes = [
@@ -354,8 +347,6 @@ function bottomWithBeam(options: TestOptions, contextBuilder: ContextBuilder): v
 function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 650, 950);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)
@@ -382,8 +373,6 @@ function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilde
 function justificationStemDown(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 650, 1000);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -182,8 +182,7 @@ function drawFermata(options: TestOptions): void {
 
 function verticalPlacement(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 750, 300);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   const staveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
   const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
 

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -39,8 +39,7 @@ const bendWithPhrase = (phrase: BendPhrase[]) => new Bend('', false, phrase);
 function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -132,8 +131,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
   const ctx = contextBuilder(options.elementId, 500, 240);
 
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.setFont('10pt Arial');
 
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
@@ -185,8 +183,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
 function bendPhrase(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = Font.SIZE + 'pt ' + Font.SANS_SERIF; // Optionally use constants defined in Font.
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -56,8 +56,6 @@ function withModifiers(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 750, 580);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], y: number) {
     const notes = [
@@ -150,8 +148,6 @@ function fontSize(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 750, 580);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], y: number) {
     const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble');
@@ -248,8 +244,6 @@ function kern(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 650 * 1.5, 650);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], y: number) {
     const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
@@ -305,8 +299,6 @@ function top(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 650 * 1.5, 650);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(c1: ChordSymbol, c2: ChordSymbol, y: number) {
     const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
@@ -358,8 +350,6 @@ function topJustify(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 500 * 1.5, 680);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chord1: ChordSymbol, chord2: ChordSymbol, y: number) {
     const stave = new Stave(10, y, 450).addClef('treble').setContext(ctx).draw();
@@ -408,8 +398,6 @@ function bottom(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 600 * 1.5, 230);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], y: number) {
     const stave = new Stave(10, y, 400).addClef('treble').setContext(ctx).draw();
@@ -438,8 +426,6 @@ function bottomStemDown(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 600 * 1.5, 330);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], y: number) {
     // Helper function to create a StaveNote with a ChordSymbol and the stem pointing down.
@@ -471,8 +457,6 @@ function doubleBottom(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 600 * 1.5, 260);
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   function draw(chords: ChordSymbol[], chords2: ChordSymbol[], y: number) {
     // Helper function to create a StaveNote with two ChordSymbols attached.

--- a/tests/dot_tests.ts
+++ b/tests/dot_tests.ts
@@ -39,8 +39,6 @@ function showOneNote(note1: StaveNote, stave: Stave, ctx: RenderContext, x: numb
 
 function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 1000, 240);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(10, 10, 975);
   stave.setContext(ctx);
@@ -105,8 +103,6 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 
 function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 750, 300);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(30, 45, 700).setContext(ctx).draw();
 

--- a/tests/notehead_tests.ts
+++ b/tests/notehead_tests.ts
@@ -39,8 +39,7 @@ function setContextStyle(ctx: RenderContext): void {
   // ctx.scale(0.9, 0.9);
   // ctx.scale(2.0, 2.0);
   ctx.scale(1.8, 1.8);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
 }
 

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -283,8 +283,6 @@ function jazzOrnaments(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 950, 400);
   const ctx = f.getContext();
   ctx.scale(1, 1);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   const xStart = 10;
   const width = 300;

--- a/tests/rests_tests.ts
+++ b/tests/rests_tests.ts
@@ -50,8 +50,7 @@ function setupContext(
   // context is SVGContext or CanvasRenderingContext2D (native) or CanvasContext (only if Renderer.USE_CANVAS_PROXY is true).
   const context = contextBuilder(options.elementId, width, height);
   context.scale(0.9, 0.9);
-  context.fillStyle = '#221';
-  context.strokeStyle = '#221';
+
   context.font = '10pt Arial';
 
   const stave = new Stave(10, 30, width).addClef('treble').addTimeSignature('4/4').setContext(context).draw();

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -525,8 +525,6 @@ function drawBass(options: TestOptions, contextBuilder: ContextBuilder): void {
 function displacements(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 700, 155);
   ctx.scale(0.9, 0.9);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
 
   const stave = new Stave(10, 10, 675);
   stave.setContext(ctx);
@@ -865,8 +863,6 @@ function drawBeamStyles(options: TestOptions, contextBuilder: ContextBuilder): v
 function dotsAndFlagsStemUp(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 800, 150);
   ctx.scale(1.0, 1.0);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(10, 10, 975);
 
@@ -899,8 +895,6 @@ function dotsAndFlagsStemUp(options: TestOptions, contextBuilder: ContextBuilder
 function dotsAndFlagsStemDown(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 800, 160);
   ctx.scale(1.0, 1.0);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(10, 10, 975);
 
@@ -932,8 +926,6 @@ function dotsAndFlagsStemDown(options: TestOptions, contextBuilder: ContextBuild
 function dotsAndBeamsUp(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 800, 150);
   ctx.scale(1.0, 1.0);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(10, 10, 975);
 
@@ -968,8 +960,6 @@ function dotsAndBeamsUp(options: TestOptions, contextBuilder: ContextBuilder): v
 function dotsAndBeamsDown(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 800, 160);
   ctx.scale(1.0, 1.0);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
 
   const stave = new Stave(10, 10, 975);
 

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -110,8 +110,7 @@ function stave(options: TestOptions): void {
  */
 function tab(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 140);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph();
   stave.getModifiers()[2].setStyle(FS('blue'));

--- a/tests/tabslide_tests.ts
+++ b/tests/tabslide_tests.ts
@@ -50,8 +50,7 @@ function setupContext(options: TestOptions, width?: number): { context: RenderCo
   // eslint-disable-next-line
   const context = options.contextBuilder!(options.elementId, 350, 140);
   context.scale(0.9, 0.9);
-  context.fillStyle = '#221';
-  context.strokeStyle = '#221';
+
   context.font = '10pt Arial';
   const stave = new TabStave(10, 10, width || 350).addTabGlyph().setContext(context).draw();
 

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -41,8 +41,7 @@ const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 function setupContext(options: TestOptions, w: number = 0, h: number = 0): { context: RenderContext; stave: TabStave } {
   // eslint-disable-next-line
   const context = options.contextBuilder!(options.elementId, w || 350, h || 160);
-  context.fillStyle = '#221';
-  context.strokeStyle = '#221';
+
   context.setFont('Arial', VexFlowTests.Font.size);
 
   const stave = new TabStave(10, 10, w || 350).addTabGlyph().setContext(context).draw();

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -26,8 +26,7 @@ const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -57,8 +56,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
 function harsh(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  ctx.fillStyle = '#221';
-  ctx.strokeStyle = '#221';
+
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 
@@ -83,8 +81,7 @@ function harsh(options: TestOptions, contextBuilder: ContextBuilder): void {
 function withBend(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.3, 1.3);
-  ctx.setFillStyle('#221');
-  ctx.setStrokeStyle('#221');
+
   ctx.setFont(Font.SANS_SERIF, VexFlowTests.Font.size);
   const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
 


### PR DESCRIPTION
addresses #1452 

A lot of minor visual differences. I will copy the bravura ones.