### PR TITLE
Addresses a grace note issue mentioned in the #441 thread.

### DIFF
--- a/tests/bach_tests.ts
+++ b/tests/bach_tests.ts
@@ -180,7 +180,7 @@ function minuet1(options: TestOptions): void {
 
   /*  Measure 8 */
   system = appendSystem(180);
-  const grace = f.GraceNote({ keys: ['d/3'], clef: 'bass', duration: '8', slash: true });
+  const grace = f.GraceNote({ keys: ['d/3'], clef: 'bass', duration: '4', slash: false });
 
   system.addStave({ voices: [voice(notes('A4/h.[id="m8c"]'))] });
   system.addStave({


### PR DESCRIPTION
<img width="1207" alt="A" src="https://user-images.githubusercontent.com/239113/211690978-4c02e889-f544-4661-be6d-417d0ec254c2.png">

The only difference is in measure 8.