### PR TITLE
Add complex key signatures support

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -531,7 +531,7 @@ export class Stave extends Element {
    *
    * Example:
    * `stave.addKeySignature('Db');`
-   * @param keySpec new key specification `[A-G][b|#]?`
+   * @param keySpec new key specification `[A-G][b|#]?` or `[flats|sharps]_[1-14]?`
    * @param cancelKeySpec
    * @param position
    * @returns

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -742,15 +742,28 @@ export class Tables {
       '#': [0, 1.5, -0.5, 1, 2.5, 0.5, 2],
     };
 
-    const notes = accidentalList[keySpec.acc];
-
-    const acc_list = [];
-    for (let i = 0; i < keySpec.num; ++i) {
-      const line = notes[i];
-      acc_list.push({ type: keySpec.acc, line });
+    // Check if the accidental type exists in accidentalList
+    const baseNotes = accidentalList[keySpec.acc];
+    if (!baseNotes) {
+      throw new RuntimeError('UnsupportedAccidental', `Unsupported accidental type: '${keySpec.acc}'`);
     }
 
-    return acc_list;
+    const accidentalCount = Math.min(keySpec.num, 7);
+    const doubleAccidentalCount = Math.max(keySpec.num - 7, 0);
+
+    // Map the first `accidentalCount` notes as regular accidentals
+    const regularAccidentals = baseNotes.slice(doubleAccidentalCount, accidentalCount).map((line) => ({
+      type: `${keySpec.acc}`,
+      line,
+    }));
+
+    // Map the last `doubleAccidentalCount` notes as double accidentals
+    const doubleAccidentals = baseNotes
+      .slice(0, doubleAccidentalCount)
+      .map((line) => ({ type: `${keySpec.acc}${keySpec.acc}`, line }));
+
+    // Combine regular and double accidentals
+    return [...regularAccidentals, ...doubleAccidentals];
   }
 
   static getKeySignatures(): Record<string, { acc?: string; num: number }> {

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -54,6 +54,8 @@ const keySignatures: Record<string, { acc?: string; num: number }> = {
   Ebm: { acc: 'b', num: 6 },
   Cb: { acc: 'b', num: 7 },
   Abm: { acc: 'b', num: 7 },
+  Dbm: { acc: 'b', num: 8 },
+  Gbm: { acc: 'b', num: 9 },
   G: { acc: '#', num: 1 },
   Em: { acc: '#', num: 1 },
   D: { acc: '#', num: 2 },
@@ -68,6 +70,9 @@ const keySignatures: Record<string, { acc?: string; num: number }> = {
   'D#m': { acc: '#', num: 6 },
   'C#': { acc: '#', num: 7 },
   'A#m': { acc: '#', num: 7 },
+  'G#': { acc: '#', num: 8 },
+  'D#': { acc: '#', num: 9 },
+  'A#': { acc: '#', num: 10 },
 };
 
 const clefs: Record<string, { line_shift: number }> = {

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -61,7 +61,7 @@ const generateKeySignatures = (): KeySignatures => {
 };
 
 
-const keySignatures: Record<string, { acc?: string; num: number }> = {
+const keySignatures: Record<string, KeySignature> = {
   ...generateKeySignatures(),
   C: { num: 0 },
   Am: { num: 0 },

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -759,8 +759,6 @@ export class Tables {
   static keySignature(spec: string): { type: string; line: number }[] {
     const keySpec = keySignatures[spec];
 
-    console.log({keySignatures});
-
     if (!keySpec) {
       throw new RuntimeError('BadKeySignature', `Bad key signature spec: '${spec}'`);
     }

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -37,7 +37,32 @@ const durationAliases: Record<string, string> = {
   b: '256',
 };
 
+type KeySignature = {
+  acc?: string;
+  num: number;
+};
+
+type KeySignatures = Record<string, KeySignature>;
+
+const generateKeySignatures = (): KeySignatures => {
+  const keySignatures: KeySignatures = {};
+
+  // Generate flats
+  for (let i = 1; i <= 14; i++) {
+    keySignatures[`flats_${i}`] = { acc: 'b', num: i };
+  }
+
+  // Generate sharps
+  for (let i = 1; i <= 14; i++) {
+    keySignatures[`sharps_${i}`] = { acc: '#', num: i };
+  }
+
+  return keySignatures;
+};
+
+
 const keySignatures: Record<string, { acc?: string; num: number }> = {
+  ...generateKeySignatures(),
   C: { num: 0 },
   Am: { num: 0 },
   F: { acc: 'b', num: 1 },
@@ -733,6 +758,8 @@ export class Tables {
 
   static keySignature(spec: string): { type: string; line: number }[] {
     const keySpec = keySignatures[spec];
+
+    console.log({keySignatures});
 
     if (!keySpec) {
       throw new RuntimeError('BadKeySignature', `Bad key signature spec: '${spec}'`);


### PR DESCRIPTION
## Support for Complex Key Signatures and Alternative Definition Method

This update introduces support for complex key signatures, including theoretical or rare keys from different modes. It enhances versatility and provides additional options for defining key signatures. This implementation preserves backward compatibility, ensuring that all existing key signature definitions and functionality remain unaffected.

### Key Features

1. **Alternative Key Signature Definition:**  
   The `addKeySignature` method now accepts a new format, allowing direct specification of the number of flats or sharps:
   ```javascript
   stave.addKeySignature('flats_4');
   ```
   This adds four flats to the key signature, suitable for modes such as Ab major, F minor, Bb Dorian, C Phrygian, Db Lydian, Eb Mixolydian, or G Locrian.

2. **Support for Double Alterations:**  
   Numbers between 8 and 14 introduce double alterations (e.g., double flats or double sharps) in the key signature, enabling the rendering of more complex and less common keys.

---

This change enhances the flexibility of the `KeySignature` class, making it suitable for a wider range of musical contexts and theoretical applications.