### PR TITLE
Time Signature simplifications

### DIFF
--- a/src/fonts/bravura_metrics.ts
+++ b/src/fonts/bravura_metrics.ts
@@ -242,7 +242,7 @@ export const BravuraMetrics = {
 
   // These are for numeric digits, such as in time signatures
   digits: {
-    // used by timesig
+    // used by TimeSignature object
     shiftLine: -1,
     point: 34,
 

--- a/src/fonts/leland_metrics.ts
+++ b/src/fonts/leland_metrics.ts
@@ -237,7 +237,7 @@ export const LelandMetrics = {
 
   // These are for numeric digits, such as in time signatures
   digits: {
-    // used by timesig
+    // used by TimeSignature objects
     shiftLine: -1,
     point: 34,
 

--- a/src/note.ts
+++ b/src/note.ts
@@ -488,7 +488,7 @@ export abstract class Note extends Tickable {
 
   /** Accessor to isDotted. */
   isDotted(): boolean {
-    return this.getModifiersByType('Dot').length > 0;
+    return this.getModifiersByType(Category.Dot).length > 0;
   }
 
   /** Accessor to hasStem. */

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -90,6 +90,15 @@ export class StaveModifier extends Element {
     return this;
   }
 
+  /**
+   * Runs setYShift() for the Glyph object so that it matches the position of line for
+   * the Stave provided.  A `customShift` can also be given (measured in the same units
+   * as `setYShift` not in lines) and this will be added after all other positions are
+   * calculated from the Stave.
+   *
+   * Note that this routine only sets the yShift; it does not actually "place" (meaning
+   * draw) the Glyph on the Stave.  Call .draw() afterwards to do that.
+   */
   placeGlyphOnLine(glyph: Glyph, stave: Stave, line?: number, customShift = 0): void {
     glyph.setYShift(stave.getYForLine(line ?? 0) - stave.getYForGlyphs() + customShift);
   }

--- a/src/timesigglyph.ts
+++ b/src/timesigglyph.ts
@@ -104,7 +104,7 @@ export class TimeSignatureGlyph extends Glyph {
     y = stave.getYForLine(this.timeSignature.bottomLine);
     for (let i = 0; i < this.botGlyphs.length; ++i) {
       const glyph = this.botGlyphs[i];
-      this.timeSignature.placeGlyphOnLine(glyph, stave, 0);
+      this.timeSignature.placeGlyphOnLine(glyph, stave, this.timeSignature.getLine());
       Glyph.renderOutline(ctx, glyph.getMetrics().outline, this.scale, start_x + glyph.getMetrics().x_shift, y);
       start_x += defined(glyph.getMetrics().width);
     }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -62,14 +62,13 @@ export class TimeSignature extends StaveModifier {
 
   protected timeSpec: string = '4/4';
   protected line: number = 0;
-  protected glyph: Glyph;
+  protected glyph!: Glyph;
   protected is_numeric: boolean = true;
   protected validate_args: boolean;
 
   constructor(timeSpec: string = '4/4', customPadding = 15, validate_args = true) {
     super();
     this.validate_args = validate_args;
-    this.timeSpec = timeSpec;
 
     const padding = customPadding;
 
@@ -81,13 +80,7 @@ export class TimeSignature extends StaveModifier {
     this.topLine = 2 + fontLineShift;
     this.bottomLine = 4 + fontLineShift;
     this.setPosition(StaveModifierPosition.BEGIN);
-
-    // violates DRY w/ setTimeSig(timeSpec) but needed to convince TypeScript that all is well.
-    const info = this.parseTimeSpec(timeSpec);
-    this.glyph = info.glyph;
-    this.is_numeric = info.num;
-    this.line = info.line;
-
+    this.setTimeSig(timeSpec);
     this.setWidth(defined(this.glyph.getMetrics().width));
     this.setPadding(padding);
   }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -60,6 +60,7 @@ export class TimeSignature extends StaveModifier {
   bottomLine: number;
   topLine: number;
 
+  protected timeSpec: string = '4/4';
   protected line: number = 0;
   protected glyph: Glyph;
   protected is_numeric: boolean = true;
@@ -68,6 +69,18 @@ export class TimeSignature extends StaveModifier {
   constructor(timeSpec: string = '4/4', customPadding = 15, validate_args = true) {
     super();
     this.validate_args = validate_args;
+    this.timeSpec = timeSpec;
+
+    const padding = customPadding;
+
+    // point must be defined before parsing spec.
+    const musicFont = Tables.currentMusicFont();
+    this.point = musicFont.lookupMetric('digits.point');
+
+    const fontLineShift = musicFont.lookupMetric('digits.shiftLine', 0);
+    this.topLine = 2 + fontLineShift;
+    this.bottomLine = 4 + fontLineShift;
+    this.setPosition(StaveModifierPosition.BEGIN);
 
     // violates DRY w/ setTimeSig(timeSpec) but needed to convince TypeScript that all is well.
     const info = this.parseTimeSpec(timeSpec);
@@ -75,14 +88,6 @@ export class TimeSignature extends StaveModifier {
     this.is_numeric = info.num;
     this.line = info.line;
 
-    const padding = customPadding;
-
-    const musicFont = Tables.currentMusicFont();
-    this.point = musicFont.lookupMetric('digits.point');
-    const fontLineShift = musicFont.lookupMetric('digits.shiftLine', 0);
-    this.topLine = 2 + fontLineShift;
-    this.bottomLine = 4 + fontLineShift;
-    this.setPosition(StaveModifierPosition.BEGIN);
     this.setWidth(defined(this.glyph.getMetrics().width));
     this.setPadding(padding);
   }
@@ -124,13 +129,20 @@ export class TimeSignature extends StaveModifier {
 
   /**
    * Set a new time signature specification without changing customPadding, etc.
+   *
+   * The getter for this is `getTimeSpec` not `getTimeSig`.
    */
   setTimeSig(timeSpec: string): this {
+    this.timeSpec = timeSpec;
     const info = this.parseTimeSpec(timeSpec);
     this.glyph = info.glyph;
     this.is_numeric = info.num;
     this.line = info.line;
     return this;
+  }
+
+  getTimeSpec(): string {
+    return this.timeSpec;
   }
 
   getLine(): number {

--- a/src/timesignote.ts
+++ b/src/timesignote.ts
@@ -3,7 +3,7 @@
 
 import { ModifierContext } from './modifiercontext';
 import { Note } from './note';
-import { TimeSignature, TimeSignatureInfo } from './timesignature';
+import { TimeSignature } from './timesignature';
 import { Category } from './typeguard';
 
 export class TimeSigNote extends Note {
@@ -11,14 +11,13 @@ export class TimeSigNote extends Note {
     return Category.TimeSigNote;
   }
 
-  protected timeSigInfo: TimeSignatureInfo;
+  protected timeSig: TimeSignature;
 
   constructor(timeSpec: string, customPadding?: number) {
     super({ duration: 'b' });
 
-    const timeSignature = new TimeSignature(timeSpec, customPadding);
-    this.timeSigInfo = timeSignature.getInfo();
-    this.setWidth(this.timeSigInfo.glyph.getMetrics().width);
+    this.timeSig = new TimeSignature(timeSpec, customPadding);
+    this.setWidth(this.timeSig.getGlyph().getMetrics().width);
 
     // Note properties
     this.ignore_ticks = true;
@@ -41,12 +40,13 @@ export class TimeSigNote extends Note {
     const ctx = this.checkContext();
     this.setRendered();
 
-    if (!this.timeSigInfo.glyph.getContext()) {
-      this.timeSigInfo.glyph.setContext(ctx);
+    const tsGlyph = this.timeSig.getGlyph();
+    if (!tsGlyph.getContext()) {
+      tsGlyph.setContext(ctx);
     }
 
-    this.timeSigInfo.glyph.setStave(stave);
-    this.timeSigInfo.glyph.setYShift(stave.getYForLine(2) - stave.getYForGlyphs());
-    this.timeSigInfo.glyph.renderToStave(this.getAbsoluteX());
+    tsGlyph.setStave(stave);
+    tsGlyph.setYShift(stave.getYForLine(2) - stave.getYForGlyphs());
+    tsGlyph.renderToStave(this.getAbsoluteX());
   }
 }

--- a/tests/timesignature_tests.ts
+++ b/tests/timesignature_tests.ts
@@ -29,6 +29,7 @@ const TimeSignatureTests = {
 
 function parser(): void {
   const timeSig = new TimeSignature();
+  equal(timeSig.getTimeSpec(), '4/4', 'default time signature is 4/4');
 
   const mustFail = ['asdf', '123/', '/10', '/', '4567', 'C+', '1+', '+1', '(3+', '+3)', '()', '(+)'];
   mustFail.forEach((invalidString) => {
@@ -38,10 +39,11 @@ function parser(): void {
   const mustPass = ['4/4', '10/12', '1/8', '1234567890/1234567890', 'C', 'C|', '+'];
   mustPass.forEach((validString) => timeSig.parseTimeSpec(validString));
 
-  timeSig.parseTimeSpec('4/4');
+  timeSig.setTimeSig('4/4');
   equal(timeSig.getIsNumeric(), true, '4/4 is numeric');
   equal(timeSig.getLine(), 0, 'digits are on line 0');
-  timeSig.parseTimeSpec('C|');
+  timeSig.setTimeSig('C|');
+  equal(timeSig.getTimeSpec(), 'C|', 'timeSpec changed to C|');
   equal(timeSig.getIsNumeric(), false, 'cut time is not numeric');
   equal(timeSig.getLine(), 2, 'cut/common are on line 2');
 

--- a/tests/timesignature_tests.ts
+++ b/tests/timesignature_tests.ts
@@ -38,6 +38,13 @@ function parser(): void {
   const mustPass = ['4/4', '10/12', '1/8', '1234567890/1234567890', 'C', 'C|', '+'];
   mustPass.forEach((validString) => timeSig.parseTimeSpec(validString));
 
+  timeSig.parseTimeSpec('4/4');
+  equal(timeSig.getIsNumeric(), true, '4/4 is numeric');
+  equal(timeSig.getLine(), 0, 'digits are on line 0');
+  timeSig.parseTimeSpec('C|');
+  equal(timeSig.getIsNumeric(), false, 'cut time is not numeric');
+  equal(timeSig.getLine(), 2, 'cut/common are on line 2');
+
   ok(true, 'all pass');
 }
 


### PR DESCRIPTION
To the extent possible without breaking backwards compatibility of public interfaces, this PR implements a little bit of my (second) comment on #1498 which @sschmidTU gave a thumbs up to: deemphasizing using structs in favor of objects themselves on TimeSignature and TimeSigNote.

Places line, glyph, num (now "is_numeric") attributes directly on the TimeSignature object (where the crucial .point) already is, rather than on a .info interface.   (Note that the name of this struct differs among modifiers.  On the Clef object it is ".clef", so changing one type of Modifier without changing all should not break code expecting a standard .info struct.)

TimeSigNote now stores the reference to the TimeSignature object rather than the .info struct, so that it can be modified up until the point it is formatted/drawn.

Feel free to comment if this is the right direction or not.  I won't be offended (too much.  :-D ) if it's not where the project should go.  But class-objects are quite lightweight and as long as we're creating the TimeSignature object anyhow, might as well hang onto it until we're ready.

All visual tests pass.