### PR TITLE
Refactor FontMetrics: stringnumber

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -1,3 +1,4 @@
+import { StringNumberMetrics } from './stringnumber';
 import { defined } from './util';
 
 export interface FontInfo {
@@ -42,6 +43,7 @@ export interface FontMetrics extends Record<string, any> {
   tremolo?: Record<string, Record<string, number>>;
   // Not specified in bravura_metrics.ts or gonville_metrics.ts.
   noteHead?: Record<string, Record<string, number>>;
+  stringNumber?: StringNumberMetrics;
   // eslint-disable-next-line
   glyphs: Record<string, Record<string, any>>;
 }

--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -203,6 +203,13 @@ export const BravuraMetrics = {
     },
   },
 
+  stringNumber: {
+    verticalPadding: 8,
+    stemPadding: 2,
+    leftPadding: 5,
+    rightPadding: 6,
+  },
+
   // Values under here are used by the Glyph class to reposition and rescale
   // glyphs based on their category. This should be the first stop for
   // custom font glyph repositioning.
@@ -243,12 +250,6 @@ export const BravuraMetrics = {
       ornamentTurnSlash: {
         scale: 1.2,
       },
-    },
-    stringNumber: {
-      verticalPadding: 8,
-      stemPadding: 2,
-      leftPadding: 5,
-      rightPadding: 6,
     },
     stroke: {
       arrowheadBlackDown: {

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -193,6 +193,13 @@ export const GonvilleMetrics = {
     },
   },
 
+  stringNumber: {
+    verticalPadding: 8,
+    stemPadding: 2,
+    leftPadding: 5,
+    rightPadding: 6,
+  },
+
   glyphs: {
     flag: {
       shiftX: -0.08,
@@ -223,12 +230,6 @@ export const GonvilleMetrics = {
       flag128thUp: {
         shiftY: -22,
       },
-    },
-    stringNumber: {
-      verticalPadding: 8,
-      stemPadding: 2,
-      leftPadding: 5,
-      rightPadding: 6,
     },
     textNote: {
       point: 40,

--- a/src/fonts/leland_metrics.ts
+++ b/src/fonts/leland_metrics.ts
@@ -199,6 +199,13 @@ export const LelandMetrics = {
     },
   },
 
+  stringNumber: {
+    verticalPadding: 8,
+    stemPadding: 2,
+    leftPadding: 5,
+    rightPadding: 6,
+  },
+
   // Values under here are used by the Glyph class to reposition and rescale
   // glyphs based on their category. This should be the first stop for
   // custom font glyph repositioning.
@@ -239,12 +246,6 @@ export const LelandMetrics = {
       ornamentTurnSlash: {
         scale: 1.2,
       },
-    },
-    stringNumber: {
-      verticalPadding: 8,
-      stemPadding: 2,
-      leftPadding: 5,
-      rightPadding: 6,
     },
     stroke: {
       arrowheadBlackDown: {

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -207,6 +207,13 @@ export const PetalumaMetrics = {
     },
   },
 
+  stringNumber: {
+    verticalPadding: 8,
+    stemPadding: 2,
+    leftPadding: 5,
+    rightPadding: 6,
+  },
+
   // Values under here are used by the Glyph class to reposition and rescale
   // glyphs based on their category. This should be the first stop for
   // custom font glyph repositioning.
@@ -271,12 +278,6 @@ export const PetalumaMetrics = {
       ornamentTurnSlash: {
         scale: 1.2,
       },
-    },
-    stringNumber: {
-      verticalPadding: 8,
-      stemPadding: 2,
-      leftPadding: 5,
-      rightPadding: 6,
     },
     stroke: {
       arrowheadBlackDown: {

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -15,6 +15,13 @@ import { Tables } from './tables';
 import { Category, isStaveNote, isStemmableNote } from './typeguard';
 import { RuntimeError } from './util';
 
+export interface StringNumberMetrics {
+  verticalPadding: number;
+  stemPadding: number;
+  leftPadding: number;
+  rightPadding: number;
+}
+
 export class StringNumber extends Modifier {
   static get CATEGORY(): string {
     return Category.StringNumber;
@@ -27,9 +34,15 @@ export class StringNumber extends Modifier {
     style: FontStyle.NORMAL,
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static get metrics(): any {
-    return Tables.currentMusicFont().getMetrics().glyphs.stringNumber;
+  static get metrics(): StringNumberMetrics {
+    return (
+      Tables.currentMusicFont().getMetrics().stringNumber ?? {
+        verticalPadding: 0,
+        stemPadding: 0,
+        leftPadding: 0,
+        rightPadding: 0,
+      }
+    );
   }
 
   // ## Static Methods


### PR DESCRIPTION
In order to facilitate the review of #1486 this PR includes only the changes related to `StringNumber`:
- definition of `StringNumberMetrics`
- movement of these  metrics outside the `glyphs` section.

It is a step to address #1485