### PR TITLE
fix: BarNote getSVGElement always returning undefined

### DIFF
--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -30,6 +30,7 @@ export class BarNote extends Note {
   protected metrics: { widths: Record<string, number> };
   // Initialized by the constructor via this.setType(type)
   protected type!: BarlineType;
+  public barline!: Barline;
 
   constructor(type: string | BarlineType = BarlineType.SINGLE) {
     super({ duration: 'b' });
@@ -52,6 +53,7 @@ export class BarNote extends Note {
     // Tell the formatter that bar notes have no duration.
     this.ignore_ticks = true;
     this.setType(type);
+    this.barline = new Barline(type);
   }
 
   /** Get the type of bar note.*/
@@ -86,9 +88,13 @@ export class BarNote extends Note {
     const ctx = this.checkContext();
     L('Rendering bar line at: ', this.getAbsoluteX());
     this.applyStyle(ctx);
-    const barline = new Barline(this.type);
-    barline.setX(this.getAbsoluteX());
-    barline.draw(this.checkStave());
+
+    ctx.openGroup('barnote', this.getAttribute('id'));
+    this.barline.setType(this.type);
+    this.barline.setX(this.getAbsoluteX());
+    this.barline.draw(this.checkStave());
+    ctx.closeGroup();
+
     this.restoreStyle(ctx);
     this.setRendered();
   }

--- a/tests/barline_tests.ts
+++ b/tests/barline_tests.ts
@@ -44,6 +44,10 @@ function simple(options: TestOptions): void {
   f.Formatter().joinVoices([voice]).formatToStave([voice], stave);
   f.draw();
 
+  notes.forEach((note) => {
+    options.assert.notEqual(note.getSVGElement(), undefined);
+  });
+
   options.assert.ok(true, 'Simple Test');
 }
 

--- a/tests/barline_tests.ts
+++ b/tests/barline_tests.ts
@@ -5,6 +5,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Renderer } from '../src';
 import { Barline, BarlineType } from '../src/stavebarline';
 
 const BarlineTests = {
@@ -44,9 +45,11 @@ function simple(options: TestOptions): void {
   f.Formatter().joinVoices([voice]).formatToStave([voice], stave);
   f.draw();
 
-  notes.forEach((note) => {
-    options.assert.notEqual(note.getSVGElement(), undefined);
-  });
+  if (options.backend === Renderer.Backends.SVG) {
+    notes.forEach((note) => {
+      options.assert.notEqual(note.getSVGElement(), undefined);
+    });
+  }
 
   options.assert.ok(true, 'Simple Test');
 }


### PR DESCRIPTION
BarNote is not opening its own context group which means it fails to perform operations requiring the id of the Element such as getSVGElement, addClass, removeClass etc.

I also added barline as a property of barnote to memoize it and have direct access to the barline if one needs it.

It looks like there are not any tests for the barnote directly but I added a test for the error scenario I was running into where  getSVGElement was always returning undefined for rendered BarNotes