### PR TITLE
fix pitch-sorting

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -284,8 +284,8 @@ export class Annotation extends Modifier {
       const yb = stave.getYForBottomText(this.text_line);
       y = yt + (yb - yt) / 2 + text_height / 2;
     } else if (this.verticalJustification === AnnotationVerticalJustify.TOP) {
-      const yAr = note.getYs();
-      y = yAr[yAr.length - 1] - (this.text_line + 1) * Tables.STAVE_LINE_DISTANCE;
+      const topY = Math.min(...note.getYs());
+      y = topY - (this.text_line + 1) * Tables.STAVE_LINE_DISTANCE;
       if (has_stem && stemDirection === Stem.UP) {
         // If the stem is above the stave already, go with default line width vs. actual
         // since the lines between don't really matter.

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -730,8 +730,7 @@ export class ChordSymbol extends Modifier {
       }
     } else {
       // (this.vertical === VerticalJustify.TOP)
-      const yAr = note.getYs();
-      const topY = yAr[yAr.length - 1];
+      const topY = Math.min(...note.getYs());
       y = Math.min(stave.getYForTopText(this.text_line), topY - 10);
       if (hasStem) {
         const stem_ext = note.checkStem().getExtents();


### PR DESCRIPTION
Take smallest Y, which is not always last entry for Tab note.  This is a bug introduced in a recent (earlier today!) PR.  The visual diffs only show fixes, and Harmonics test in annotation looks good.