### PR TITLE
The grunt get:releases:X.Y.Z script fails because `npm pack` does not create the directory for you if it doesn't already exist.

### DIFF
--- a/tools/get_releases.mjs
+++ b/tools/get_releases.mjs
@@ -128,8 +128,10 @@ async function getReleasesForVersion4OrLater() {
     const tempDir = path.join(RELEASES_DIR, ver + TEMP_SUFFIX);
     // Remove the temporary directory if it already exists.
     if (fs.existsSync(tempDir)) {
-      fs.rmdirSync(tempDir, { recursive: true });
+      fs.rmSync(tempDir, { recursive: true });
     }
+    // Make the temporary directory.
+    fs.mkdirSync(tempDir);
 
     console.log('\nDownload', ver, 'from npm.');
     execSync(`npm pack vexflow@${ver} --pack-destination ${tempDir} 2> /dev/null`).toString();


### PR DESCRIPTION
This patch allows for easier visual diffing between our current work and a release that has been published on NPM.

This was previously applied to the VexFlow 5+ repo: https://github.com/vexflow/vexflow/pull/8