### PR TITLE
access to font stack

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -250,6 +250,10 @@ export class Flow {
     return fonts.map((font) => font.getName());
   }
 
+  static getMusicFontStack(): Font[] {
+    return Tables.MUSIC_FONT_STACK;
+  }
+
   static get RENDER_PRECISION_PLACES(): number {
     return Tables.RENDER_PRECISION_PLACES;
   }


### PR DESCRIPTION
In order to adjust metrics the library has to provide access to the font stack.