### PR TITLE
Fix ornament delayed draw, such as on a grand staff.

### DIFF
--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -303,7 +303,7 @@ export class Ornament extends Modifier {
     // Ajdust x position if ornament is delayed
     if (this.delayed) {
       let delayXShift = 0;
-      const startX = glyphX - (stave.getX() - 10);
+      const startX = glyphX - stave.getNoteStartX();
       if (this.delayXShift !== undefined) {
         delayXShift = this.delayXShift;
       } else {

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -308,11 +308,12 @@ export class Ornament extends Modifier {
         delayXShift = this.delayXShift;
       } else {
         delayXShift += this.glyph.getMetrics().width / 2;
-        const nextContext = TickContext.getNextContext(note.getTickContext());
-        if (nextContext) {
+        const context = note.getTickContext();
+        const nextContext = TickContext.getNextContext(context);
+        if (nextContext && context.getTickID() < nextContext.getTickID()) {
           delayXShift += (nextContext.getX() - startX) * 0.5;
         } else {
-          delayXShift += (stave.getX() + stave.getWidth() - startX) * 0.5;
+          delayXShift += (stave.getX() + stave.getWidth() - glyphX) * 0.5;
         }
         this.delayXShift = delayXShift;
       }

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -308,9 +308,10 @@ export class Ornament extends Modifier {
         delayXShift = this.delayXShift;
       } else {
         delayXShift += this.glyph.getMetrics().width / 2;
-        const context = note.getTickContext();
-        const nextContext = TickContext.getNextContext(context);
-        if (nextContext && context.getTickID() < nextContext.getTickID()) {
+        const tickables = note.getVoice().getTickables();
+        const index = tickables.indexOf(note);
+        const nextContext = index + 1 < tickables.length ? tickables[index + 1].checkTickContext() : undefined;
+        if (nextContext) {
           delayXShift += (nextContext.getX() - startX) * 0.5;
         } else {
           delayXShift += (stave.getX() + stave.getWidth() - glyphX) * 0.5;

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -8,7 +8,6 @@ import { ModifierContextState } from './modifiercontext';
 import { Stem } from './stem';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
-import { TickContext } from './tickcontext';
 import { Category, isTabNote } from './typeguard';
 import { defined, log, RuntimeError } from './util';
 

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -28,6 +28,7 @@ const OrnamentTests = {
     run('Ornaments Vertically Shifted', drawOrnamentsDisplaced);
     run('Ornaments - Delayed turns', drawOrnamentsDelayed);
     run('Ornaments - Delayed turns, Multiple Draws', drawOrnamentsDelayedMultipleDraws);
+    run('Ornaments - Delayed turns, Multiple Voices', drawOrnamentsDelayedMultipleVoices);
     run('Stacked', drawOrnamentsStacked);
     run('With Upper/Lower Accidentals', drawOrnamentsWithAccidentals);
     run('Jazz Ornaments', jazzOrnaments);
@@ -165,6 +166,46 @@ function drawOrnamentsDelayedMultipleDraws(options: TestOptions): void {
   // However, if you inspect the SVG element, you will see duplicate paths.
   Formatter.FormatAndDraw(context, stave, notes);
   Formatter.FormatAndDraw(context, stave, notes);
+}
+
+function drawOrnamentsDelayedMultipleVoices(options: TestOptions, contextBuilder: ContextBuilder): void {
+  options.assert.expect(0);
+
+  // Get the rendering context
+  const ctx = contextBuilder(options.elementId, 550, 195);
+
+  const stave = new Stave(10, 30, 500);
+  stave.addClef('treble');
+  stave.addKeySignature('C#');
+  stave.addTimeSignature('4/4');
+
+  const notes1 = [
+    new StaveNote({ keys: ['f/5'], duration: '2r'}),
+    new StaveNote({ keys: ['c/5'], duration: '2', stem_direction: 1 }),
+  ];
+  const notes2 = [
+    new StaveNote({ keys: ['a/4'], duration: '4', stem_direction: -1 }),
+    new StaveNote({ keys: ['e/4'], duration: '4r'}),
+    new StaveNote({ keys: ['e/4'], duration: '2r'}),
+  ];
+
+  notes1[1].addModifier(new Ornament('turn_inverted').setDelayed(true), 0);
+  notes2[0].addModifier(new Ornament('turn').setDelayed(true), 0);
+
+  const voice1 = new Voice({ num_beats: 4, beat_value: 4, });
+  voice1.addTickables(notes1);
+  const voice2 = new Voice({ num_beats: 4, beat_value: 4, });
+  voice2.addTickables(notes2);
+
+  const formatWidth = stave.getNoteEndX() - stave.getNoteStartX();
+  const formatter = new Formatter();
+  formatter.joinVoices([voice1]);
+  formatter.joinVoices([voice2]);
+  formatter.format([voice1, voice2], formatWidth);
+
+  stave.setContext(ctx).draw();
+  voice1.draw(ctx, stave);
+  voice2.draw(ctx, stave);
 }
 
 function drawOrnamentsStacked(options: TestOptions): void {


### PR DESCRIPTION
When building a TickContext with multiple voices, such as a grand staff, the order of ticks was not continuous, so detection of the end of voice element failed and the Ornament display position was incorrect.

**Before**
![image](https://github.com/0xfe/vexflow/assets/36094352/baea5817-cf29-45c1-887c-ee3defd190e1)

**After**
![image](https://github.com/0xfe/vexflow/assets/36094352/ed9f13c9-6d24-4422-a01e-4f41ef1abac7)
