### PR TITLE
Include class attribute when drawing stavenote and stem

### DIFF
--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -1263,7 +1263,8 @@ export class StaveNote extends StemmableNote {
 
     // Apply the overall style -- may be contradicted by local settings:
     this.applyStyle();
-    ctx.openGroup('stavenote', this.getAttribute('id'));
+    const cls = 'stavenote' + (this.getAttribute('class') ? ' ' + this.getAttribute('class') : '');
+    ctx.openGroup(cls, this.getAttribute('id'));
     this.drawLedgerLines();
     if (shouldRenderStem) this.drawStem();
     this.drawNoteHeads();

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -211,7 +211,8 @@ export class Stem extends Element {
     // Draw the stem
     ctx.save();
     this.applyStyle();
-    ctx.openGroup('stem', this.getAttribute('id'), { pointerBBox: true });
+    const cls = 'stem' + (this.getAttribute('class') ? ' ' + this.getAttribute('class') : '');
+    ctx.openGroup(cls, this.getAttribute('id'), { pointerBBox: true });
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
     ctx.moveTo(stem_x, stem_y - stemletYOffset + y_base_offset);


### PR DESCRIPTION
I'm building a midi application and would like to be able to individually color notes, element.ts already had a class attribute, it's just wasn't being used on these subclasses.