### PR TITLE
Refactor FontMetrics: chordsymbol

### DIFF
--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -18,7 +18,7 @@ import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { TextFormatter } from './textformatter';
 import { Category, isStemmableNote } from './typeguard';
-import { log } from './util';
+import { log, RuntimeError } from './util';
 
 // To enable logging for this class. Set `Vex.Flow.ChordSymbol.DEBUG` to `true`.
 // eslint-disable-next-line
@@ -35,6 +35,25 @@ export interface ChordSymbolBlock {
   vAlign: boolean;
   width: number;
   glyph?: Glyph;
+}
+
+export interface ChordSymbolGlyphMetrics {
+  leftSideBearing: number;
+  advanceWidth: number;
+  yOffset: number;
+}
+
+export interface ChordSymbolMetrics {
+  global: {
+    superscriptOffset: number;
+    subscriptOffset: number;
+    kerningOffset: number;
+    lowerKerningText: string[];
+    upperKerningText: string[];
+    spacing: number;
+    superSubRatio: number;
+  };
+  glyphs: Record<string, ChordSymbolGlyphMetrics>;
 }
 
 export enum ChordSymbolHorizontalJustify {
@@ -104,10 +123,9 @@ export class ChordSymbol extends Modifier {
     return ChordSymbol.noFormat;
   }
 
-  // eslint-disable-next-line
-  static getMetricForGlyph(glyphCode: string): any {
-    if (ChordSymbol.metrics[glyphCode]) {
-      return ChordSymbol.metrics[glyphCode];
+  static getMetricForGlyph(glyphCode: string): ChordSymbolGlyphMetrics | undefined {
+    if (ChordSymbol.metrics.glyphs[glyphCode]) {
+      return ChordSymbol.metrics.glyphs[glyphCode];
     }
     return undefined;
   }
@@ -224,9 +242,11 @@ export class ChordSymbol extends Modifier {
 
   static readonly symbolModifiers = SymbolModifiers;
 
-  // eslint-disable-next-line
-  static get metrics(): any {
-    return Tables.currentMusicFont().getMetrics().glyphs.chordSymbol;
+  static get metrics(): ChordSymbolMetrics {
+    const chordSymbol = Tables.currentMusicFont().getMetrics().chordSymbol;
+
+    if (!chordSymbol) throw new RuntimeError('BadMetrics', `chordSymbol missing`);
+    return chordSymbol;
   }
 
   static get lowerKerningText(): string[] {

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,3 +1,4 @@
+import { ChordSymbolMetrics } from './chordsymbol';
 import { StringNumberMetrics } from './stringnumber';
 import { defined } from './util';
 
@@ -43,6 +44,7 @@ export interface FontMetrics extends Record<string, any> {
   tremolo?: Record<string, Record<string, number>>;
   // Not specified in bravura_metrics.ts or gonville_metrics.ts.
   noteHead?: Record<string, Record<string, number>>;
+  chordSymbol?: ChordSymbolMetrics;
   stringNumber?: StringNumberMetrics;
   // eslint-disable-next-line
   glyphs: Record<string, Record<string, any>>;

--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -19,6 +19,89 @@ export const BravuraMetrics = {
     accidentalSpacing: 3,
   },
 
+  chordSymbol: {
+    global: {
+      superscriptOffset: -400,
+      subscriptOffset: 300,
+      kerningOffset: -250,
+      lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
+      upperKerningText: ['A', 'L'],
+      spacing: 100,
+      superSubRatio: 0.66,
+    },
+    glyphs: {
+      csymDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymHalfDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymAugmented: {
+        leftSideBearing: 0,
+        advanceWidth: 530,
+        yOffset: 0,
+      },
+      csymParensLeftTall: {
+        leftSideBearing: -20,
+        advanceWidth: 184,
+        yOffset: 250,
+      },
+      csymParensRightTall: {
+        leftSideBearing: 0,
+        advanceWidth: 189,
+        yOffset: 250,
+      },
+      csymBracketLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 328,
+        yOffset: 0,
+      },
+      csymBracketRightTall: {
+        leftSideBearing: 1,
+        advanceWidth: 600,
+        yOffset: 0,
+      },
+      csymParensLeftVeryTall: {
+        leftSideBearing: 50,
+        advanceWidth: 121,
+        yOffset: 350,
+      },
+      csymParensRightVeryTall: {
+        leftSideBearing: 0,
+        advanceWidth: 111,
+        yOffset: 350,
+      },
+      csymDiagonalArrangementSlash: {
+        leftSideBearing: -1,
+        advanceWidth: 990,
+        yOffset: 0,
+      },
+      csymMinor: {
+        leftSideBearing: 0,
+        advanceWidth: 482,
+        yOffset: 0,
+      },
+      csymMajorSeventh: {
+        leftSideBearing: 200,
+        yOffset: 0,
+        advanceWidth: 600,
+      },
+      accidentalSharp: {
+        leftSideBearing: 20,
+        advanceWidth: 250,
+        yOffset: -302,
+      },
+      accidentalFlat: {
+        leftSideBearing: -20,
+        advanceWidth: 226,
+        yOffset: -184,
+      },
+    },
+  },
   clef: {
     default: {
       point: 32,
@@ -319,98 +402,47 @@ export const BravuraMetrics = {
       },
     },
     chordSymbol: {
-      global: {
-        superscriptOffset: -400,
-        subscriptOffset: 300,
-        kerningOffset: -250,
-        lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
-        upperKerningText: ['A', 'L'],
-        spacing: 100,
-        superSubRatio: 0.66,
-      },
       csymDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymHalfDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymAugmented: {
         scale: 1,
-        leftSideBearing: 0,
-        advanceWidth: 530,
-        yOffset: 0,
       },
       csymParensLeftTall: {
         scale: 0.8,
-        leftSideBearing: -20,
-        advanceWidth: 184,
-        yOffset: 250,
       },
       csymParensRightTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 189,
-        yOffset: 250,
       },
       csymBracketLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 328,
-        yOffset: 0,
       },
       csymBracketRightTall: {
         scale: 0.8,
-        leftSideBearing: 1,
-        advanceWidth: 600,
-        yOffset: 0,
       },
       csymParensLeftVeryTall: {
         scale: 0.9,
-        leftSideBearing: 50,
-        advanceWidth: 121,
-        yOffset: 350,
       },
       csymParensRightVeryTall: {
         scale: 0.9,
-        leftSideBearing: 0,
-        advanceWidth: 111,
-        yOffset: 350,
       },
       csymDiagonalArrangementSlash: {
         scale: 0.6,
-        leftSideBearing: -1,
-        advanceWidth: 990,
-        yOffset: 0,
       },
       csymMinor: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 482,
-        yOffset: 0,
       },
       csymMajorSeventh: {
         scale: 0.9,
-        leftSideBearing: 200,
-        yOffset: 0,
-        advanceWidth: 600,
       },
       accidentalSharp: {
         scale: 0.75,
-        leftSideBearing: 20,
-        advanceWidth: 250,
-        yOffset: -302,
       },
       accidentalFlat: {
         scale: 0.9,
-        leftSideBearing: -20,
-        advanceWidth: 226,
-        yOffset: -184,
       },
     },
     jazzOrnaments: {

--- a/src/fonts/gonville_metrics.ts
+++ b/src/fonts/gonville_metrics.ts
@@ -19,6 +19,90 @@ export const GonvilleMetrics = {
     accidentalSpacing: 3,
   },
 
+  chordSymbol: {
+    global: {
+      superscriptOffset: -400,
+      subscriptOffset: 300,
+      kerningOffset: -250,
+      lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
+      upperKerningText: ['A', 'L'],
+      spacing: 100,
+      superSubRatio: 0.66,
+    },
+    glyphs: {
+      csymDiminished: {
+        leftSideBearing: 0,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymHalfDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymAugmented: {
+        leftSideBearing: 0,
+        advanceWidth: 530,
+        yOffset: 0,
+      },
+      csymParensLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 155,
+        yOffset: 250,
+      },
+      csymParensRightTall: {
+        leftSideBearing: -40,
+        advanceWidth: 189,
+        yOffset: 250,
+      },
+      csymBracketLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 328,
+        yOffset: 0,
+      },
+      csymBracketRightTall: {
+        leftSideBearing: 1,
+        advanceWidth: 600,
+        yOffset: 0,
+      },
+      csymParensLeftVeryTall: {
+        leftSideBearing: 0,
+        advanceWidth: 121,
+        yOffset: 350,
+      },
+      csymParensRightVeryTall: {
+        leftSideBearing: 50,
+        advanceWidth: 111,
+        yOffset: 350,
+      },
+      csymDiagonalArrangementSlash: {
+        leftSideBearing: -1,
+        advanceWidth: 990,
+        yOffset: 0,
+      },
+      csymMinor: {
+        leftSideBearing: 0,
+        advanceWidth: 482,
+        yOffset: 0,
+      },
+      csymMajorSeventh: {
+        leftSideBearing: 200,
+        yOffset: 0,
+        advanceWidth: 600,
+      },
+      accidentalSharp: {
+        leftSideBearing: 40,
+        advanceWidth: 250,
+        yOffset: -402,
+      },
+      accidentalFlat: {
+        leftSideBearing: -50,
+        advanceWidth: 208,
+        yOffset: -184,
+      },
+    },
+  },
+
   clef: {
     default: {
       point: 40,
@@ -243,98 +327,47 @@ export const GonvilleMetrics = {
       minPadding: 2,
     },
     chordSymbol: {
-      global: {
-        superscriptOffset: -400,
-        subscriptOffset: 300,
-        kerningOffset: -250,
-        lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
-        upperKerningText: ['A', 'L'],
-        spacing: 100,
-        superSubRatio: 0.66,
-      },
       csymDiminished: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymHalfDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymAugmented: {
         scale: 1,
-        leftSideBearing: 0,
-        advanceWidth: 530,
-        yOffset: 0,
       },
       csymParensLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 155,
-        yOffset: 250,
       },
       csymParensRightTall: {
         scale: 0.8,
-        leftSideBearing: -40,
-        advanceWidth: 189,
-        yOffset: 250,
       },
       csymBracketLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 328,
-        yOffset: 0,
       },
       csymBracketRightTall: {
         scale: 0.8,
-        leftSideBearing: 1,
-        advanceWidth: 600,
-        yOffset: 0,
       },
       csymParensLeftVeryTall: {
         scale: 0.9,
-        leftSideBearing: 0,
-        advanceWidth: 121,
-        yOffset: 350,
       },
       csymParensRightVeryTall: {
         scale: 0.9,
-        leftSideBearing: 50,
-        advanceWidth: 111,
-        yOffset: 350,
       },
       csymDiagonalArrangementSlash: {
         scale: 0.6,
-        leftSideBearing: -1,
-        advanceWidth: 990,
-        yOffset: 0,
       },
       csymMinor: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 482,
-        yOffset: 0,
       },
       csymMajorSeventh: {
         scale: 0.9,
-        leftSideBearing: 200,
-        yOffset: 0,
-        advanceWidth: 600,
       },
       accidentalSharp: {
         scale: 0.75,
-        leftSideBearing: 40,
-        advanceWidth: 250,
-        yOffset: -402,
       },
       accidentalFlat: {
         scale: 0.95,
-        leftSideBearing: -50,
-        advanceWidth: 208,
-        yOffset: -184,
       },
     },
     jazzOrnaments: {

--- a/src/fonts/leland_metrics.ts
+++ b/src/fonts/leland_metrics.ts
@@ -15,6 +15,90 @@ export const LelandMetrics = {
     accidentalSpacing: 3,
   },
 
+  chordSymbol: {
+    global: {
+      superscriptOffset: -400,
+      subscriptOffset: 300,
+      kerningOffset: -250,
+      lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
+      upperKerningText: ['A', 'L'],
+      spacing: 100,
+      superSubRatio: 0.66,
+    },
+    glyphs: {
+      csymDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymHalfDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymAugmented: {
+        leftSideBearing: 0,
+        advanceWidth: 530,
+        yOffset: 0,
+      },
+      csymParensLeftTall: {
+        leftSideBearing: -20,
+        advanceWidth: 184,
+        yOffset: 250,
+      },
+      csymParensRightTall: {
+        leftSideBearing: 0,
+        advanceWidth: 189,
+        yOffset: 250,
+      },
+      csymBracketLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 328,
+        yOffset: 0,
+      },
+      csymBracketRightTall: {
+        leftSideBearing: 1,
+        advanceWidth: 600,
+        yOffset: 0,
+      },
+      csymParensLeftVeryTall: {
+        leftSideBearing: 50,
+        advanceWidth: 121,
+        yOffset: 350,
+      },
+      csymParensRightVeryTall: {
+        leftSideBearing: 0,
+        advanceWidth: 111,
+        yOffset: 350,
+      },
+      csymDiagonalArrangementSlash: {
+        leftSideBearing: -1,
+        advanceWidth: 990,
+        yOffset: 0,
+      },
+      csymMinor: {
+        leftSideBearing: 0,
+        advanceWidth: 482,
+        yOffset: 0,
+      },
+      csymMajorSeventh: {
+        leftSideBearing: 200,
+        yOffset: 0,
+        advanceWidth: 600,
+      },
+      accidentalSharp: {
+        leftSideBearing: 20,
+        advanceWidth: 250,
+        yOffset: -302,
+      },
+      accidentalFlat: {
+        leftSideBearing: -20,
+        advanceWidth: 226,
+        yOffset: -184,
+      },
+    },
+  },
+
   clef: {
     default: {
       point: 32,
@@ -315,98 +399,47 @@ export const LelandMetrics = {
       },
     },
     chordSymbol: {
-      global: {
-        superscriptOffset: -400,
-        subscriptOffset: 300,
-        kerningOffset: -250,
-        lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
-        upperKerningText: ['A', 'L'],
-        spacing: 100,
-        superSubRatio: 0.66,
-      },
       csymDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymHalfDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymAugmented: {
         scale: 1,
-        leftSideBearing: 0,
-        advanceWidth: 530,
-        yOffset: 0,
       },
       csymParensLeftTall: {
         scale: 0.8,
-        leftSideBearing: -20,
-        advanceWidth: 184,
-        yOffset: 250,
       },
       csymParensRightTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 189,
-        yOffset: 250,
       },
       csymBracketLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 328,
-        yOffset: 0,
       },
       csymBracketRightTall: {
         scale: 0.8,
-        leftSideBearing: 1,
-        advanceWidth: 600,
-        yOffset: 0,
       },
       csymParensLeftVeryTall: {
         scale: 0.9,
-        leftSideBearing: 50,
-        advanceWidth: 121,
-        yOffset: 350,
       },
       csymParensRightVeryTall: {
         scale: 0.9,
-        leftSideBearing: 0,
-        advanceWidth: 111,
-        yOffset: 350,
       },
       csymDiagonalArrangementSlash: {
         scale: 0.6,
-        leftSideBearing: -1,
-        advanceWidth: 990,
-        yOffset: 0,
       },
       csymMinor: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 482,
-        yOffset: 0,
       },
       csymMajorSeventh: {
         scale: 0.9,
-        leftSideBearing: 200,
-        yOffset: 0,
-        advanceWidth: 600,
       },
       accidentalSharp: {
         scale: 0.75,
-        leftSideBearing: 20,
-        advanceWidth: 250,
-        yOffset: -302,
       },
       accidentalFlat: {
         scale: 0.9,
-        leftSideBearing: -20,
-        advanceWidth: 226,
-        yOffset: -184,
       },
     },
     jazzOrnaments: {

--- a/src/fonts/petaluma_metrics.ts
+++ b/src/fonts/petaluma_metrics.ts
@@ -19,6 +19,89 @@ export const PetalumaMetrics = {
     accidentalSpacing: 3,
   },
 
+  chordSymbol: {
+    global: {
+      superscriptOffset: -400,
+      subscriptOffset: 300,
+      kerningOffset: -150,
+      lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
+      upperKerningText: ['L'],
+      spacing: 20,
+      superSubRatio: 0.73,
+    },
+    glyphs: {
+      csymDiminished: {
+        leftSideBearing: -95,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymHalfDiminished: {
+        leftSideBearing: -32,
+        advanceWidth: 506,
+        yOffset: 0,
+      },
+      csymAugmented: {
+        leftSideBearing: -25,
+        advanceWidth: 530,
+        yOffset: 0,
+      },
+      csymParensLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 155,
+        yOffset: 150,
+      },
+      csymParensRightTall: {
+        leftSideBearing: 40,
+        advanceWidth: 189,
+        yOffset: 150,
+      },
+      csymBracketLeftTall: {
+        leftSideBearing: 0,
+        advanceWidth: 328,
+        yOffset: 0,
+      },
+      csymBracketRightTall: {
+        leftSideBearing: 1,
+        advanceWidth: 600,
+        yOffset: 0,
+      },
+      csymParensLeftVeryTall: {
+        leftSideBearing: 0,
+        advanceWidth: 210,
+        yOffset: 250,
+      },
+      csymParensRightVeryTall: {
+        leftSideBearing: -100,
+        advanceWidth: 111,
+        yOffset: 250,
+      },
+      csymDiagonalArrangementSlash: {
+        leftSideBearing: -1,
+        advanceWidth: 990,
+        yOffset: 0,
+      },
+      csymMinor: {
+        leftSideBearing: 0,
+        advanceWidth: 482,
+        yOffset: 0,
+      },
+      csymMajorSeventh: {
+        leftSideBearing: 100,
+        yOffset: 0,
+        advanceWidth: 600,
+      },
+      accidentalSharp: {
+        leftSideBearing: 0,
+        advanceWidth: 425,
+        yOffset: -422,
+      },
+      accidentalFlat: {
+        leftSideBearing: -10,
+        advanceWidth: 228,
+        yOffset: -284,
+      },
+    },
+  },
   clef: {
     default: {
       point: 32,
@@ -344,98 +427,47 @@ export const PetalumaMetrics = {
       },
     },
     chordSymbol: {
-      global: {
-        superscriptOffset: -400,
-        subscriptOffset: 300,
-        kerningOffset: -150,
-        lowerKerningText: ['D', 'F', 'P', 'T', 'V', 'Y'],
-        upperKerningText: ['L'],
-        spacing: 20,
-        superSubRatio: 0.73,
-      },
       csymDiminished: {
         scale: 0.8,
-        leftSideBearing: -95,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymHalfDiminished: {
         scale: 0.8,
-        leftSideBearing: -32,
-        advanceWidth: 506,
-        yOffset: 0,
       },
       csymAugmented: {
         scale: 1,
-        leftSideBearing: -25,
-        advanceWidth: 530,
-        yOffset: 0,
       },
       csymParensLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 155,
-        yOffset: 150,
       },
       csymParensRightTall: {
         scale: 0.8,
-        leftSideBearing: 40,
-        advanceWidth: 189,
-        yOffset: 150,
       },
       csymBracketLeftTall: {
         scale: 0.8,
-        leftSideBearing: 0,
-        advanceWidth: 328,
-        yOffset: 0,
       },
       csymBracketRightTall: {
         scale: 0.8,
-        leftSideBearing: 1,
-        advanceWidth: 600,
-        yOffset: 0,
       },
       csymParensLeftVeryTall: {
         scale: 0.95,
-        leftSideBearing: 0,
-        advanceWidth: 210,
-        yOffset: 250,
       },
       csymParensRightVeryTall: {
         scale: 0.9,
-        leftSideBearing: -100,
-        advanceWidth: 111,
-        yOffset: 250,
       },
       csymDiagonalArrangementSlash: {
         scale: 0.6,
-        leftSideBearing: -1,
-        advanceWidth: 990,
-        yOffset: 0,
       },
       csymMinor: {
         scale: 0.7,
-        leftSideBearing: 0,
-        advanceWidth: 482,
-        yOffset: 0,
       },
       csymMajorSeventh: {
         scale: 0.8,
-        leftSideBearing: 100,
-        yOffset: 0,
-        advanceWidth: 600,
       },
       accidentalSharp: {
         scale: 0.7,
-        leftSideBearing: 0,
-        advanceWidth: 425,
-        yOffset: -422,
       },
       accidentalFlat: {
         scale: 0.8,
-        leftSideBearing: -10,
-        advanceWidth: 228,
-        yOffset: -284,
       },
     },
     jazzOrnaments: {


### PR DESCRIPTION
In order to facilitate the review of #1486 this PR includes only the changes related to `ChordSymbol`:
- definition of `ChordSymbolMetrics`
- movement of these  metrics outside the `glyphs` section.

It is a step to address #1485