### PR TITLE
fix notehead bounding box

### DIFF
--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -10,7 +10,7 @@ import { Stave } from './stave';
 import { Stem } from './stem';
 import { Tables } from './tables';
 import { Category } from './typeguard';
-import { defined, log, RuntimeError } from './util';
+import { defined, log } from './util';
 
 // eslint-disable-next-line
 function L(...args: any[]) {
@@ -232,9 +232,6 @@ export class NoteHead extends Note {
 
   /** Get the `BoundingBox` for the `NoteHead`. */
   getBoundingBox(): BoundingBox {
-    if (!this.preFormatted) {
-      throw new RuntimeError('UnformattedNote', "Can't call getBoundingBox on an unformatted note.");
-    }
     const spacing = this.checkStave().getSpacingBetweenLines();
     const half_spacing = spacing / 2;
     const min_y = this.y - half_spacing;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -469,7 +469,7 @@ export class StaveNote extends StemmableNote {
 
     const stave = this.stave;
     if (stave) {
-      this._noteHeads.forEach((head) => head.setStave(stave));
+      this.setStave(stave);
     }
     this.calcNoteDisplacements();
     return this;

--- a/tests/notehead_tests.ts
+++ b/tests/notehead_tests.ts
@@ -268,8 +268,8 @@ function basicBoundingBoxes(options: TestOptions, contextBuilder: ContextBuilder
   const formatter = new Formatter();
   const voice = new Voice(Flow.TIME4_4).setStrict(false);
 
-  const nh1 = new NoteHead({ duration: '4', line: 3 });
-  const nh2 = new NoteHead({ duration: '2', line: 2.5 });
+  const nh1 = new StaveNote({ keys: ['b/4'], duration: '4' });
+  const nh2 = new StaveNote({ keys: ['a/4'], duration: '2' });
   const nh3 = new NoteHead({ duration: '1', line: 0 });
 
   voice.addTickables([nh1, nh2, nh3]);
@@ -277,7 +277,7 @@ function basicBoundingBoxes(options: TestOptions, contextBuilder: ContextBuilder
 
   voice.draw(ctx, stave);
 
-  for (const bb of [nh1.getBoundingBox(), nh2.getBoundingBox(), nh3.getBoundingBox()]) {
+  for (const bb of [nh1.noteHeads[0].getBoundingBox(), nh2.noteHeads[0].getBoundingBox(), nh3.getBoundingBox()]) {
     ctx.rect(bb.getX(), bb.getY(), bb.getW(), bb.getH());
   }
   ctx.stroke();


### PR DESCRIPTION
fixes #556

- noteheads of stavenotes are not preformatted.
- stavenot reset should use setstave to recalculate properly.