### PR TITLE
Prevent octave from being -0 when calculating key properties

### DIFF
--- a/src/tables.ts
+++ b/src/tables.ts
@@ -615,7 +615,7 @@ export class Tables {
     let octave = parseInt(pieces[1], 10);
 
     // Octave_shift is the shift to compensate for clef 8va/8vb.
-    octave += -1 * options.octave_shift;
+    octave -= options.octave_shift;
 
     const baseIndex = octave * 7 - 4 * 7;
     let line = (baseIndex + value.index) / 2;


### PR DESCRIPTION
Fixes https://github.com/0xfe/vexflow/issues/1595. -0 seems to cause issues on certain platforms/environments. There are other instances where -0 is possible throughout the codebase, but I wanted this PR to be as minimal as possible.