### PR TITLE
issue #1603 - key signature on non-treble stave, no glyph

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -443,7 +443,14 @@ export class Stave extends Element {
     }
     return this;
   }
-
+  /**
+   * treat the stave as if the clef is clefSpec, but don't display the clef
+   * @param clefSpec 
+   */
+  setClefLines(clefSpec: string) {
+    this.clef = clefSpec;
+    return this;
+  }
   setClef(clefSpec: string, size?: string, annotation?: string, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -443,14 +443,15 @@ export class Stave extends Element {
     }
     return this;
   }
+
   /**
    * treat the stave as if the clef is clefSpec, but don't display the clef
-   * @param clefSpec 
    */
   setClefLines(clefSpec: string) {
     this.clef = clefSpec;
     return this;
   }
+
   setClef(clefSpec: string, size?: string, annotation?: string, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -26,6 +26,7 @@ const KeySignatureTests = {
     run('Altered key test', majorKeysAltered);
     run('End key with clef test', endKeyWithClef);
     run('Key Signature Change test', changeKey);
+    run('Key Signature with/without clef symbol', clefKeySignature);
   },
 };
 
@@ -370,5 +371,34 @@ function changeKey(options: TestOptions): void {
   options.assert.ok(true, 'all pass');
 }
 
+function clefKeySignature(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 900);
+
+  // The previous code was buggy: f.Stave(10, 10, 800), even though Factory.Stave() only accepts 1 argument.
+  const stave = f.Stave({ x: 10, y: 10, width: 800 }).addClef('bass').addTimeSignature('C|').setClefLines('bass');
+
+  const voice = f
+    .Voice()
+    .setStrict(false)
+    .addTickables([
+      f.KeySigNote({ key: 'Bb' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.BarNote(),
+      f.KeySigNote({ key: 'D', cancelKey: 'Bb' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.BarNote(),
+      f.KeySigNote({ key: 'Bb' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.BarNote(),
+      f.KeySigNote({ key: 'D', alterKey: ['b', 'n'] }), // TODO: alterKey needs to be a string[]
+      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+    ]);
+
+  f.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  options.assert.ok(true, 'all pass');
+}
 VexFlowTests.register(KeySignatureTests);
 export { KeySignatureTests };

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -382,16 +382,16 @@ function clefKeySignature(options: TestOptions): void {
     .setStrict(false)
     .addTickables([
       f.KeySigNote({ key: 'Bb' }),
-      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass' }),
       f.BarNote(),
       f.KeySigNote({ key: 'D', cancelKey: 'Bb' }),
-      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass'  }),
       f.BarNote(),
       f.KeySigNote({ key: 'Bb' }),
-      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass'  }),
       f.BarNote(),
       f.KeySigNote({ key: 'D', alterKey: ['b', 'n'] }), // TODO: alterKey needs to be a string[]
-      f.StaveNote({ keys: ['c/4'], duration: '1' }),
+      f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass'  }),
     ]);
 
   f.Formatter().joinVoices([voice]).formatToStave([voice], stave);

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -373,8 +373,6 @@ function changeKey(options: TestOptions): void {
 
 function clefKeySignature(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 900);
-
-  // The previous code was buggy: f.Stave(10, 10, 800), even though Factory.Stave() only accepts 1 argument.
   const stave = f.Stave({ x: 10, y: 10, width: 800 }).addClef('bass').addTimeSignature('C|').setClefLines('bass');
 
   const voice = f
@@ -390,7 +388,7 @@ function clefKeySignature(options: TestOptions): void {
       f.KeySigNote({ key: 'Bb' }),
       f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass'  }),
       f.BarNote(),
-      f.KeySigNote({ key: 'D', alterKey: ['b', 'n'] }), // TODO: alterKey needs to be a string[]
+      f.KeySigNote({ key: 'D', alterKey: ['b', 'n'] }),
       f.StaveNote({ keys: ['c/4'], duration: '1', clef: 'bass'  }),
     ]);
 
@@ -400,5 +398,6 @@ function clefKeySignature(options: TestOptions): void {
 
   options.assert.ok(true, 'all pass');
 }
+
 VexFlowTests.register(KeySignatureTests);
 export { KeySignatureTests };


### PR DESCRIPTION
Prior to this fix, there was no way to show a key signature correctly in a bass clef stave, without the clef glyph (and any other non-treble).  I added a test case and created a `stave.addClefLines(clefSpec: string)` method that adds the logical clef (e.g. the lines match the clef) but without the glyph.