### PR TITLE
Always truthy error

### DIFF
--- a/src/tables.ts
+++ b/src/tables.ts
@@ -635,7 +635,7 @@ export class Tables {
     let customNoteHeadProps = {};
     if (pieces.length > 2 && pieces[2]) {
       const glyphName = pieces[2].toUpperCase();
-      customNoteHeadProps = { code: this.codeNoteHead(glyphName, duration) } || {};
+      customNoteHeadProps = { code: this.codeNoteHead(glyphName, duration) };
     }
 
     return {


### PR DESCRIPTION
Remove part of a line in tables.ts that will never be executed -- raises a compiler error in Typescript 5.6 and above.  Probably a result of a refactor.  Will commit also to VF5 repo.