### PR TITLE
issue 1469 - get top Y for top annotation

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -284,7 +284,8 @@ export class Annotation extends Modifier {
       const yb = stave.getYForBottomText(this.text_line);
       y = yt + (yb - yt) / 2 + text_height / 2;
     } else if (this.verticalJustification === AnnotationVerticalJustify.TOP) {
-      y = note.getYs()[0] - (this.text_line + 1) * Tables.STAVE_LINE_DISTANCE;
+      const yAr = note.getYs();
+      y = yAr[yAr.length - 1] - (this.text_line + 1) * Tables.STAVE_LINE_DISTANCE;
       if (has_stem && stemDirection === Stem.UP) {
         // If the stem is above the stave already, go with default line width vs. actual
         // since the lines between don't really matter.

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -730,7 +730,9 @@ export class ChordSymbol extends Modifier {
       }
     } else {
       // (this.vertical === VerticalJustify.TOP)
-      y = Math.min(stave.getYForTopText(this.text_line), note.getYs()[0] - 10);
+      const yAr = note.getYs();
+      const topY = yAr[yAr.length - 1];
+      y = Math.min(stave.getYForTopText(this.text_line), topY - 10);
       if (hasStem) {
         const stem_ext = note.checkStem().getExtents();
         const spacing = stave.getSpacingBetweenLines();

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -360,7 +360,7 @@ function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilde
     const notes = [
       staveNote({ keys: ['c/3'], duration: 'q' }).addModifier(annotation('Text', 1, v), 0),
       staveNote({ keys: ['c/4'], duration: 'q' }).addModifier(annotation('Text', 2, v), 0),
-      staveNote({ keys: ['c/5'], duration: 'q' }).addModifier(annotation('Text', 3, v), 0),
+      staveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'q' }).addModifier(annotation('Text', 3, v), 0),
       staveNote({ keys: ['c/6'], duration: 'q' }).addModifier(annotation('Text', 4, v), 0),
     ];
 
@@ -384,7 +384,10 @@ function justificationStemDown(options: TestOptions, contextBuilder: ContextBuil
     const stave = new Stave(10, (v - 1) * 150 + 40, 400).addClef('treble').setContext(ctx).draw();
     const notes = [
       staveNote({ keys: ['c/3'], duration: 'q', stem_direction: -1 }).addModifier(annotation('Text', 1, v), 0),
-      staveNote({ keys: ['c/4'], duration: 'q', stem_direction: -1 }).addModifier(annotation('Text', 2, v), 0),
+      staveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'q', stem_direction: -1 }).addModifier(
+        annotation('Text', 2, v),
+        0
+      ),
       staveNote({ keys: ['c/5'], duration: 'q', stem_direction: -1 }).addModifier(annotation('Text', 3, v), 0),
       staveNote({ keys: ['c/6'], duration: 'q', stem_direction: -1 }).addModifier(annotation('Text', 4, v), 0),
     ];

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -300,11 +300,15 @@ function top(options: TestOptions): void {
   const ctx = f.getContext();
   ctx.scale(1.5, 1.5);
 
+  // Helper function for creating StaveNotes.
+  const note = (factory: Factory, keys: string[], duration: string, chordSymbol: ChordSymbol, direction: number) =>
+    factory.StaveNote({ keys, duration, stem_direction: direction }).addModifier(chordSymbol, 0);
+
   function draw(c1: ChordSymbol, c2: ChordSymbol, y: number) {
     const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
     const notes = [
-      note(f, ['e/4', 'a/4', 'd/5'], 'h', c1).addModifier(new Accidental('b'), 0),
-      note(f, ['c/4', 'e/4', 'b/4'], 'h', c2),
+      note(f, ['e/4', 'a/4', 'd/5'], 'h', c1, 1).addModifier(new Accidental('b'), 0),
+      note(f, ['c/5', 'e/5', 'c/6'], 'h', c2, -1),
     ];
     const score = f.EasyScore();
     const voice = score.voice(notes, { time: '4/4' });


### PR DESCRIPTION
Small change, when annotation placement is 'top', get the final entry in the `note.Ys()`, since that will have the (numerically lowest, screen highest) Y value.  Previously, it was always getting entry [0] which is the numerically highest, staff-lowest pitch.

old:
![image](https://user-images.githubusercontent.com/5438280/201823038-07dfaf37-c36a-44a6-9d01-652c1e0d26f6.png)

new test case:
![image](https://user-images.githubusercontent.com/5438280/201823141-252066b3-d5e6-45c7-be67-5f56b8f6e1b1.png)

I am upgrading my Ubuntu VM right now so I can't do visual diff.  But this will only affect cases with multiple pitch keys and stem up, and we didn't have any test cases for that.
